### PR TITLE
Remove volumes from docker compose

### DIFF
--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/DockerCompose.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/compile/DockerCompose.java
@@ -65,8 +65,6 @@ public class DockerCompose {
         + "    ports:\n"
         + "      - \"9092:9092\"\n"
         + "      - \"9094:9094\"\n"
-        + "    volumes:\n"
-        + "      - \"kafka_data:/bitnami\"\n"
         + "    environment:\n"
         + "      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true\n"
         + "      - ALLOW_PLAINTEXT_LISTENER=yes\n"
@@ -104,12 +102,7 @@ public class DockerCompose {
         + "      - ./flink-job.jar:/flink-job.jar\n"
         + "      - ./submit-flink-job.sh:/submit-flink-job.sh\n"
         + "    entrypoint: /submit-flink-job.sh\n"
-        + "\n"
-        + "volumes:\n"
-        + "  database:\n"
-        + "    driver: local\n"
-        + "  kafka_data:\n"
-        + "    driver: local";
+        + "\n";
   }
 
   public static String getInitFlink() {


### PR DESCRIPTION
This removes persistence between docker-compose runes. The volume mapping seems to cause more confusion than help, and it may not be necessary since we don't persist flink state.

Fixes #348