### PR TITLE
Timestamp fix

### DIFF
--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/AtZoneFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/AtZoneFunction.java
@@ -24,12 +24,12 @@ public class AtZoneFunction extends SqrlScalarFunction {
     super(
         new SqlIdentifier("AT_ZONE", SqlParserPos.ZERO),
         SqlKind.OTHER,
-        ReturnTypes.TIMESTAMP,
+        ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
         InferTypes.ANY_NULLABLE,
         OperandTypes.operandMetadata(
             List.of(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.CHARACTER),
             typeFactory -> List.of(
-                typeFactory.createSqlType(SqlTypeName.TIMESTAMP),
+                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
                 typeFactory.createSqlType(SqlTypeName.VARCHAR)),
             i -> "arg" + i,
             i -> false),

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/NumToTimestampFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/NumToTimestampFunction.java
@@ -23,7 +23,7 @@ public class NumToTimestampFunction extends SqrlScalarFunction {
     super(
         new SqlIdentifier("NUM_TO_TIMESTAMP", SqlParserPos.ZERO),
         SqlKind.OTHER,
-        ReturnTypes.TIMESTAMP,
+        ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
         //ReturnTypes.explicit(SqlTypeName.TIMESTAMP),
         InferTypes.ANY_NULLABLE,
         OperandTypes.operandMetadata(

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/SqrlTimeRoundingFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/SqrlTimeRoundingFunction.java
@@ -1,13 +1,16 @@
 package ai.datasqrl.function.builtin.time;
 
+import java.util.List;
 import org.apache.calcite.schema.ScalarFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.*;
-
-import java.util.List;
+import org.apache.calcite.sql.type.InferTypes;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 
 public class SqrlTimeRoundingFunction extends SqrlScalarFunction {
 
@@ -15,18 +18,20 @@ public class SqrlTimeRoundingFunction extends SqrlScalarFunction {
     super(
         new SqlIdentifier(sqlIdentifier, SqlParserPos.ZERO),
         SqlKind.OTHER,
-        ReturnTypes.TIMESTAMP,
-        InferTypes.ANY_NULLABLE,
+        ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
+        InferTypes.RETURN_TYPE,
         OperandTypes.operandMetadata(
             List.of(SqlTypeFamily.TIMESTAMP),
             typeFactory -> List.of(
-                typeFactory.createSqlType(SqlTypeName.TIMESTAMP)),
+                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3)),
             i -> "arg" + i,
             i -> false),
         scalarFunction,
         SqlFunctionCategory.USER_DEFINED_FUNCTION
     );
   }
+
+
 
   @Override
   public boolean isTimestampPreserving() {
@@ -37,6 +42,5 @@ public class SqrlTimeRoundingFunction extends SqrlScalarFunction {
   public boolean isTimeBucketingFunction() {
     return true;
   }
-
 
 }

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/StringToTimestampFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/StringToTimestampFunction.java
@@ -23,7 +23,7 @@ public class StringToTimestampFunction extends SqrlScalarFunction {
     super(
         new SqlIdentifier("STRING_TO_TIMESTAMP", SqlParserPos.ZERO),
         SqlKind.OTHER,
-        ReturnTypes.TIMESTAMP,
+        ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
         //ReturnTypes.explicit(SqlTypeName.TIMESTAMP),
         InferTypes.ANY_NULLABLE,
         OperandTypes.operandMetadata(

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/TimestampToEpochFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/TimestampToEpochFunction.java
@@ -29,7 +29,7 @@ public class TimestampToEpochFunction extends SqrlScalarFunction {
         OperandTypes.operandMetadata(
             List.of(SqlTypeFamily.TIMESTAMP),
             typeFactory -> List.of(
-                typeFactory.createSqlType(SqlTypeName.TIMESTAMP)),
+                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3)),
             i -> "arg" + i,
             i -> false),
         fnc,

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/TimestampToStringFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/TimestampToStringFunction.java
@@ -29,7 +29,7 @@ public class TimestampToStringFunction extends SqrlScalarFunction {
         OperandTypes.operandMetadata(
             List.of(SqlTypeFamily.TIMESTAMP),
             typeFactory -> List.of(
-                typeFactory.createSqlType(SqlTypeName.TIMESTAMP)),
+                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3)),
             i -> "arg" + i,
             i -> false),
         fnc,

--- a/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/ToUtcFunction.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/function/builtin/time/ToUtcFunction.java
@@ -24,12 +24,12 @@ public class ToUtcFunction extends SqrlScalarFunction {
     super(
         new SqlIdentifier("TO_UTC", SqlParserPos.ZERO),
         SqlKind.OTHER,
-        ReturnTypes.TIMESTAMP,
+        ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
         InferTypes.ANY_NULLABLE,
         OperandTypes.operandMetadata(
             List.of(SqlTypeFamily.TIMESTAMP),
             typeFactory -> List.of(
-                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
                 typeFactory.createSqlType(SqlTypeName.TIMESTAMP)),
             i -> "arg" + i,
             i -> false),

--- a/sqrl-core/src/main/java/ai/datasqrl/plan/calcite/TranspilerFactory.java
+++ b/sqrl-core/src/main/java/ai/datasqrl/plan/calcite/TranspilerFactory.java
@@ -17,7 +17,7 @@ public class TranspilerFactory {
     Properties p = new Properties();
     p.put(CalciteConnectionProperty.CASE_SENSITIVE.name(), false);
     SqrlValidatorImpl validator = new SqrlValidatorImpl(
-        SqlStdOperatorTable.instance(),
+        SqrlOperatorTable.instance(),
         new CalciteCatalogReader(schema, List.of(), new SqrlTypeFactory(new SqrlTypeSystem()),
             new CalciteConnectionConfigImpl(p).set(CalciteConnectionProperty.CASE_SENSITIVE,
                 "false")),
@@ -33,7 +33,7 @@ public class TranspilerFactory {
 
   public static SqlValidator createSqlValidator(CalciteSchema schema) {
     SqlValidator validator = SqlValidatorUtil.newValidator(
-        SqlStdOperatorTable.instance(),
+        SqrlOperatorTable.instance(),
         new CalciteCatalogReader(schema, List.of(), new SqrlTypeFactory(new SqrlTypeSystem()),
             new CalciteConnectionConfigImpl(new Properties()).set(CalciteConnectionProperty.CASE_SENSITIVE,
                 "false")),

--- a/sqrl-core/src/test/java/ai/datasqrl/plan/local/analyze/ResolveTest.java
+++ b/sqrl-core/src/test/java/ai/datasqrl/plan/local/analyze/ResolveTest.java
@@ -98,6 +98,13 @@ class ResolveTest extends AbstractSQRLIT {
   }
 
   @Test
+  public void timeFunctionFixTest() {
+    StringBuilder builder = imports();
+    builder.append("TimeTest := SELECT ROUND_TO_MONTH(ROUND_TO_MONTH(\"time\")) FROM orders;");
+    process(builder.toString());
+  }
+
+  @Test
   public void streamStateAggregateTest() {
     StringBuilder builder = imports();
     builder.append("OrderCustomer := SELECT o.id, c.name, o.customerid FROM Orders o JOIN Customer c on o.customerid = c.customerid;");


### PR DESCRIPTION
Timestamp functions should now have correct return types. I tested ROUND_TO_MONTH(ROUND_TO_MONTH(time)) in ResolveTest.java, which cleared the process(builder.toString()) bar, but I'm not 100% sure that's all we need. 