### PR TITLE
Support table functions in SQL

### DIFF
--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/SqrlToSql.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/SqrlToSql.java
@@ -1,5 +1,6 @@
 package com.datasqrl.calcite;
 
+import static com.datasqrl.plan.validate.ScriptValidator.addError;
 import static com.datasqrl.plan.validate.ScriptValidator.isSelfTable;
 import static com.datasqrl.plan.validate.ScriptValidator.isVariable;
 
@@ -16,6 +17,7 @@ import com.datasqrl.calcite.sqrl.PathToSql;
 import com.datasqrl.calcite.visitor.SqlNodeVisitor;
 import com.datasqrl.calcite.visitor.SqlRelationVisitor;
 import com.datasqrl.canonicalizer.ReservedName;
+import com.datasqrl.error.ErrorLabel;
 import com.datasqrl.plan.hints.TopNHint.Type;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -373,6 +375,17 @@ public class SqrlToSql implements SqlRelationVisitor<Result, Context> {
         tableReferences,
         Optional.empty(),
         operandResults.get(0).params);
+  }
+
+  @Override
+  public Result visitTableFunction(SqlCall node, Context context) {
+    //Let sql validator resolve table function
+    return new Result(node, List.of(), List.of(), List.of(), Optional.empty(), parameters);
+  }
+
+  @Override
+  public Result visitCall(SqlCall node, Context context) {
+    throw new RuntimeException("Expected call");
   }
 
   @Value

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/SqrlToSql.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/SqrlToSql.java
@@ -44,6 +44,7 @@ import org.apache.calcite.sql.SqlHint;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLateralOperator;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
@@ -385,6 +386,12 @@ public class SqrlToSql implements SqlRelationVisitor<Result, Context> {
 
   @Override
   public Result visitCall(SqlCall node, Context context) {
+    if (node.getOperator() instanceof SqlLateralOperator) {
+      Result result = SqlNodeVisitor.accept(this, node.getOperandList().get(0), context);
+      SqlCall call = node.getOperator().createCall(node.getParserPosition(), result.sqlNode);
+      return new Result(call, result.currentPath, result.pullupColumns, result.tableReferences,
+          result.condition, result.params);
+    }
     throw new RuntimeException("Expected call");
   }
 

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlNodeVisitor.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlNodeVisitor.java
@@ -5,8 +5,11 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLateralOperator;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlUnnestOperator;
+import org.apache.calcite.sql.SqlUnresolvedFunction;
 import org.apache.calcite.sql.SqrlAssignTimestamp;
 import org.apache.calcite.sql.SqrlAssignment;
 import org.apache.calcite.sql.SqrlDistinctQuery;
@@ -19,6 +22,7 @@ import org.apache.calcite.sql.SqrlSqlQuery;
 import org.apache.calcite.sql.SqrlStreamQuery;
 import org.apache.calcite.sql.StatementVisitor;
 import org.apache.calcite.sql.fun.SqlCollectionTableOperator;
+import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
 
 public abstract class SqlNodeVisitor<R, C> implements
     SqlRelationVisitor<R, C>,
@@ -63,7 +67,17 @@ public abstract class SqlNodeVisitor<R, C> implements
         && SqlKind.SET_QUERY.contains(node.getKind())) {
       return visitor.visitSetOperation((SqlCall) node, context);
     } else if (node instanceof SqlCall && ((SqlCall) node).getOperator() instanceof SqlCollectionTableOperator) {
-      return visitor.visitTableFunction((SqlCall) node, context);
+      return visitor.visitCollectTableFunction((SqlCall) node, context);
+    } else if (node instanceof SqlCall && ((SqlCall) node).getOperator() instanceof SqlLateralOperator) {
+      return visitor.visitLateralFunction((SqlCall) node, context);
+    } else if (node instanceof SqlCall && ((SqlCall) node).getOperator() instanceof SqlUnnestOperator) {
+      return visitor.visitUnnestFunction((SqlCall) node, context);
+    } else if (node instanceof SqlCall &&
+        ((SqlCall) node).getOperator() instanceof SqlUserDefinedTableFunction) {
+      return visitor.visitUserDefinedTableFunction((SqlCall) node, context);
+    } else if (node instanceof SqlCall &&
+        ((SqlCall) node).getOperator() instanceof SqlUnresolvedFunction) {
+      return visitor.visitUserDefinedTableFunction((SqlCall) node, context);
     } else if (node instanceof SqlCall) {
       return visitor.visitCall((SqlCall) node, context);
     }

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlRelationVisitor.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlRelationVisitor.java
@@ -8,7 +8,6 @@ public interface SqlRelationVisitor<R, C> {
   R visitTable(SqlIdentifier node, C context);
   R visitJoin(SqlJoin node, C context);
   R visitSetOperation(SqlCall node, C context);
-  default R visitTableFunction(SqlCall node, C context) {
-    return null;
-  }
+  R visitTableFunction(SqlCall node, C context);
+  R visitCall(SqlCall node, C context);
 }

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlRelationVisitor.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/calcite/visitor/SqlRelationVisitor.java
@@ -8,6 +8,9 @@ public interface SqlRelationVisitor<R, C> {
   R visitTable(SqlIdentifier node, C context);
   R visitJoin(SqlJoin node, C context);
   R visitSetOperation(SqlCall node, C context);
-  R visitTableFunction(SqlCall node, C context);
+  R visitCollectTableFunction(SqlCall node, C context);
+  R visitLateralFunction(SqlCall node, C context);
+  R visitUnnestFunction(SqlCall node, C context);
+  R visitUserDefinedTableFunction(SqlCall node, C context);
   R visitCall(SqlCall node, C context);
 }

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
@@ -56,6 +56,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLateralOperator;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
@@ -479,6 +480,10 @@ public class ScriptValidator implements StatementVisitor<Void, Void> {
 
       @Override
       public SqlNode visitCall(SqlCall node, Object context) {
+        if (node.getOperator() instanceof SqlLateralOperator) {
+          SqlNode op = SqlNodeVisitor.accept(this, node.getOperandList().get(0), context);
+          return node.getOperator().createCall(node.getParserPosition(), op);
+        }
         throw addError(ErrorLabel.GENERIC, node, "Unsupported call: %s", node.getOperator().getName());
       }
     }, query, null);

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
@@ -355,6 +355,7 @@ public class ScriptValidator implements StatementVisitor<Void, Void> {
         }
       }
 
+      System.out.println(sqlNode);
       validated = validator.validate(sqlNode);
     } catch (CalciteContextException e) {
       throw addError(ErrorLabel.GENERIC, e);

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
@@ -355,7 +355,6 @@ public class ScriptValidator implements StatementVisitor<Void, Void> {
         }
       }
 
-      System.out.println(sqlNode);
       validated = validator.validate(sqlNode);
     } catch (CalciteContextException e) {
       throw addError(ErrorLabel.GENERIC, e);

--- a/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
+++ b/sqrl-planner/sqrl-common/src/main/java/com/datasqrl/plan/validate/ScriptValidator.java
@@ -469,6 +469,18 @@ public class ScriptValidator implements StatementVisitor<Void, Void> {
                 .map(o->SqlNodeVisitor.accept(this, o, context))
                 .collect(Collectors.toList()));
       }
+
+      @Override
+      public SqlNode visitTableFunction(SqlCall node, Object context) {
+        SqlCall sqlNode = (SqlCall)node.getOperandList().get(0);
+        return node.getOperator().createCall(node.getParserPosition(),
+            sqlNode.accept(rewriteVariables(parameterList, materializeSelf)));
+      }
+
+      @Override
+      public SqlNode visitCall(SqlCall node, Object context) {
+        throw addError(ErrorLabel.GENERIC, node, "Unsupported call: %s", node.getOperator().getName());
+      }
     }, query, null);
 
     return Pair.of(parameterList, node);

--- a/sqrl-planner/sqrl-common/src/main/java/org/apache/calcite/jdbc/SqrlSchema.java
+++ b/sqrl-planner/sqrl-common/src/main/java/org/apache/calcite/jdbc/SqrlSchema.java
@@ -85,7 +85,9 @@ public class SqrlSchema extends SimpleCalciteSchema {
     removePrefix(this.pathToAbsolutePathMap.keySet(),root.getName().toNamePath());
     plus().add(String.join(".", root.getPath().toStringList()) + "$"
         + sqrlFramework.getUniqueMacroInt().incrementAndGet(), root);
-    plus().add(root.getName().getDisplay(), root);
+    if (!root.getParameters().isEmpty()) {
+      plus().add(root.getName().getDisplay(), root);
+    }
   }
 
   private void removePrefix(Set<NamePath> set, NamePath prefix) {
@@ -107,6 +109,9 @@ public class SqrlSchema extends SimpleCalciteSchema {
     this.sysTableToRelationshipMap.put(relationship.getFromTable(), relationship);
     plus().add(String.join(".", relationship.getPath().toStringList()) + "$"
         + sqrlFramework.getUniqueMacroInt().incrementAndGet(), relationship);
+    if (!relationship.getParameters().isEmpty()) {
+      plus().add(String.join(".", relationship.getPath().toStringList()), relationship);
+    }
   }
 
   public void addTableMapping(NamePath path, String nameId) {

--- a/sqrl-planner/sqrl-common/src/main/java/org/apache/calcite/jdbc/SqrlSchema.java
+++ b/sqrl-planner/sqrl-common/src/main/java/org/apache/calcite/jdbc/SqrlSchema.java
@@ -84,8 +84,8 @@ public class SqrlSchema extends SimpleCalciteSchema {
   public void addTable(RootSqrlTable root) {
     removePrefix(this.pathToAbsolutePathMap.keySet(),root.getName().toNamePath());
     plus().add(String.join(".", root.getPath().toStringList()) + "$"
-        + sqrlFramework.getUniqueMacroInt().incrementAndGet(), root
-        );
+        + sqrlFramework.getUniqueMacroInt().incrementAndGet(), root);
+    plus().add(root.getName().getDisplay(), root);
   }
 
   private void removePrefix(Set<NamePath> set, NamePath prefix) {

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1112,6 +1112,23 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
   }
 
   @Test
+  public void callTableFunction() {
+    validateScript("IMPORT ecommerce-data.Orders;\n"
+        + "X(@id: Int) := SELECT * FROM Orders WHERE id = @id;\n"
+        + "X(@id: Int, @customerid: Int) := SELECT * FROM Orders WHERE id = @id AND customerid = @customerid;\n"
+        + "Y(@id: Int) := SELECT * FROM TABLE(X(2));\n"
+        + "Z(@id: Int) := SELECT * FROM TABLE(X(2, 3));\n");
+  }
+
+  @Test
+  public void chainedTableFncCallTest() {
+    validateScript("IMPORT ecommerce-data.Orders;\n"
+        + "X(@id: Int) := SELECT * FROM Orders WHERE id = @id;\n"
+        + "Y(@id: Int) := SELECT * FROM TABLE(X(@id));\n"
+        + "Z := SELECT * FROM TABLE(Y(3));\n");
+  }
+
+  @Test
   public void orderTest() {
     validateScript("IMPORT ecommerce-data.Orders;"
         + "Orders.ordered_entries := SELECT e.* FROM @ JOIN @.entries AS e ORDER BY @._uuid;");

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1129,9 +1129,12 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
   }
 
   @Test
+  @Disabled
+  //todo: Illegal use of dynamic param error
   public void joinTableFncCallTest() {
     validateScript("IMPORT ecommerce-data.Orders;\n"
         + "IMPORT ecommerce-data.Product;\n"
+        + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
         + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
         + "Y(@id: Int) := SELECT * FROM TABLE(`Orders.entries.product`(@id));");
   }

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1135,6 +1135,15 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
     validateScript("IMPORT ecommerce-data.Orders;\n"
         + "IMPORT ecommerce-data.Product;\n"
         + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
+        + "Y(@id: Int) := SELECT * FROM TABLE(`Orders.entries.product`(@id));");
+  }
+  @Test
+  @Disabled
+  //todo: Illegal use of dynamic param error
+  public void joinTableFncCall2Test() {
+    validateScript("IMPORT ecommerce-data.Orders;\n"
+        + "IMPORT ecommerce-data.Product;\n"
+        + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
         + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
         + "Y(@id: Int) := SELECT * FROM TABLE(`Orders.entries.product`(@id));");
   }

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1127,6 +1127,14 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
         + "Y(@id: Int) := SELECT * FROM TABLE(X(@id));\n"
         + "Z := SELECT * FROM TABLE(Y(3));\n");
   }
+  
+  @Test
+  public void lateralJoinTest() {
+    validateScript("IMPORT ecommerce-data.Orders;\n"
+        + "X(@id: Int) := SELECT * FROM Orders WHERE id = @id;\n"
+        + "X(@id: Int, @customerid: Int) := SELECT * FROM Orders WHERE id = @id AND customerid = @customerid;\n"
+        + "Y(@id: Int) := SELECT * FROM TABLE(X(2)) AS t JOIN LATERAL TABLE(X(t.id, 3));\n");
+  }
 
   @Test
   public void orderTest() {

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1129,8 +1129,6 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
   }
 
   @Test
-  @Disabled
-  //todo: Illegal use of dynamic param error
   public void joinTableFncCallTest() {
     validateScript("IMPORT ecommerce-data.Orders;\n"
         + "IMPORT ecommerce-data.Product;\n"

--- a/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
+++ b/sqrl-planner/sqrl-planner-local/src/test/java/com/datasqrl/plan/local/analyze/QuerySnapshotTest.java
@@ -1127,7 +1127,15 @@ class QuerySnapshotTest extends AbstractLogicalSQRLIT {
         + "Y(@id: Int) := SELECT * FROM TABLE(X(@id));\n"
         + "Z := SELECT * FROM TABLE(Y(3));\n");
   }
-  
+
+  @Test
+  public void joinTableFncCallTest() {
+    validateScript("IMPORT ecommerce-data.Orders;\n"
+        + "IMPORT ecommerce-data.Product;\n"
+        + "Orders.entries.product(@id: Int) := JOIN Product p ON p.productid = @id;\n"
+        + "Y(@id: Int) := SELECT * FROM TABLE(`Orders.entries.product`(@id));");
+  }
+
   @Test
   public void lateralJoinTest() {
     validateScript("IMPORT ecommerce-data.Orders;\n"

--- a/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/callTableFunction.txt
+++ b/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/callTableFunction.txt
@@ -1,0 +1,23 @@
+>>>orders$2
+LogicalTableScan(table=[[orders$1]])
+
+>>>x$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, ?0)])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>x$2
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[AND(=($2, ?0), =($3, ?1))])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>y$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, 2)])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>z$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[AND(=($2, 2), =($3, 3))])
+    LogicalTableScan(table=[[orders$2]])
+

--- a/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/chainedTableFncCallTest.txt
+++ b/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/chainedTableFncCallTest.txt
@@ -1,0 +1,18 @@
+>>>orders$2
+LogicalTableScan(table=[[orders$1]])
+
+>>>x$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, ?0)])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>y$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, ?0)])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>z$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, 3)])
+    LogicalTableScan(table=[[orders$2]])
+

--- a/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/joinTableFncCallTest.txt
+++ b/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/joinTableFncCallTest.txt
@@ -1,0 +1,11 @@
+>>>orders$2
+LogicalTableScan(table=[[orders$1]])
+
+>>>product$2
+LogicalTableScan(table=[[product$1]])
+
+>>>y$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], productid=[$2], name=[$3], description=[$4], category=[$5])
+  LogicalFilter(condition=[=($2, ?0)])
+    LogicalTableScan(table=[[product$2]])
+

--- a/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/lateralJoinTest.txt
+++ b/sqrl-planner/sqrl-planner-local/src/test/resources/snapshots/com/datasqrl/plan/local/analyze/QuerySnapshotTest/lateralJoinTest.txt
@@ -1,0 +1,27 @@
+>>>orders$2
+LogicalTableScan(table=[[orders$1]])
+
+>>>x$1
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[=($2, ?0)])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>x$2
+LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5])
+  LogicalFilter(condition=[AND(=($2, ?0), =($3, ?1))])
+    LogicalTableScan(table=[[orders$2]])
+
+>>>y$1
+LogicalProject(_uuid=[$0], _uuid0=[$6], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5], _ingest_time0=[$7], id0=[$8], customerid0=[$9], time0=[$10], entries0=[$11], __timestamp16=[CASE(<($4, $15), $15, $4)])
+  LogicalJoin(condition=[=($2, $12)], joinType=[inner])
+    LogicalFilter(condition=[=($2, 2)])
+      LogicalTableScan(table=[[orders$2]])
+    LogicalProject(_uuid=[$0], _ingest_time=[$1], id=[$2], customerid=[$3], time=[$4], entries=[$5], id0=[$6], time0=[$7], _rownum=[$8], __timestamp=[CASE(<($4, $7), $7, $4)])
+      LogicalJoin(condition=[=($2, CAST($6):INTEGER NOT NULL)], joinType=[inner])
+        LogicalFilter(condition=[=($3, 3)])
+          LogicalTableScan(table=[[orders$2]])
+        LogicalFilter(condition=[=($2, 1)])
+          LogicalProject(id=[$2], time=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $4 DESC NULLS LAST)])
+            LogicalFilter(condition=[=($2, 2)])
+              LogicalTableScan(table=[[orders$2]])
+


### PR DESCRIPTION
Initial support for table functions in SQL. Supports calling sqrl table functions but does not impart sqrl native table paths. 

```
IMPORT ecommerce-data.Orders;
X(@id: Int) := SELECT * FROM Orders WHERE id = @id;
X(@id: Int, @customerid: Int) := SELECT * FROM Orders WHERE id = @id AND customerid = @customerid;
Y(@id: Int) := SELECT * FROM TABLE(X(2));
Z(@id: Int) := SELECT * FROM TABLE(X(2, 3));
```

```
IMPORT ecommerce-data.Orders;
X(@id: Int) := SELECT * FROM Orders WHERE id = @id;
Y(@id: Int) := SELECT * FROM TABLE(X(@id));
Z := SELECT * FROM TABLE(Y(3));
```