### PR TITLE
Add support for graphql-ws websockets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <mockito.version>4.8.0</mockito.version>
     <jackson.version>2.14.0</jackson.version>
-    <vertx.version>4.3.5</vertx.version>
+    <vertx.version>4.5.7</vertx.version>
     <agroal.version>1.11</agroal.version>
     <kafka.version>3.4.0</kafka.version>
     <flink.version>1.16.1</flink.version>

--- a/profiles/flink-1.16/flink/Dockerfile
+++ b/profiles/flink-1.16/flink/Dockerfile
@@ -1,4 +1,4 @@
-FROM datasqrl/sqrl-dependencies:0.5-RC2 as m2-dependencies
+FROM datasqrl/sqrl-dependencies:v0.5.0-RC3 as m2-dependencies
 
 # Stage 1: Building the dependencies or the fat JAR
 FROM gradle:8.6-jdk11 AS build

--- a/profiles/flink-1.16/flink/build.gradle
+++ b/profiles/flink-1.16/flink/build.gradle
@@ -12,7 +12,7 @@ ext {
     flinkVersion = "1.16.1"
     jdbcVersion = "1.16.1"
     kafkaVersion = "1.16.1"
-    sqrlVersion = "0.5.0-RC2"
+    sqrlVersion = "0.5.0-RC3-SNAPSHOT"
 }
 
 repositories {

--- a/profiles/flink-1.16/vertx/Dockerfile
+++ b/profiles/flink-1.16/vertx/Dockerfile
@@ -1,4 +1,4 @@
-FROM datasqrl/sqrl-server:v0.5.0-RC2
+FROM datasqrl/sqrl-server:v0.5.0-RC3
 
 COPY server-model.json /opt/sqrl/server-model.json
 COPY server-config.json /opt/sqrl/server-config.json

--- a/profiles/flink-1.16/vertx/server-config.json
+++ b/profiles/flink-1.16/vertx/server-config.json
@@ -1,9 +1,9 @@
 {
   "servletConfig": {
-    "graphiQLEndpoint": "/graphiql/*",
+    "graphiQLEndpoint": "/graphiql*",
     "graphQLEndpoint": "/graphql",
     "usePgPool": true,
-    "useApolloWs": true,
+    "useApolloWs": false,
     "graphQLWsEndpoint": "/graphql-ws"
   },
   "graphQLHandlerOptions": {

--- a/profiles/flink-1.17/flink/Dockerfile
+++ b/profiles/flink-1.17/flink/Dockerfile
@@ -1,4 +1,4 @@
-FROM datasqrl/sqrl-dependencies:0.5-RC2 as m2-dependencies
+FROM datasqrl/sqrl-dependencies:v0.5.0-RC3 as m2-dependencies
 
 # Stage 1: Building the dependencies or the fat JAR
 FROM gradle:8.6-jdk11 AS build

--- a/profiles/flink-1.18/flink/Dockerfile
+++ b/profiles/flink-1.18/flink/Dockerfile
@@ -1,4 +1,4 @@
-FROM datasqrl/sqrl-dependencies:0.5-RC2 as m2-dependencies
+FROM datasqrl/sqrl-dependencies:v0.5.0-RC3 as m2-dependencies
 
 # Stage 1: Building the dependencies or the fat JAR
 FROM gradle:8.6-jdk11 AS build


### PR DESCRIPTION
Closes #507

By convention, graphql-ws uses the same route as the graphql endpoint, so it is no longer configurable. 