### PR TITLE
Use ungeneralized types for flexible schema and planner

### DIFF
--- a/sqrl-examples/conference/mysourcepackage/authtokens.schema.yml
+++ b/sqrl-examples/conference/mysourcepackage/authtokens.schema.yml
@@ -12,6 +12,6 @@ columns:
   tests:
   - "not_null"
 - name: "last_updated"
-  type: "DATETIME"
+  type: "TIMESTAMP"
   tests:
   - "not_null"

--- a/sqrl-examples/conference/mysourcepackage/authtokens.schema.yml
+++ b/sqrl-examples/conference/mysourcepackage/authtokens.schema.yml
@@ -12,6 +12,6 @@ columns:
   tests:
   - "not_null"
 - name: "last_updated"
-  type: "TIMESTAMP"
+  type: "DATETIME"
   tests:
   - "not_null"

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/input/external/SchemaImport.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/input/external/SchemaImport.java
@@ -231,7 +231,7 @@ public class SchemaImport {
     }
 
     public static String export(int arrayDepth, BasicType<?> type) {
-      String r = type.getName().get(0);
+      String r = type.getName();
       for (int i = 0; i < arrayDepth; i++) {
         r = "[" + r + "]";
       }

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
@@ -29,7 +29,7 @@ public abstract class AbstractBasicType<J> implements BasicType<J> {
       return false;
     }
     AbstractBasicType<?> that = (AbstractBasicType<?>) o;
-    return getNames().equals(that.getNames());
+    return getName().equals(that.getName());
   }
 
   @Override

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
@@ -33,8 +33,8 @@ public abstract class AbstractBasicType<J> implements BasicType<J> {
     return getName().get(0);
   }
 
-  public int compareTo(BasicType<?> o) {
-    return getName().get(0).compareTo(o.getName().get(0));
+  public int compareTo(BasicType o) {
+    return getName().get(0).compareTo((String)o.getName().get(0));
   }
 
   public <R, C> R accept(SqrlTypeVisitor<R, C> visitor, C context) {

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
@@ -33,8 +33,8 @@ public abstract class AbstractBasicType<J> implements BasicType<J> {
     return getName().get(0);
   }
 
-  public int compareTo(BasicType o) {
-    return getName().get(0).compareTo((String)o.getName().get(0));
+  public int compareTo(BasicType<?> o) {
+    return getName().get(0).compareTo(o.getName().get(0));
   }
 
   public <R, C> R accept(SqrlTypeVisitor<R, C> visitor, C context) {

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/AbstractBasicType.java
@@ -12,7 +12,12 @@ public abstract class AbstractBasicType<J> implements BasicType<J> {
 
   @Override
   public int hashCode() {
-    return getName().get(0).hashCode();
+    return getName().hashCode();
+  }
+
+  @Override
+  public String getName() {
+    return getNames().get(0);
   }
 
   @Override
@@ -24,17 +29,16 @@ public abstract class AbstractBasicType<J> implements BasicType<J> {
       return false;
     }
     AbstractBasicType<?> that = (AbstractBasicType<?>) o;
-    return getName().equals(that.getName());
+    return getNames().equals(that.getNames());
   }
-
 
   @Override
   public String toString() {
-    return getName().get(0);
+    return getName();
   }
 
   public int compareTo(BasicType<?> o) {
-    return getName().get(0).compareTo(o.getName().get(0));
+    return getName().compareTo(o.getName());
   }
 
   public <R, C> R accept(SqrlTypeVisitor<R, C> visitor, C context) {

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BasicType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BasicType.java
@@ -7,11 +7,8 @@ import com.datasqrl.schema.type.Type;
 import java.util.List;
 
 public interface BasicType<JavaType> extends Type, Comparable<BasicType<?>> {
-
   //First entry is the preferred name, the remaining are for backwards compatibility
-  List<String> getName();
-
+  String getName();
+  List<String> getNames();
   TypeConversion<JavaType> conversion();
-
-
 }

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BasicTypeManager.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BasicTypeManager.java
@@ -31,7 +31,7 @@ public class BasicTypeManager {
   }).collect(Collectors.toUnmodifiableMap(Pair::getKey, Pair::getValue));
 
   public static final Map<String, BasicType<?>> ALL_TYPES_BY_NAME = Arrays.stream(ALL_TYPES)
-      .flatMap(type->type.getName().stream().map(name->Pair.of(name, type)))
+      .flatMap(type->type.getNames().stream().map(name->Pair.of(name, type)))
       .collect(Collectors.toUnmodifiableMap(t ->(t.getLeft()).toLowerCase(Locale.ENGLISH),
           Pair::getRight));
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BigIntType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BigIntType.java
@@ -17,7 +17,7 @@ public class BigIntType extends AbstractBasicType<Long> {
   public static final BigIntType INSTANCE = new BigIntType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("BIGINT", "INTEGER");
   }
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BooleanType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/BooleanType.java
@@ -26,7 +26,7 @@ public class BooleanType extends AbstractBasicType<Boolean> {
   public static final BooleanType INSTANCE = new BooleanType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("BOOLEAN");
   }
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/DoubleType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/DoubleType.java
@@ -16,7 +16,7 @@ public class DoubleType extends AbstractBasicType<Double> {
   public static final DoubleType INSTANCE = new DoubleType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("DOUBLE", "FLOAT");
   }
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/IntervalType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/IntervalType.java
@@ -14,7 +14,7 @@ public class IntervalType extends AbstractBasicType<Duration> {
   public static final IntervalType INSTANCE = new IntervalType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("INTERVAL");
   }
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/StringType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/StringType.java
@@ -14,7 +14,7 @@ public class StringType extends AbstractBasicType<String> {
   public static final StringType INSTANCE = new StringType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("STRING");
   }
 

--- a/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/TimestampType.java
+++ b/sqrl-io/sqrl-io-schema-flexible/src/main/java/com/datasqrl/schema/type/basic/TimestampType.java
@@ -18,7 +18,7 @@ public class TimestampType extends AbstractBasicType<Instant> {
   public static final TimestampType INSTANCE = new TimestampType();
 
   @Override
-  public List<String> getName() {
+  public List<String> getNames() {
     return List.of("TIMESTAMP", "DATETIME");
   }
 

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/QueryPlanner.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/QueryPlanner.java
@@ -194,25 +194,18 @@ public class QueryPlanner {
    * type definition syntax.
    */
   @SneakyThrows
-  public static RelDataType parseDatatype(String datatype) {
-    TypeFactory typeFactory = TypeFactory.getTypeFactory();
-    SqlCall sqlNode = (SqlCall) SqlParser.create(
-        String.format("CAST(null AS %s)", datatype)).parseExpression();
+  public RelDataType parseDatatype(String datatype) {
+    SqlCall sqlNode = (SqlCall) SqlParser.create(String.format("CAST(null AS %s)", datatype))
+        .parseExpression();
 
-    SqrlSqlValidator validator = new SqrlSqlValidator(
-        SqlStdOperatorTable.instance(),
-        new CalciteCatalogReader(CalciteSchema.createRootSchema(false),
-            List.of(), typeFactory, null),
-        typeFactory,
-        SqrlConfigurations.sqlValidatorConfig);
-
+    SqlValidator validator = createSqlValidator();
     validator.validate(sqlNode);
 
     SqlDataTypeSpec typeSpec = (SqlDataTypeSpec) sqlNode.getOperandList().get(1);
 
-    RelDataType relType = typeSpec.deriveType(validator);
-    return relType;
+    return typeSpec.deriveType(validator);
   }
+
   /**
    * Plans a sql statement against a relnode
    */


### PR DESCRIPTION
Moves away from the generalized graphql-esque type mapping to the more concrete sql types. 

Some schemas are published in the registry so the flexible schema is made to be backwards compatible.

Also removes UUID type.