### PR TITLE
Copy S3 plugin to flink for docker compose

### DIFF
--- a/sqrl-execute/sqrl-execute-flink/sqrl-execute-flink-core/src/main/java/com/datasqrl/serializer/Base64Deserializer.java
+++ b/sqrl-execute/sqrl-execute-flink/sqrl-execute-flink-core/src/main/java/com/datasqrl/serializer/Base64Deserializer.java
@@ -9,19 +9,41 @@ import org.apache.commons.codec.binary.Base64;
 
 public abstract class Base64Deserializer<T extends Serializable> extends StdDeserializer<T> {
 
-    public Base64Deserializer(Class<T> vc) {
-        super(vc);
+  public Base64Deserializer(Class<T> vc) {
+    super(vc);
+  }
+
+  @Override
+  public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String base64 = p.getValueAsString();
+    byte[] bytes = Base64.decodeBase64(base64);
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new CustomObjectInputStream(bais, contextClassLoader)) {
+      return (T) ois.readObject();
+    } catch (ClassNotFoundException e) {
+      throw new IOException("Failed to deserialize object", e);
+    }
+  }
+
+  public class CustomObjectInputStream extends ObjectInputStream {
+
+    private final ClassLoader classLoader;
+
+    public CustomObjectInputStream(ByteArrayInputStream bais, ClassLoader classLoader)
+        throws IOException {
+      super(bais);
+      this.classLoader = classLoader;
     }
 
     @Override
-    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        String base64 = p.getValueAsString();
-        byte[] bytes = Base64.decodeBase64(base64);
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-             ObjectInputStream ois = new ObjectInputStream(bais)) {
-            return (T) ois.readObject();
-        } catch (ClassNotFoundException e) {
-            throw new IOException("Failed to deserialize object", e);
-        }
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+        throws IOException, ClassNotFoundException {
+      try {
+        return Class.forName(desc.getName(), false, classLoader);
+      } catch (ClassNotFoundException e) {
+        return super.resolveClass(desc);
+      }
     }
+  }
 }

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
@@ -113,6 +113,7 @@ public abstract class AbstractCompilerCommand extends AbstractCommand {
     if (configSupplier.usesDefault) {
       addDockerCompose(Optional.ofNullable(mountDirectory));
       addFlinkExecute();
+      addInitFlink();
     }
     if (isGenerateGraphql()) {
       addGraphql(packager.getBuildDir(), packager.getRootDir());
@@ -146,11 +147,20 @@ public abstract class AbstractCompilerCommand extends AbstractCommand {
   }
 
   protected void addFlinkExecute() {
-    String sh = DockerCompose.getFlinkExecute();
-    Path toFile = targetDir.resolve("submit-flink-job.sh");
+    String content = DockerCompose.getFlinkExecute();
+    copyExecutableFile("submit-flink-job.sh", content);
+  }
+
+  protected void addInitFlink() {
+    String content = DockerCompose.getInitFlink();
+    copyExecutableFile("init-flink.sh", content);
+  }
+
+  protected void copyExecutableFile(String fileName, String content) {
+    Path toFile = targetDir.resolve(fileName);
     try {
       Files.createDirectories(targetDir);
-      Files.writeString(toFile, sh);
+      Files.writeString(toFile, content);
 
       Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-xr-x");
       Files.setPosixFilePermissions(toFile, perms);

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/DockerCompose.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/DockerCompose.java
@@ -7,14 +7,13 @@ import java.util.Optional;
 public class DockerCompose {
 
   public static String getYml(Optional<Path> mountDir) {
-    String volumneMnt = mountDir.map(dir -> dir.toAbsolutePath().normalize())
-        .map(dir -> ""
-            + "    volumes:\n"
-            + "      - " + dir.toAbsolutePath() + ":/build\n"
-            + "      - ./init-flink.sh:/exec/init-flink.sh\n")
-        .orElse(""
-            + "    volumes:\n"
-            + "      - ./init-flink.sh:/exec/init-flink.sh\n");
+    String volumneMnt = ""
+        + "    volumes:\n"
+        + mountDir
+        .map(dir -> dir.toAbsolutePath().normalize())
+        .map(dir -> "      - " + dir.toAbsolutePath() + ":/build\n")
+        .orElse("")
+        + "      - ./init-flink.sh:/exec/init-flink.sh\n";
 
     return "# This is a docker-compose template for starting a DataSQRL compiled data pipeline\n"
         + "# This template uses the Apache Flink as the stream engine, Postgres as the database engine, and Vertx as the server engine.\n"

--- a/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileNutshop.txt
+++ b/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileNutshop.txt
@@ -3,6 +3,7 @@ create-topics.sh
 database-schema.sql
 docker-compose.yml
 flink-plan.json
+init-flink.sh
 kafka-plan.json
 server-config.json
 server-model.json

--- a/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileNutshopWithSchema.txt
+++ b/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileNutshopWithSchema.txt
@@ -3,6 +3,7 @@ create-topics.sh
 database-schema.sql
 docker-compose.yml
 flink-plan.json
+init-flink.sh
 kafka-plan.json
 server-config.json
 server-model.json

--- a/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileRetail.txt
+++ b/sqrl-tools/sqrl-cli/src/test/resources/snapshots/com/datasqrl/cmd/TestCmd/compileRetail.txt
@@ -3,6 +3,7 @@ create-topics.sh
 database-schema.sql
 docker-compose.yml
 flink-plan.json
+init-flink.sh
 kafka-plan.json
 server-config.json
 server-model.json


### PR DESCRIPTION
Follows the recommended practice as outlined here:

https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/filesystems/plugins/

This copies the presto s3 connector. If using azure, other plugins will need to be copied in. To use, set the aws access key and secret key like the following:

```
  flink-jobmanager:
    image: flink:1.16.1-scala_2.12-java11
    ports:
      - "8081:8081"
    command: /bin/bash /exec/init-flink.sh jobmanager
    environment:
      - |
        FLINK_PROPERTIES=
        jobmanager.rpc.address: flink-jobmanager
      - AWS_ACCESS_KEY_ID=...
      - AWS_SECRET_KEY=...
    volumes:
      - ./init-flink.sh:/exec/init-flink.sh
```