### PR TITLE
Add servlets as engine types (#231)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
                 <artifactId>sqrl-engine-jdbc</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.datasqrl</groupId>
+                <artifactId>sqrl-engine-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- examples-->
             <dependency>
                 <groupId>com.datasqrl</groupId>

--- a/sqrl-engines/pom.xml
+++ b/sqrl-engines/pom.xml
@@ -19,5 +19,6 @@
     <module>sqrl-engine-core</module>
     <module>sqrl-engine-flink</module>
     <module>sqrl-engine-jdbc</module>
+    <module>sqrl-engine-server</module>
   </modules>
 </project>

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/config/PipelineFactory.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/config/PipelineFactory.java
@@ -87,11 +87,9 @@ public class PipelineFactory {
 
   public Optional<ServerEngine> getServerEngine() {
     Collection<ExecutionEngine> engines = getEngines(Optional.of(Type.SERVER)).values();
-    if (engines.isEmpty()) {
-      return Optional.empty();
-    }
 
-    return Optional.of((ServerEngine)engines.stream().findFirst().get());
+    return engines.stream().findFirst()
+        .map(e->(ServerEngine) e);
   }
 
   public ExecutionPipeline createPipeline() {

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/config/PipelineFactory.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/config/PipelineFactory.java
@@ -10,6 +10,7 @@ import com.datasqrl.engine.database.DatabaseEngine;
 import com.datasqrl.engine.database.DatabaseEngineFactory;
 import com.datasqrl.engine.pipeline.SimplePipeline;
 import com.datasqrl.engine.pipeline.ExecutionPipeline;
+import com.datasqrl.engine.server.ServerEngine;
 import com.datasqrl.engine.stream.StreamEngine;
 import com.datasqrl.metadata.MetadataStoreProvider;
 import java.util.Collection;
@@ -84,12 +85,19 @@ public class PipelineFactory {
     return (StreamEngine) getEngine(Type.STREAM);
   }
 
+  public Optional<ServerEngine> getServerEngine() {
+    Collection<ExecutionEngine> engines = getEngines(Optional.of(Type.SERVER)).values();
+    if (engines.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of((ServerEngine)engines.stream().findFirst().get());
+  }
+
   public ExecutionPipeline createPipeline() {
     DatabaseEngine db = getDatabaseEngine();
     StreamEngine stream = getStreamEngine();
-    return SimplePipeline.of(stream, db);
+    Optional<ServerEngine> server = getServerEngine();
+    return SimplePipeline.of(stream, db, server);
   }
-
-
-
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
@@ -34,7 +34,9 @@ public enum EngineCapability {
   //Writing/upserting data into engine by primary key will deduplicate data
   MATERIALIZE_ON_KEY,
   //Engine supports data monitoring
-  DATA_MONITORING;
+  DATA_MONITORING,
+  //No capabilities
+  NONE;
 
 
   public static EnumSet<EngineCapability> STANDARD_STREAM = EnumSet.of(DENORMALIZE,
@@ -43,6 +45,8 @@ public enum EngineCapability {
 
   public static EnumSet<EngineCapability> STANDARD_DATABASE = EnumSet.of(NOW, GLOBAL_SORT, MATERIALIZE_ON_KEY,
       MULTI_RANK);
+
+  public static EnumSet<EngineCapability> NO_CAPABILITIES = EnumSet.of(NONE);
 
 
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
@@ -46,7 +46,5 @@ public enum EngineCapability {
   public static EnumSet<EngineCapability> STANDARD_DATABASE = EnumSet.of(NOW, GLOBAL_SORT, MATERIALIZE_ON_KEY,
       MULTI_RANK);
 
-  public static EnumSet<EngineCapability> NO_CAPABILITIES = EnumSet.of(NONE);
-
-
+  public static EnumSet<EngineCapability> NO_CAPABILITIES = EnumSet.noneOf(EngineCapability.class);
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/EngineCapability.java
@@ -34,10 +34,7 @@ public enum EngineCapability {
   //Writing/upserting data into engine by primary key will deduplicate data
   MATERIALIZE_ON_KEY,
   //Engine supports data monitoring
-  DATA_MONITORING,
-  //No capabilities
-  NONE;
-
+  DATA_MONITORING;
 
   public static EnumSet<EngineCapability> STANDARD_STREAM = EnumSet.of(DENORMALIZE,
       TEMPORAL_JOIN, TO_STREAM, STREAM_WINDOW_AGGREGATION, EXTENDED_FUNCTIONS, CUSTOM_FUNCTIONS,

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/pipeline/SimplePipeline.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/pipeline/SimplePipeline.java
@@ -4,10 +4,13 @@
 package com.datasqrl.engine.pipeline;
 
 import com.datasqrl.engine.database.DatabaseEngine;
+import com.datasqrl.engine.server.ServerEngine;
 import com.datasqrl.engine.stream.StreamEngine;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.Value;
 
@@ -35,10 +38,14 @@ public class SimplePipeline implements ExecutionPipeline {
     }
   }
 
-  public static SimplePipeline of(StreamEngine stream, DatabaseEngine db) {
-    return new SimplePipeline(List.of(new EngineStage(stream), new EngineStage(db)));
-  }
+  public static SimplePipeline of(StreamEngine stream, DatabaseEngine db, Optional<ServerEngine> server) {
+    List<ExecutionStage> stages = new ArrayList<>();
+    stages.add(new EngineStage(stream));
+    stages.add(new EngineStage(db));
+    server.ifPresent((s)->stages.add(new EngineStage(s)));
 
+    return new SimplePipeline(stages);
+  }
 
   @Override
   public Set<ExecutionStage> getUpStreamFrom(ExecutionStage stage) {

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/server/ServerEngine.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/server/ServerEngine.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021, DataSQRL. All rights reserved. Use is subject to license terms.
+ */
+package com.datasqrl.engine.server;
+
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.stream.monitor.DataMonitor;
+import java.io.Closeable;
+
+/**
+ * The server engine is a combination of the server core (the graphql engine) and the
+ * servlet that is running it. Some servlets may not support things like Java, reflection,
+ * code generation executors, etc.
+ */
+public interface ServerEngine extends ExecutionEngine {
+
+  default DataMonitor createDataMonitor() {
+    throw new UnsupportedOperationException("Capability not supported by engine");
+  }
+}

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/server/ServerEngine.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/server/ServerEngine.java
@@ -14,7 +14,4 @@ import java.io.Closeable;
  */
 public interface ServerEngine extends ExecutionEngine {
 
-  default DataMonitor createDataMonitor() {
-    throw new UnsupportedOperationException("Capability not supported by engine");
-  }
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/stream/StreamEngine.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/stream/StreamEngine.java
@@ -9,4 +9,14 @@ import java.io.Closeable;
 
 public interface StreamEngine extends Closeable, ExecutionEngine {
 
+  /**
+   * This method must be implemented if the engine supports {@link com.datasqrl.engine.EngineCapability#DATA_MONITORING}
+   * otherwise it can be ignored.
+   *
+   * @return
+   */
+  default DataMonitor createDataMonitor() {
+    throw new UnsupportedOperationException("Capability not supported by engine");
+  }
+
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/stream/StreamEngine.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/engine/stream/StreamEngine.java
@@ -9,14 +9,4 @@ import java.io.Closeable;
 
 public interface StreamEngine extends Closeable, ExecutionEngine {
 
-  /**
-   * This method must be implemented if the engine supports {@link com.datasqrl.engine.EngineCapability#DATA_MONITORING}
-   * otherwise it can be ignored.
-   *
-   * @return
-   */
-  default DataMonitor createDataMonitor() {
-    throw new UnsupportedOperationException("Capability not supported by engine");
-  }
-
 }

--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/plan/global/PhysicalDAGPlan.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/plan/global/PhysicalDAGPlan.java
@@ -4,6 +4,7 @@
 package com.datasqrl.plan.global;
 
 import com.datasqrl.engine.pipeline.ExecutionStage;
+import com.datasqrl.graphql.server.Model.RootGraphqlModel;
 import com.datasqrl.io.tables.TableSink;
 import com.datasqrl.plan.queries.APIQuery;
 import com.datasqrl.util.StreamUtil;
@@ -55,6 +56,7 @@ public class PhysicalDAGPlan {
 
     Map<String, UserDefinedFunction> udfs;
 
+    RootGraphqlModel model;
   }
 
   public interface Query {

--- a/sqrl-engines/sqrl-engine-server/pom.xml
+++ b/sqrl-engines/sqrl-engine-server/pom.xml
@@ -2,17 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.datasqrl</groupId>
     <artifactId>sqrl-engines</artifactId>
     <version>0.1-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <!--
-    README: Shared dependencies between all engines
-  -->
-  <artifactId>sqrl-engine-core</artifactId>
+  <artifactId>sqrl-engine-server</artifactId>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
@@ -20,44 +17,24 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+
   <dependencies>
     <dependency>
       <groupId>com.datasqrl</groupId>
-      <artifactId>sqrl-common</artifactId>
+      <artifactId>sqrl-engine-core</artifactId>
     </dependency>
-    <!-- todo: Currently we have hard references to flink functions (time functions).
-               They should be refactored to have engine generic engine functions.
-    -->
-    <dependency>
-      <groupId>com.datasqrl</groupId>
-      <artifactId>sqrl-execute-flink-function</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-execute-http-core</artifactId>
     </dependency>
-
-    <!-- Used by in-memory stream
-         TODO: should be removed -->
     <dependency>
       <groupId>com.datasqrl</groupId>
-      <artifactId>sqrl-io-file</artifactId>
+      <artifactId>sqrl-execute-http-vertx</artifactId>
     </dependency>
-
-    <!-- TODO: Should be removed for base calcite -->
-<!--    <dependency>-->
-<!--      <groupId>org.apache.flink</groupId>-->
-<!--      <artifactId>flink-table-planner_2.12</artifactId>-->
-<!--      <scope>provided</scope>-->
-<!--    </dependency>-->
-
-    <!--  Test -->
     <dependency>
-      <artifactId>sqrl-common</artifactId>
       <groupId>com.datasqrl</groupId>
-      <type>test-jar</type>
-      <scope>test</scope>
+      <artifactId>sqrl-engine-jdbc</artifactId>
     </dependency>
   </dependencies>
+
 </project>

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/GenericJavaServerEngine.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/GenericJavaServerEngine.java
@@ -1,0 +1,36 @@
+package com.datasqrl.engine.server;
+
+import static com.datasqrl.engine.EngineCapability.NO_CAPABILITIES;
+
+import com.datasqrl.engine.EnginePhysicalPlan;
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.ExecutionResult;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.io.tables.TableSink;
+import com.datasqrl.plan.global.PhysicalDAGPlan.StagePlan;
+import com.datasqrl.plan.global.PhysicalDAGPlan.StageSink;
+import java.util.List;
+import org.apache.calcite.tools.RelBuilder;
+
+/**
+ * A no-feature java server engine.
+ */
+public abstract class GenericJavaServerEngine extends ExecutionEngine.Base implements ServerEngine {
+
+  public GenericJavaServerEngine(String engineName) {
+    super(engineName, Type.SERVER, NO_CAPABILITIES);
+  }
+
+  @Override
+  public ExecutionResult execute(EnginePhysicalPlan plan, ErrorCollector errors) {
+    //Executed at runtime
+    return new ExecutionResult.Message("SUCCESS");
+  }
+
+  @Override
+  public EnginePhysicalPlan plan(StagePlan plan, List<StageSink> inputs, RelBuilder relBuilder,
+      TableSink errorSink) {
+
+    return new ServerPhysicalPlan(plan.getModel());
+  }
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/GraphqlServerEngineFactory.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/GraphqlServerEngineFactory.java
@@ -1,0 +1,14 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.engine.EngineFactory;
+import com.datasqrl.engine.ExecutionEngine.Type;
+
+public abstract class GraphqlServerEngineFactory implements EngineFactory {
+  public static final String ENGINE_NAME_KEY = "name";
+
+  @Override
+  public Type getEngineType() {
+    return Type.SERVER;
+  }
+
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaJavaEngineFactory.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaJavaEngineFactory.java
@@ -1,0 +1,31 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.config.SqrlConfig;
+import com.datasqrl.engine.EngineFactory;
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.server.LambdaNativeArm64EngineFactory.LambdaNativeArm64Engine;
+import com.google.auto.service.AutoService;
+import lombok.NonNull;
+
+@AutoService(EngineFactory.class)
+public class LambdaJavaEngineFactory extends GraphqlServerEngineFactory {
+
+  public static final String ENGINE_NAME = "aws-lambda-native";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public ExecutionEngine initialize(@NonNull SqrlConfig config) {
+    return new LambdaJavaEngine();
+  }
+
+  public class LambdaJavaEngine extends GenericJavaServerEngine {
+
+    public LambdaJavaEngine() {
+      super(ENGINE_NAME);
+    }
+  }
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaNativeArm64EngineFactory.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaNativeArm64EngineFactory.java
@@ -1,0 +1,31 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.config.SqrlConfig;
+import com.datasqrl.engine.EngineFactory;
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.server.LambdaJavaEngineFactory.LambdaJavaEngine;
+import com.google.auto.service.AutoService;
+import lombok.NonNull;
+
+@AutoService(EngineFactory.class)
+public class LambdaNativeArm64EngineFactory extends GraphqlServerEngineFactory {
+
+  public static final String ENGINE_NAME = "aws-lambda-native-arm64";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public ExecutionEngine initialize(@NonNull SqrlConfig config) {
+    return new LambdaNativeArm64Engine();
+  }
+
+  public class LambdaNativeArm64Engine extends GenericJavaServerEngine {
+
+    public LambdaNativeArm64Engine() {
+      super(ENGINE_NAME);
+    }
+  }
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaNativeX86EngineFactory.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/LambdaNativeX86EngineFactory.java
@@ -1,0 +1,31 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.config.SqrlConfig;
+import com.datasqrl.engine.EngineFactory;
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.server.LambdaNativeArm64EngineFactory.LambdaNativeArm64Engine;
+import com.google.auto.service.AutoService;
+import lombok.NonNull;
+
+@AutoService(EngineFactory.class)
+public class LambdaNativeX86EngineFactory extends GraphqlServerEngineFactory {
+
+  public static final String ENGINE_NAME = "aws-lambda-native-x86";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public ExecutionEngine initialize(@NonNull SqrlConfig config) {
+    return new LambdaNativeX86Engine();
+  }
+
+  public class LambdaNativeX86Engine extends GenericJavaServerEngine {
+
+    public LambdaNativeX86Engine() {
+      super(ENGINE_NAME);
+    }
+  }
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/ServerPhysicalPlan.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/ServerPhysicalPlan.java
@@ -1,0 +1,10 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.engine.EnginePhysicalPlan;
+import com.datasqrl.graphql.server.Model.RootGraphqlModel;
+import lombok.Value;
+
+@Value
+public class ServerPhysicalPlan implements EnginePhysicalPlan {
+  RootGraphqlModel model;
+}

--- a/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/VertxEngineFactory.java
+++ b/sqrl-engines/sqrl-engine-server/src/main/java/com/datasqrl/engine/server/VertxEngineFactory.java
@@ -1,0 +1,31 @@
+package com.datasqrl.engine.server;
+
+import com.datasqrl.config.SqrlConfig;
+import com.datasqrl.engine.EngineFactory;
+import com.datasqrl.engine.ExecutionEngine;
+import com.datasqrl.engine.server.LambdaNativeX86EngineFactory.LambdaNativeX86Engine;
+import com.google.auto.service.AutoService;
+import lombok.NonNull;
+
+@AutoService(EngineFactory.class)
+public class VertxEngineFactory extends GraphqlServerEngineFactory {
+
+  public static final String ENGINE_NAME = "vertx";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public ExecutionEngine initialize(@NonNull SqrlConfig config) {
+    return new VertxEngine();
+  }
+
+  public class VertxEngine extends GenericJavaServerEngine {
+
+    public VertxEngine() {
+      super(ENGINE_NAME);
+    }
+  }
+}

--- a/sqrl-planner/sqrl-planner-local/pom.xml
+++ b/sqrl-planner/sqrl-planner-local/pom.xml
@@ -29,6 +29,10 @@
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-engine-flink</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.datasqrl</groupId>
+      <artifactId>sqrl-engine-server</artifactId>
+    </dependency>
     <!-- execute-->
     <dependency>
       <groupId>com.datasqrl</groupId>

--- a/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/frontend/SqrlOptimizeDag.java
+++ b/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/frontend/SqrlOptimizeDag.java
@@ -1,6 +1,7 @@
 package com.datasqrl.frontend;
 
 import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.graphql.server.Model.RootGraphqlModel;
 import com.datasqrl.loaders.ModuleLoader;
 import com.datasqrl.canonicalizer.NameCanonicalizer;
 import com.datasqrl.parse.SqrlParser;
@@ -31,15 +32,12 @@ public class SqrlOptimizeDag extends SqrlPlan {
     super(parser, errors, nsFactory, moduleLoader, nameCanonicalizer, statementProcessor, planner, debuggerConfig);
   }
 
-  public PhysicalDAGPlan planDag(Namespace ns, Collection<APIQuery> queries) {
-    return planDag(ns, queries, true);
-  }
-
-  public PhysicalDAGPlan planDag(Namespace ns, Collection<APIQuery> queries, boolean includeJars) {
+  public PhysicalDAGPlan planDag(Namespace ns, Collection<APIQuery> queries, RootGraphqlModel model,
+      boolean includeJars) {
     DAGPlanner dagPlanner = new DAGPlanner(planner.createRelBuilder(), ns.getSchema().getPlanner(),
         ns.getSchema().getPipeline(), getDebugger(), errors);
     CalciteSchema relSchema = planner.getSchema();
     return dagPlanner.plan(relSchema, queries, ns.getExports(), includeJars ? ns.getJars() : Set.of(),
-        ns.getUdfs());
+        ns.getUdfs(), model);
   }
 }

--- a/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGAssembler.java
+++ b/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGAssembler.java
@@ -178,16 +178,15 @@ public class DAGAssembler {
 
 
     Optional<ExecutionStage> serverStage = pipeline.getStage(Type.SERVER);
+    List<PhysicalDAGPlan.StagePlan> basePlans = ListUtils.union(List.of(streamPlan), databasePlans);
+
     if (serverStage.isPresent()) {
-
-      PhysicalDAGPlan.StagePlan serverPlan = new PhysicalDAGPlan.StagePlan(serverStage.get(), List.of(),
-          null, jars, udfs, model);
-
-      return new PhysicalDAGPlan(
-          ListUtils.union(ListUtils.union(List.of(streamPlan), databasePlans),
-              List.of(serverPlan)));
+      PhysicalDAGPlan.StagePlan serverPlan = new PhysicalDAGPlan.StagePlan(
+          serverStage.get(), List.of(), null, jars, udfs, model
+      );
+      return new PhysicalDAGPlan(ListUtils.union(basePlans, List.of(serverPlan)));
     } else {
-      return new PhysicalDAGPlan(ListUtils.union(List.of(streamPlan), databasePlans));
+      return new PhysicalDAGPlan(basePlans);
     }
   }
 

--- a/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGAssembler.java
+++ b/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGAssembler.java
@@ -8,6 +8,7 @@ import com.datasqrl.engine.database.DatabaseEngine;
 import com.datasqrl.engine.pipeline.ExecutionPipeline;
 import com.datasqrl.engine.pipeline.ExecutionStage;
 import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.graphql.server.Model.RootGraphqlModel;
 import com.datasqrl.io.tables.TableSink;
 import com.datasqrl.canonicalizer.Name;
 import com.datasqrl.plan.RelStageRunner;
@@ -59,7 +60,8 @@ public class DAGAssembler {
   private ErrorCollector errors;
 
 
-  public PhysicalDAGPlan assemble(SqrlDAG dag, Set<URL> jars, Map<String, UserDefinedFunction> udfs) {
+  public PhysicalDAGPlan assemble(SqrlDAG dag, Set<URL> jars, Map<String, UserDefinedFunction> udfs,
+      RootGraphqlModel model) {
     //Plan final version of all tables
     dag.allNodesByClass(SqrlDAG.TableNode.class).forEach( tableNode -> {
       ExecutionStage stage = tableNode.getChosenStage();
@@ -136,7 +138,7 @@ public class DAGAssembler {
       Collection<IndexDefinition> indexDefinitions = indexSelector.optimizeIndexes(indexCalls)
           .keySet();
       databasePlans.add(new PhysicalDAGPlan.StagePlan(database, readDAG, indexDefinitions,
-          null, null));
+          null, null, null));
     }
 
     //Add exported tables
@@ -172,10 +174,21 @@ public class DAGAssembler {
         });
 
     PhysicalDAGPlan.StagePlan streamPlan = new PhysicalDAGPlan.StagePlan(streamStage, writeDAG,
-        null, jars, udfs);
+        null, jars, udfs, null);
 
-    return new PhysicalDAGPlan(ListUtils.union(List.of(streamPlan),databasePlans));
 
+    Optional<ExecutionStage> serverStage = pipeline.getStage(Type.SERVER);
+    if (serverStage.isPresent()) {
+
+      PhysicalDAGPlan.StagePlan serverPlan = new PhysicalDAGPlan.StagePlan(serverStage.get(), List.of(),
+          null, jars, udfs, model);
+
+      return new PhysicalDAGPlan(
+          ListUtils.union(ListUtils.union(List.of(streamPlan), databasePlans),
+              List.of(serverPlan)));
+    } else {
+      return new PhysicalDAGPlan(ListUtils.union(List.of(streamPlan), databasePlans));
+    }
   }
 
   private Pair<RelNode,Integer> produceWriteTree(RelNode relNode, SQRLConverter.Config config, ErrorCollector errors) {

--- a/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGPlanner.java
+++ b/sqrl-planner/sqrl-planner-local/src/main/java/com/datasqrl/plan/global/DAGPlanner.java
@@ -7,6 +7,7 @@ import com.datasqrl.engine.ExecutionEngine;
 import com.datasqrl.engine.pipeline.ExecutionPipeline;
 import com.datasqrl.engine.pipeline.ExecutionStage;
 import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.graphql.server.Model.RootGraphqlModel;
 import com.datasqrl.plan.rules.SQRLConverter;
 import com.datasqrl.plan.local.generate.Debugger;
 import com.datasqrl.plan.local.generate.ResolvedExport;
@@ -85,17 +86,19 @@ public class DAGPlanner {
     }
   }
 
-  public PhysicalDAGPlan assemble(SqrlDAG dag, Set<URL> jars, Map<String, UserDefinedFunction> udfs) {
+  public PhysicalDAGPlan assemble(SqrlDAG dag, Set<URL> jars, Map<String, UserDefinedFunction> udfs,
+      RootGraphqlModel model) {
     //Stitch DAG together
     DAGAssembler assembler = new DAGAssembler(planner, sqrlConverter, pipeline, debugger, errors);
-    return assembler.assemble(dag, jars, udfs);
+    return assembler.assemble(dag, jars, udfs, model);
   }
 
   public PhysicalDAGPlan plan(CalciteSchema relSchema, Collection<APIQuery> queries,
-      Collection<ResolvedExport> exports, Set<URL> jars, Map<String, UserDefinedFunction> udfs) {
+      Collection<ResolvedExport> exports, Set<URL> jars, Map<String, UserDefinedFunction> udfs,
+      RootGraphqlModel model) {
 
     SqrlDAG dag = build(relSchema, queries, exports);
     optimize(dag);
-    return assemble(dag,jars, udfs);
+    return assemble(dag,jars, udfs, model);
   }
 }

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/AbstractPhysicalSQRLIT.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/AbstractPhysicalSQRLIT.java
@@ -126,7 +126,7 @@ public class AbstractPhysicalSQRLIT extends AbstractLogicalSQRLIT {
       queries.add(new APIQuery(tableName, rel));
     }
 
-    PhysicalDAGPlan dag = physicalPlanner.planDag(ns, queries, true);
+    PhysicalDAGPlan dag = physicalPlanner.planDag(ns, queries, null, true);
     addContent(dag);
 
     PhysicalPlan physicalPlan = physicalPlanner.createPhysicalPlan(dag);

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/graphql/inference/AbstractSchemaInferenceModelTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/graphql/inference/AbstractSchemaInferenceModelTest.java
@@ -83,7 +83,7 @@ public class AbstractSchemaInferenceModelTest extends AbstractLogicalSQRLIT {
     DAGPlanner dagPlanner = new DAGPlanner(planner.createRelBuilder(), ns.getSchema().getPlanner(),
         ns.getSchema().getPipeline(), Debugger.NONE, errors);
     PhysicalDAGPlan dag = dagPlanner.plan(ns.getSchema(), queries, ns.getExports(), ns.getJars(),
-        ns.getUdfs());
+        ns.getUdfs(), null);
 
     IndexSelector indexSelector = new IndexSelector(ns.getSchema().getPlanner(),
         IndexSelectorConfigByDialect.of("POSTGRES"));

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractQuerySQRLIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractQuerySQRLIT.java
@@ -70,7 +70,7 @@ public class AbstractQuerySQRLIT extends AbstractPhysicalSQRLIT {
     Pair<RootGraphqlModel, List<APIQuery>> modelAndQueries = t
         .getModelAndQueries(planner, schema);
 
-    PhysicalDAGPlan dag = physicalPlanner.planDag(ns, modelAndQueries.getRight(), true);
+    PhysicalDAGPlan dag = physicalPlanner.planDag(ns, modelAndQueries.getRight(), modelAndQueries.getLeft(), true);
 
     PhysicalPlan physicalPlan = physicalPlanner.createPhysicalPlan(dag);
 

--- a/sqrl-tools/sqrl-cli/pom.xml
+++ b/sqrl-tools/sqrl-cli/pom.xml
@@ -58,10 +58,6 @@
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-discovery</artifactId>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>com.datasqrl</groupId>-->
-<!--      <artifactId>sqrl-engine-flink</artifactId>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-io-jdbc</artifactId>

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
@@ -73,11 +73,11 @@ public abstract class AbstractCompilerCommand extends AbstractCommand {
     this.startGraphql = startGraphql;
   }
 
-  @SneakyThrows
-  public void runCommand(ErrorCollector errors) throws IOException {
+  public void runCommand(ErrorCollector errors) {
     SqrlConfig config = PackagerUtil.getOrCreateDefaultConfiguration(root, errors);
-    Build build = new Build(errors);
     Packager packager = PackagerUtil.create(root.rootDir, files, config, errors);
+
+    Build build = new Build(errors);
     Path packageFilePath = build.build(packager, !noinfer);
     PipelineFactory pipelineFactory = PipelineFactory.fromRootConfig(config);
     DatabaseEngine dbEngine = pipelineFactory.getDatabaseEngine();

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/Compiler.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/Compiler.java
@@ -114,7 +114,7 @@ public class Compiler {
 
     RootGraphqlModel root = inferredSchema.accept(pgSchemaBuilder, null);
 
-    PhysicalDAGPlan dag = planner.planDag(ns, pgSchemaBuilder.getApiQueries(),
+    PhysicalDAGPlan dag = planner.planDag(ns, pgSchemaBuilder.getApiQueries(), root,
         !(resourceResolver instanceof ClasspathResourceResolver));
     PhysicalPlan plan = createPhysicalPlan(dag, queryPlanner, ns, errorSink);
 

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/service/PackagerUtil.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/service/PackagerUtil.java
@@ -5,7 +5,9 @@ import com.datasqrl.config.PipelineFactory;
 import com.datasqrl.config.SqrlConfig;
 import com.datasqrl.config.SqrlConfigCommons;
 import com.datasqrl.engine.database.relational.JDBCEngineFactory;
+import com.datasqrl.engine.server.GraphqlServerEngineFactory;
 import com.datasqrl.engine.stream.flink.FlinkEngineFactory;
+import com.datasqrl.engine.server.VertxEngineFactory;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.error.ErrorPrefix;
 import com.datasqrl.io.impl.jdbc.JdbcDataSystemConnector;
@@ -31,10 +33,11 @@ public class PackagerUtil {
   }
 
   protected static PackagerConfig createPackageConfig(Path[] files, Path rootDir, SqrlConfig config) {
-    PackagerConfig.PackagerConfigBuilder pkgBuilder = PackagerConfig.builder();
-    pkgBuilder.rootDir(rootDir);
-    pkgBuilder.config(config);
-    pkgBuilder.mainScript(files[0]);
+    PackagerConfig.PackagerConfigBuilder pkgBuilder =
+        PackagerConfig.builder()
+            .rootDir(rootDir)
+            .config(config)
+            .mainScript(files[0]);
     if (files.length > 1) {
       pkgBuilder.graphQLSchemaFile(files[1]);
     }
@@ -82,6 +85,9 @@ public class PackagerUtil {
 
     SqrlConfig flinkConfig = config.getSubConfig("stream");
     flinkConfig.setProperty(FlinkEngineFactory.ENGINE_NAME_KEY, FlinkEngineFactory.ENGINE_NAME);
+
+    SqrlConfig server = config.getSubConfig("server");
+    server.setProperty(GraphqlServerEngineFactory.ENGINE_NAME_KEY, VertxEngineFactory.ENGINE_NAME);
 
     return rootConfig;
   }

--- a/sqrl-tools/sqrl-packager/pom.xml
+++ b/sqrl-tools/sqrl-packager/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>sqrl-planner-local</artifactId>
             <groupId>com.datasqrl</groupId>
         </dependency>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>sqrl-execute-http-vertx</artifactId>
+        </dependency>
 
         <!-- Utils -->
         <dependency>


### PR DESCRIPTION
Adds servlets as a 'server' engine type. Currently it is a no-op for planning since the engine type currently has no local query engine. This is a necessary prerequisite for adding the ability to generate deployment assets.