### PR TITLE
Fix Flink 1.15 class compatibility bug

### DIFF
--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractQuerySQRLIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractQuerySQRLIT.java
@@ -89,14 +89,16 @@ public class AbstractQuerySQRLIT extends AbstractPhysicalSQRLIT {
 
     CountDownLatch countDownLatch = new CountDownLatch(1);
 
-
     this.port = getPort(8888);
     GraphQLServer server = new GraphQLServer(model, port, jdbc);
     vertx.deployVerticle(server, c->countDownLatch.countDown());
     countDownLatch.await(10, TimeUnit.SECONDS);
     if (countDownLatch.getCount() != 0) {
-      throw new RuntimeException();
+      throw new RuntimeException("Could not start vertx");
     }
+
+    //Testing short sleep for failing test
+    Thread.sleep(2000);
 
     for (Map.Entry<String, String> query : queries.entrySet()) {
       HttpResponse<String> response = testQuery(query.getValue());


### PR DESCRIPTION
SingleOutputStreamOperator.getSideOutput return a DataStream in 1.15 but a SideOutputDataStream in 1.16. This fixes a method missing exception.

Caused by: java.lang.NoSuchMethodError: 'org.apache.flink.streaming.api.datastream.SideOutputDataStream org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator.getSideOutput(org.apache.flink.util.OutputTag)'
at com.datasqrl.FlinkEnvironmentBuilder.buildStream(FlinkEnvironmentBuilder.java:376)


https://nightlies.apache.org/flink/flink-docs-release-1.15/api/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.html#getSideOutput-org.apache.flink.util.OutputTag-
https://nightlies.apache.org/flink/flink-docs-release-1.16/api/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.html#getSideOutput-org.apache.flink.util.OutputTag-