### PR TITLE
Allow REST calls for the graphql server

### DIFF
--- a/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/plan/queries/APISource.java
+++ b/sqrl-engines/sqrl-engine-core/src/main/java/com/datasqrl/plan/queries/APISource.java
@@ -29,9 +29,9 @@ public class APISource {
   @Include
   Name name;
   String schemaDefinition;
-  List<PreparsedQuery> preparsedQueries;
+  List<String> preparsedQueries;
 
-  private APISource(Name name, String schemaDefinition, List<PreparsedQuery> preparsedQueries) {
+  private APISource(Name name, String schemaDefinition, List<String> preparsedQueries) {
     this.name = name;
     this.schemaDefinition = schemaDefinition;
     this.preparsedQueries = preparsedQueries;
@@ -45,7 +45,7 @@ public class APISource {
     return of(name, schemaDefinition, List.of());
   }
 
-  public static APISource of(Name name, String schemaDefinition, List<PreparsedQuery> queries) {
+  public static APISource of(Name name, String schemaDefinition, List<String> queries) {
     return new APISource(name,
         schemaDefinition.replaceAll("\t", "  "),
         queries);
@@ -57,7 +57,7 @@ public class APISource {
     String fileName = path.getFileName().toString().split("\\.")[0];
 
     Path queryFolderPath = path.getParent().resolve(fileName + "-queries");
-    List<PreparsedQuery> queries = new ArrayList<>();
+    List<String> queries = new ArrayList<>();
     if (Files.isDirectory(queryFolderPath)) {
       try (Stream<Path> paths = Files.walk(queryFolderPath)) {
         paths.filter(Files::isRegularFile)
@@ -65,7 +65,7 @@ public class APISource {
             .forEach(p -> {
               try {
                 String content = Files.readString(p);
-                queries.add(new PreparsedQuery(null, content));
+                queries.add(content);
               } catch (IOException e) {
                 log.error("Could not read from filesystem", e);
               }

--- a/sqrl-execute/sqrl-execute-http/sqrl-execute-http-core/src/main/java/com/datasqrl/graphql/server/Model.java
+++ b/sqrl-execute/sqrl-execute-http/sqrl-execute-http-core/src/main/java/com/datasqrl/graphql/server/Model.java
@@ -435,10 +435,19 @@ public class Model {
   public static class PreparsedQuery {
     String id;
     String query;
+    String operationName;
+    List<PreparsedQueryParameter> parameters;
 
     public <R, C> R accept(PreparsedQueryVisitor<R, C> visitor, C context) {
       return visitor.visitPreparsedQuery(this, context);
     }
+  }
+
+  @AllArgsConstructor
+  @Getter
+  @NoArgsConstructor
+  public static class PreparsedQueryParameter {
+    String name;
   }
 
   public interface PreparsedQueryVisitor<R, C> {

--- a/sqrl-execute/sqrl-execute-http/sqrl-execute-http-vertx/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
+++ b/sqrl-execute/sqrl-execute-http/sqrl-execute-http-vertx/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
@@ -29,6 +29,8 @@ public class ServletConfig {
   @Default
   public boolean useApolloWs = true;
   @Default
+  public boolean allowRest = false;
+  @Default
   public String graphQLWsEndpoint = "/graphql-ws";
 
   public JsonObject toJson() {

--- a/sqrl-execute/sqrl-execute-http/sqrl-execute-http-vertx/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
+++ b/sqrl-execute/sqrl-execute-http/sqrl-execute-http-vertx/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
@@ -29,7 +29,7 @@ public class ServletConfig {
   @Default
   public boolean useApolloWs = true;
   @Default
-  public boolean allowRest = false;
+  public boolean allowRest = true;
   @Default
   public String graphQLWsEndpoint = "/graphql-ws";
 


### PR DESCRIPTION
Uses the preparsed query mechanism to supply rest calls. The query name and parameters translate to rest calls with parameters.

For example:
The following query in schema-queries/GetOrderCount.graphql
```graphql
query GetOrderCount($limit: Int) {
   OrderCount(limit: $limit) {
     timeSec
     number
     volume
   }
 }
```

Produces a rest call that is queryable:
```shell
curl --get "http://localhost:8888/api/GetOrderCount?limit=3"
```