### PR TITLE
Allow specifying a native flink configuration

### DIFF
--- a/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/ExecutionEnvironmentFactory.java
+++ b/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/ExecutionEnvironmentFactory.java
@@ -1,0 +1,24 @@
+package com.datasqrl.engine.stream.flink;
+
+import com.datasqrl.loaders.ResourceResolver;
+import com.google.inject.Inject;
+import java.util.Map;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+public class ExecutionEnvironmentFactory {
+
+  private final Map<String, String> flinkConf;
+
+  public ExecutionEnvironmentFactory(Map<String, String> flinkConf) {
+    this.flinkConf = flinkConf;
+  }
+
+  public StreamExecutionEnvironment createEnvironment() {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(
+        org.apache.flink.configuration.Configuration.fromMap(flinkConf));
+    env.getConfig().enableObjectReuse();
+    env.setRuntimeMode(RuntimeExecutionMode.STREAMING); //todo add to config
+    return env;
+  }
+}

--- a/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/FlinkEngineConfiguration.java
+++ b/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/FlinkEngineConfiguration.java
@@ -7,6 +7,8 @@ import com.datasqrl.engine.EngineConfiguration;
 import com.datasqrl.engine.ExecutionEngine;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ConfigurationUtil;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +26,9 @@ public class FlinkEngineConfiguration implements EngineConfiguration {
   @Builder.Default
   boolean savepoint = false;
 
+  @Builder.Default
+  private Map<String, String> flinkConf = new HashMap<>();
+
   @Override
   public String getEngineName() {
     return ENGINE_NAME;
@@ -40,4 +45,7 @@ public class FlinkEngineConfiguration implements EngineConfiguration {
     return new LocalFlinkStreamEngineImpl(this);
   }
 
+  public ExecutionEnvironmentFactory createEnvFactory() {
+    return new ExecutionEnvironmentFactory(flinkConf);
+  }
 }

--- a/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/LocalFlinkStreamEngineImpl.java
+++ b/sqrl-engine-flink/src/main/java/com/datasqrl/engine/stream/flink/LocalFlinkStreamEngineImpl.java
@@ -3,10 +3,6 @@
  */
 package com.datasqrl.engine.stream.flink;
 
-import java.util.Map;
-import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-
 public class LocalFlinkStreamEngineImpl extends AbstractFlinkStreamEngine {
 
   public LocalFlinkStreamEngineImpl(FlinkEngineConfiguration config) {
@@ -14,21 +10,7 @@ public class LocalFlinkStreamEngineImpl extends AbstractFlinkStreamEngine {
   }
 
   public FlinkStreamBuilder createJob() {
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(
-        org.apache.flink.configuration.Configuration.fromMap(Map.of(
-                //todo config
-                "taskmanager.memory.network.fraction", "0.3",
-                "taskmanager.memory.network.max", "1gb",
-                "taskmanager.numberOfTaskSlots", "1",
-                "parallelism.default", "1",
-                "rest.flamegraph.enabled", "false"
-            )
-        ));
-    env.getConfig().enableObjectReuse();
-    //env.getConfig().disableGenericTypes(); TODO: use to ensure efficient serialization
-    env.setRuntimeMode(RuntimeExecutionMode.STREAMING); //todo add to config
-//        FlinkUtilities.enableCheckpointing(env);
-
-    return new FlinkStreamBuilder(this, env);
+    return new FlinkStreamBuilder(this,
+        config.createEnvFactory().createEnvironment());
   }
 }

--- a/sqrl-engine-flink/src/test/java/com/datasqrl/engine/stream/flink/FlinkEngineConfigurationTest.java
+++ b/sqrl-engine-flink/src/test/java/com/datasqrl/engine/stream/flink/FlinkEngineConfigurationTest.java
@@ -1,0 +1,24 @@
+package com.datasqrl.engine.stream.flink;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import java.nio.charset.Charset;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class FlinkEngineConfigurationTest {
+
+  @SneakyThrows
+  @Test
+  public void testPackageSerialization() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    FlinkEngineConfiguration flinkEngineConfiguration =
+        objectMapper.readValue(Resources.getResource("package-flink-conf.json"),
+            FlinkEngineConfiguration.class);
+
+    assertEquals(1, flinkEngineConfiguration.getFlinkConf().size());
+  }
+}

--- a/sqrl-engine-flink/src/test/resources/package-flink-conf.json
+++ b/sqrl-engine-flink/src/test/resources/package-flink-conf.json
@@ -1,0 +1,7 @@
+{
+  "savepoint" : false,
+  "engineName" : "flink",
+  "flinkConf" : {
+    "rest.flamegraph.enabled" : "true"
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/local/generate/FileResourceResolver.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/local/generate/FileResourceResolver.java
@@ -23,13 +23,6 @@ public class FileResourceResolver implements ResourceResolver {
     this.baseDir = baseDir;
   }
 
-  //todo hacks remove
-  public Optional<URI> resolveTableJson(NamePath namePath) {
-    Path path = namepath2Path(baseDir, namePath.popLast());
-
-    return resolve(path.resolve(namePath.getLast().getCanonical() + ".table.json"));
-  }
-
   public Optional<URI> resolve(Path path) {
     return Optional.of(path.toFile().toURI());
   }


### PR DESCRIPTION
Allow specifying native flink configuration values in the package.json. This would be the same as the flink-conf.yaml except encoded as json.

E.g.:

```
{
  "savepoint" : false,
  "engineName" : "flink",
  "flinkConf" : {
    "rest.flamegraph.enabled" : "true",
    "taskmanager.memory.network.max": "2gb"
  }
}
```