### PR TITLE
Validate package subsection in package.json

### DIFF
--- a/.github/workflows/build-config.yml
+++ b/.github/workflows/build-config.yml
@@ -1,7 +1,7 @@
 name: Build and test SQRL with Maven
 on:
   pull_request:
-    branches: [ "main", "v0.5-RC", "v0.5", "v0.5-RC2" ]
+    branches: [ "main", "v0.5", "v0.5-RC3" ]
 
 jobs:
   build:
@@ -23,4 +23,6 @@ jobs:
     - name: Build Docker image
       run: docker build -t datasqrl/sqrl-dependencies:0.5-RC2 .
     - name: Build SQRL
+      env:
+        DATASQRL_TOKEN: ${{ secrets.DATASQRL_TOKEN }}
       run: mvn -T 1 -B -U -e clean package

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-json-schema</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5</artifactId>
         <version>${vertx.version}</version>
         <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <commonsio.version>2.11.0</commonsio.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-config.version>2.9.0</commons-config.version>
+    <commons-collections.version>4.4</commons-collections.version>
+    <httpcomponents.version>4.5.14</httpcomponents.version>
     <commons-bean.version>1.9.4</commons-bean.version>
     <h2.version>2.1.214</h2.version>
     <opencsv.version>5.7.1</opencsv.version>
@@ -285,6 +287,16 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
         <version>${commons-config.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${commons-collections.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpmime</artifactId>
+        <version>${httpcomponents.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>

--- a/profiles/flink-1.16/package.json
+++ b/profiles/flink-1.16/package.json
@@ -32,5 +32,14 @@
   },
   "test-runner": {
     "delay-sec": 30
+  },
+  "package": {
+    "name": "datasqrl.profiles.flink-1-16",
+    "version": "0.0.1",
+    "variant": "dev",
+    "description": "Flink 1.16 profile",
+    "homepage": "",
+    "documentation": "",
+    "keywords": "profile"
   }
 }

--- a/sqrl-base/src/main/java/com/datasqrl/config/PackageConfiguration.java
+++ b/sqrl-base/src/main/java/com/datasqrl/config/PackageConfiguration.java
@@ -1,6 +1,7 @@
 package com.datasqrl.config;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PackageConfiguration {
 
@@ -31,4 +32,6 @@ public interface PackageConfiguration {
   void checkInitialized();
 
   Dependency asDependency();
+
+  Map<String, Object> toMap();
 }

--- a/sqrl-planner/pom.xml
+++ b/sqrl-planner/pom.xml
@@ -157,7 +157,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/LoginCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/LoginCommand.java
@@ -1,0 +1,20 @@
+package com.datasqrl.cmd;
+
+import com.datasqrl.auth.AuthProvider;
+import com.datasqrl.error.ErrorCollector;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "login", description = "Logs into the repository")
+@Slf4j
+public class LoginCommand extends AbstractCommand {
+
+  @Override
+  protected void execute(ErrorCollector errors) throws IOException {
+    AuthProvider authProvider = new AuthProvider();
+    authProvider.loginToRepository();
+    log.info("Login successful.");
+  }
+
+}

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/PackageBootstrap.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/PackageBootstrap.java
@@ -19,6 +19,7 @@ import com.datasqrl.packager.ImportExportAnalyzer;
 import com.datasqrl.packager.ImportExportAnalyzer.Result;
 import com.datasqrl.packager.Packager;
 import com.datasqrl.packager.repository.Repository;
+import com.datasqrl.util.NameUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,8 +39,10 @@ import java.util.function.Function;
 
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class PackageBootstrap {
   Path rootDir;
   List<Path> packageFiles;
@@ -98,9 +101,10 @@ public class PackageBootstrap {
         } else {
           dependency = repository.resolveDependency(profile);
         }
+        Path profilePath = namepath2Path(rootDir.resolve(BUILD_DIR_NAME), NamePath.parse(profile));
 
         if (dependency.isPresent()) {
-          boolean success = repository.retrieveDependency(rootDir.resolve("build"),
+          boolean success = repository.retrieveDependency(profilePath,
               dependency.get());
           if (success) {
             dependencies.put(profile, dependency.get());
@@ -109,9 +113,12 @@ public class PackageBootstrap {
           }
         }
 
-        Path remoteProfile = rootDir.resolve(Packager.BUILD_DIR_NAME).resolve(profile).resolve(PACKAGE_JSON);
+
+        Path remoteProfile = profilePath.resolve(PACKAGE_JSON);
         if (Files.isRegularFile(remoteProfile)) {
           configFiles.add(remoteProfile);
+        } else {
+          log.warn("Could not find package.json in profile: " + profile);
         }
       }
     }

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/PublishCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/PublishCommand.java
@@ -2,7 +2,7 @@ package com.datasqrl.cmd;
 
 import static com.datasqrl.packager.Packager.DEFAULT_PACKAGE;
 
-import com.datasqrl.config.Dependency;
+import com.datasqrl.config.PackageConfiguration;
 import com.datasqrl.config.PackageJsonImpl;
 import com.datasqrl.config.SqrlConfigCommons;
 import com.datasqrl.error.ErrorCollector;
@@ -10,47 +10,62 @@ import com.datasqrl.error.NotYetImplementedException;
 import com.datasqrl.packager.Packager;
 import com.datasqrl.packager.Publisher;
 import com.datasqrl.packager.repository.LocalRepositoryImplementation;
+import com.datasqrl.packager.repository.RemoteRepositoryImplementation;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "publish", description = "Publishes a package to local and remote repository")
+@Slf4j
 public class PublishCommand extends AbstractCommand {
 
-    @CommandLine.Parameters(index = "0", description = "Main script (optional)")
-    private Path mainScript;
+  @CommandLine.Option(names = {"--main"}, description = "Main script (optional)")
+  private Path mainScript;
 
-    @CommandLine.Option(names = {"--remote"}, description = "Publish to remote repository (local only by default)")
-    private boolean toRemote = false;
+  @CommandLine.Option(names = {"--remote"}, description = "Publish to remote repository (local only by default)")
+  private boolean toRemote = false;
 
-    @Override
-    protected void execute(ErrorCollector errors) throws IOException {
-        if (toRemote) NotYetImplementedException.trigger("Publishing to remote repository is not yet supported");
-        Path packageRoot = root.rootDir;
-        Optional<List<Path>> packageConfigsOpt = Packager.findPackageFile(root.rootDir, root.packageFiles);
-        errors.checkFatal(packageConfigsOpt.isPresent(),"Directory does not contain [%s] package configuration file",
-            Packager.PACKAGE_JSON);
-        List<Path> packageconfigs = packageConfigsOpt.get();
-        Path defaultPkgConfig = packageRoot.resolve(DEFAULT_PACKAGE);
+  @Override
+  protected void execute(ErrorCollector errors) throws IOException {
+    Path packageRoot = root.rootDir;
+    Optional<List<Path>> packageConfigsOpt = Packager.findPackageFile(root.rootDir,
+        root.packageFiles);
+    errors.checkFatal(packageConfigsOpt.isPresent(),
+        "Directory does not contain [%s] package configuration file", Packager.PACKAGE_JSON);
+    List<Path> packageconfigs = packageConfigsOpt.get();
+    Path defaultPkgConfig = packageRoot.resolve(DEFAULT_PACKAGE);
 
-        LocalRepositoryImplementation localRepo = LocalRepositoryImplementation.of(errors,
-            root.rootDir);
-        Publisher publisher = new Publisher(errors);
+    LocalRepositoryImplementation localRepo = LocalRepositoryImplementation.of(errors,
+        root.rootDir);
+    Publisher publisher = new Publisher(errors);
 
-        if (mainScript==null && packageconfigs.size()==1 && Files.isSameFile(defaultPkgConfig,packageconfigs.get(0))
-                && !new PackageJsonImpl(SqrlConfigCommons.fromFiles(errors,defaultPkgConfig)).hasScriptKey()) {
-            //If no main script is specified and only a single default package config and that config does not contain a script config
-            //then we are publishing a data source/sink or function package (i.e. we don't need to build)
-            Dependency dep = publisher.publish(packageRoot, localRepo).asDependency();
-            System.out.println(String.format("Successfully published package [%s] to local repository", dep));
-        } else {
-            //We are publishing a script bundle and need to build before invoking the publisher on the build directory
-            NotYetImplementedException.trigger("Publishing SQRL scripts is not yet supported");
+    if (mainScript == null && packageconfigs.size() == 1 && Files.isSameFile(defaultPkgConfig,
+        packageconfigs.get(0)) && !new PackageJsonImpl(
+        SqrlConfigCommons.fromFiles(errors, defaultPkgConfig)).hasScriptKey()) {
+      //If no main script is specified and only a single default package config and that config does not contain a script config
+      //then we are publishing a data source/sink or function package (i.e. we don't need to build)
+        PackageConfiguration pkgConfig = publisher.publish(packageRoot, localRepo);
+
+      if (toRemote) {
+        Path cachedPath = localRepo.getZipFilePath(pkgConfig.asDependency());
+        RemoteRepositoryImplementation remoteRepo = new RemoteRepositoryImplementation();
+        if (remoteRepo.publish(cachedPath, pkgConfig)) {
+          log.info("Successfully published package [{}] to remote repository",
+              pkgConfig.asDependency());
         }
-
+      } else {
+          log.info("Successfully published package [{}] to local repository",
+              pkgConfig.asDependency());
+      }
+    } else {
+      //We are publishing a script bundle and need to build before invoking the publisher on the build directory
+      NotYetImplementedException.trigger("Publishing SQRL scripts is not yet supported");
     }
+
+  }
 
 }

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/RootCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/RootCommand.java
@@ -11,8 +11,9 @@ import lombok.NonNull;
 import picocli.CommandLine;
 import picocli.CommandLine.ScopeType;
 
-@CommandLine.Command(name = "datasqrl", mixinStandardHelpOptions = true, version = "0.1",
-    subcommands = {CompilerCommand.class,  PublishCommand.class, TestCommand.class})
+@CommandLine.Command(name = "datasqrl", mixinStandardHelpOptions = true, version = "0.5",
+    subcommands = {CompilerCommand.class,
+         PublishCommand.class, TestCommand.class, LoginCommand.class})
 @Getter
 public class RootCommand implements Runnable {
 

--- a/sqrl-tools/sqrl-config/pom.xml
+++ b/sqrl-tools/sqrl-config/pom.xml
@@ -38,5 +38,9 @@
       <groupId>run.sqrl</groupId>
       <artifactId>sqrl-base</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-json-schema</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/PackageConfigurationImpl.java
+++ b/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/PackageConfigurationImpl.java
@@ -7,7 +7,10 @@ import com.datasqrl.config.Constraints.Default;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -56,5 +59,21 @@ public class PackageConfigurationImpl implements PackageConfiguration {
     return new DependencyImpl(getName(), getVersion(), getVariant());
   }
 
-
+  @Override
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("name", getName());
+    map.put("version", getVersion());
+    map.put("variant", getVariant());
+    map.put("latest", getLatest());
+    map.put("type", getType());
+    map.put("license", getLicense());
+    map.put("repository", getRepository());
+    map.put("homepage", getHomepage());
+    map.put("documentation", getDocumentation());
+    map.put("readme", getReadme());
+    map.put("description", getDescription());
+    map.put("keywords", getKeywords());
+    return map;
+  }
 }

--- a/sqrl-tools/sqrl-config/src/main/resources/schema/package-schema.json
+++ b/sqrl-tools/sqrl-config/src/main/resources/schema/package-schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "package": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+)$"
+        },
+        "variant": {
+          "type": "string"
+        },
+        "latest": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri"
+        },
+        "homepage": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        },
+        "readme": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string",
+          "format": "uri"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [ "name", "version", "latest", "keywords" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "package" ],
+  "additionalProperties": false
+}

--- a/sqrl-tools/sqrl-config/src/main/resources/schema/package-schema.json
+++ b/sqrl-tools/sqrl-config/src/main/resources/schema/package-schema.json
@@ -52,7 +52,5 @@
       "required": [ "name", "version", "latest", "keywords" ],
       "additionalProperties": false
     }
-  },
-  "required": [ "package" ],
-  "additionalProperties": false
+  }
 }

--- a/sqrl-tools/sqrl-packager/pom.xml
+++ b/sqrl-tools/sqrl-packager/pom.xml
@@ -82,7 +82,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
     </dependency>
     <dependency>
       <groupId>net.lingala.zip4j</groupId>

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/AuthProvider.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/AuthProvider.java
@@ -1,0 +1,177 @@
+package com.datasqrl.auth;
+
+import static com.datasqrl.auth.AuthUtils.AUTHORIZE_ENDPOINT;
+import static com.datasqrl.auth.AuthUtils.CLIENT_ID;
+import static com.datasqrl.auth.AuthUtils.REDIRECT_URI;
+import static com.datasqrl.auth.AuthUtils.TOKEN_ENDPOINT;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AuthProvider {
+  private static final long TIMEOUT_IN_SECONDS = 120;
+  private final String state = getRandomString(16);
+  private final String codeVerifier = getRandomString(43);
+  private final String codeChallenge = generateCodeChallenge(codeVerifier);
+
+  private final HttpClient client;
+  private final TokenManager tokenManager;
+
+  public AuthProvider() {
+    this.client = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.ALWAYS)
+        .build();
+    this.tokenManager = new TokenManager();
+  }
+
+  public Optional<String> getAccessToken() {
+    return tokenManager.getAccessToken()
+        .or(()->tokenManager.getRefreshToken()
+            .flatMap(this::refreshAccessToken));
+  }
+
+  public String loginToRepository() {
+    return this.browserFlow();
+  }
+
+  private Optional<String> refreshAccessToken(String refreshToken) {
+    JsonObject payload = new JsonObject();
+    payload.put("grant_type", "refresh_token");
+    payload.put("refresh_token", refreshToken);
+    payload.put("client_id", CLIENT_ID);
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(TOKEN_ENDPOINT))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+
+    try {
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      int statusCode = response.statusCode();
+      if (statusCode == 200) {
+        JsonObject jsonResponse = new JsonObject(response.body());
+
+        String newAccessToken = jsonResponse.getString("access_token");
+        tokenManager.setAccessToken(newAccessToken);
+
+        //Support rotating refresh tokens if enabled
+        String newRefreshToken = jsonResponse.containsKey("refresh_token") ?
+            jsonResponse.getString("refresh_token") : refreshToken;
+        tokenManager.setRefreshToken(newRefreshToken);
+
+        return Optional.of(newAccessToken);
+      } else if (statusCode == 403 ) {
+        log.warn(new JsonObject(response.body()).getString("error_description"));
+      } else {
+        log.error("Error during token refresh: {}", response.body());
+      }
+    } catch (IOException | InterruptedException e) {
+      log.error("Error during token refresh", e);
+    }
+    return Optional.empty();
+  }
+
+  @SneakyThrows
+  private String browserFlow() {
+    Vertx vertx = Vertx.vertx();
+
+    try {
+      CompletableFuture<JsonObject> tokenFuture = new CompletableFuture<>();
+
+      vertx.deployVerticle(
+          new OAuthCallbackVerticle(
+              code -> exchangeCodeForToken(code, tokenFuture)));
+
+      openAuthWindow();
+
+      JsonObject authToken = tokenFuture.get(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+      String accessToken = authToken.getString("access_token");
+      tokenManager.setAccessToken(accessToken);
+      String refreshToken = authToken.getString("refresh_token");
+      tokenManager.setRefreshToken(refreshToken);
+      return accessToken;
+    } catch (TimeoutException | ExecutionException | InterruptedException e) {
+      throw new RuntimeException("Exception while getting access token.", e);
+    } finally {
+      vertx.close();
+    }
+  }
+
+  private void exchangeCodeForToken(String code, CompletableFuture<JsonObject> tokenFuture) {
+    JsonObject payload = new JsonObject()
+        .put("grant_type", "authorization_code")
+        .put("client_id", CLIENT_ID)
+        .put("code_verifier", codeVerifier)
+        .put("code", code)
+        .put("redirect_uri", REDIRECT_URI);
+
+    HttpRequest request = HttpRequest.newBuilder().uri(URI.create(TOKEN_ENDPOINT))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString())).build();
+
+    client.sendAsync(request, BodyHandlers.ofString())
+        .thenAccept(response -> tokenFuture.complete(new JsonObject(response.body())))
+        .exceptionally(throwable -> {
+          tokenFuture.completeExceptionally(throwable);
+          return null;
+        });
+  }
+
+  private void openAuthWindow() throws IOException {
+    Map<String, String> parameters = Map.of(
+      "response_type", "code",
+      "client_id", CLIENT_ID,
+      "redirect_uri", REDIRECT_URI,
+      "scope", "offline_access",
+      "state", state,
+      "audience", "https://sqrl-repository-frontend-git-staging-datasqrl.vercel.app/api/client", //TODO we need to create a new audience
+      "code_challenge", codeChallenge,
+      "code_challenge_method", "S256");
+
+    String paramString = parameters.entrySet().stream()
+        .map(entry -> entry.getKey() + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+        .collect(Collectors.joining("&"));
+
+    String authUrl = AUTHORIZE_ENDPOINT + "?" + paramString;
+
+    Runtime.getRuntime().exec("open " + authUrl);
+  }
+
+  private String getRandomString(int numBytes) {
+    SecureRandom random = new SecureRandom();
+    byte[] values = new byte[numBytes];
+    random.nextBytes(values);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(values);
+  }
+
+  @SneakyThrows
+  private String generateCodeChallenge(String codeVerifier) {
+    MessageDigest md = MessageDigest.getInstance("SHA-256");
+    byte[] digest = md.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+  }
+}

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/AuthUtils.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/AuthUtils.java
@@ -1,0 +1,13 @@
+package com.datasqrl.auth;
+
+public class AuthUtils {
+
+  public static final int CALLBACK_SERVER_PORT = 18980;
+  public static final String CALLBACK_ENDPOINT = "/api/auth/callback";
+  public static final String REDIRECT_URI = String.format("http://localhost:%d%s", CALLBACK_SERVER_PORT, CALLBACK_ENDPOINT);
+
+  public static final String CLIENT_ID = "KC2EoCphVVe5wzZj3GyFiTZboulfYJNH";
+  public static final String AUTH0_BASE_URL = "https://sqrl-repository-frontend-git-staging-datasqrl.vercel.app/auth0";
+  public static final String TOKEN_ENDPOINT = AUTH0_BASE_URL + "/oauth/token";
+  public static final String AUTHORIZE_ENDPOINT = AUTH0_BASE_URL + "/authorize";
+}

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/OAuthCallbackVerticle.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/OAuthCallbackVerticle.java
@@ -1,0 +1,44 @@
+package com.datasqrl.auth;
+
+import static com.datasqrl.auth.AuthUtils.CALLBACK_ENDPOINT;
+import static com.datasqrl.auth.AuthUtils.CALLBACK_SERVER_PORT;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import java.util.function.Consumer;
+
+public class OAuthCallbackVerticle extends AbstractVerticle {
+
+  private final Consumer<String> onOAuthCallback;
+
+  public OAuthCallbackVerticle(Consumer<String> onOAuthCallback) {
+    this.onOAuthCallback = onOAuthCallback;
+  }
+
+  @Override
+  public void start(Promise<Void> startPromise) throws Exception {
+    Router router = Router.router(vertx);
+
+    router.route(CALLBACK_ENDPOINT).handler(this::handleAuthCallback);
+
+    vertx.createHttpServer().requestHandler(router).listen(CALLBACK_SERVER_PORT, http -> {
+      if (http.succeeded()) {
+        startPromise.complete();
+      } else {
+        startPromise.fail(http.cause());
+      }
+    });
+  }
+
+  private void handleAuthCallback(RoutingContext routingContext) {
+    String code = routingContext.request().getParam("code");
+
+    routingContext.response().putHeader("content-type", "text/html")
+        .end("Authentication successful. You can close this window.");
+
+    onOAuthCallback.accept(code);
+  }
+
+}

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/TokenManager.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/auth/TokenManager.java
@@ -1,0 +1,42 @@
+package com.datasqrl.auth;
+
+import com.datasqrl.util.FileUtil;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import lombok.SneakyThrows;
+
+public class TokenManager {
+
+  private static final Path DATASQRL_CONFIG_DIRECTORY = FileUtil.getUserRoot().resolve(".datasqrl");
+  private static final Path REFRESH_TOKEN_PATH = DATASQRL_CONFIG_DIRECTORY.resolve("auth");
+  private static final String ENV_DATASQRL_TOKEN = "DATASQRL_TOKEN";
+  private String accessToken;
+
+  @SneakyThrows
+  public Optional<String> getRefreshToken() {
+    String refreshTokenFromEnv = System.getenv(ENV_DATASQRL_TOKEN);
+    if (refreshTokenFromEnv != null && !refreshTokenFromEnv.isEmpty()) {
+      return Optional.of(refreshTokenFromEnv);
+    }
+
+    return Files.isRegularFile(REFRESH_TOKEN_PATH) ?
+        Optional.of(Files.readString(REFRESH_TOKEN_PATH)) :
+        Optional.empty();
+  }
+
+  @SneakyThrows
+  public void setRefreshToken(String refreshToken) {
+    Files.createDirectories(DATASQRL_CONFIG_DIRECTORY);
+    Files.write(REFRESH_TOKEN_PATH, refreshToken.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public Optional<String> getAccessToken() {
+    return accessToken == null ? Optional.empty() : Optional.of(accessToken);
+  }
+}

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Packager.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Packager.java
@@ -268,10 +268,12 @@ public class Packager {
       plans.put("test", map);
     }
 
+
     // Copy profiles
     for (String profile : profiles) {
+      Path profilePath = namepath2Path(rootDir.resolve(BUILD_DIR_NAME), NamePath.parse(profile));
       copyToDeploy(targetDir,
-          rootDir.resolve(profile), plan, testPlan, sqrlConfig, mountDirectory, plans);
+          profilePath, plan, testPlan, sqrlConfig, mountDirectory, plans);
     }
 
     copyFolder(targetDir, DATA_DIR);

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 @Slf4j
 public class LocalRepositoryImplementation implements Repository, CacheRepository, PublishRepository {
 
-    public static final String LOCAL_REPO_NAME = "datasqrl";
+    public static final String LOCAL_REPO_NAME = "datasqrl/repository";
 
     @Getter
     private final Path repositoryPath;
@@ -41,9 +41,7 @@ public class LocalRepositoryImplementation implements Repository, CacheRepositor
 
     @Override
     public boolean retrieveDependency(Path targetPath, Dependency dependency) throws IOException {
-        Path path = dependency2Path(dependency);
-        Path zipFile = path
-            .resolve(FileUtil.addExtension(dependency.getVariant(), Zipper.ZIP_EXTENSION));
+        Path zipFile = getZipFilePath(dependency);
         if (Files.isRegularFile(zipFile)) {
             new ZipFile(zipFile.toFile()).extractAll(targetPath.toString());
             return true;
@@ -57,6 +55,7 @@ public class LocalRepositoryImplementation implements Repository, CacheRepositor
             .resolve(FileUtil.addExtension(dependency.getVariant(), Zipper.ZIP_EXTENSION));
         Path parentDir = destFile.getParent();
         if (!Files.isDirectory(parentDir)) Files.createDirectories(parentDir);
+        Files.deleteIfExists(destFile);
         Files.copy(zipFile, destFile);
     }
 
@@ -70,6 +69,12 @@ public class LocalRepositoryImplementation implements Repository, CacheRepositor
     @Override
     public Optional<Dependency> resolveDependency(String packageName) {
         return Optional.empty();
+    }
+
+    public Path getZipFilePath(Dependency dependency) {
+        Path path = dependency2Path(dependency);
+        Path zipFile = path.resolve(FileUtil.addExtension(dependency.getVariant(), Zipper.ZIP_EXTENSION));
+        return zipFile;
     }
 
     private Path dependency2Path(Dependency dependency) {

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/RemoteRepositoryImplementation.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/RemoteRepositoryImplementation.java
@@ -3,25 +3,21 @@
  */
 package com.datasqrl.packager.repository;
 
-
-import com.datasqrl.config.DependencyImpl;
+import com.datasqrl.auth.AuthProvider;
 import com.datasqrl.config.Dependency;
+import com.datasqrl.config.DependencyImpl;
+import com.datasqrl.config.PackageConfiguration;
 import com.datasqrl.packager.util.FileHash;
 import com.datasqrl.packager.util.Zipper;
-import com.datasqrl.util.FileUtil;
 import com.datasqrl.util.SqrlObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import lombok.Setter;
-import lombok.SneakyThrows;
-import net.lingala.zip4j.ZipFile;
-import org.apache.commons.io.FileUtils;
-
+import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
@@ -30,17 +26,28 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import net.lingala.zip4j.ZipFile;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 
-public class RemoteRepositoryImplementation implements Repository {
-  public static final String PKG_NAME_KEY = "pkgName";
-  public static final String VERSION_KEY = "version";
-  public static final String VARIANT_KEY = "variant";
-
-  public static final URI DEFAULT_URI = URI.create("https://repo.sqrl.run");
+@Slf4j
+public class RemoteRepositoryImplementation implements Repository, PublishRepository {
+  public static final URI DEFAULT_URI = URI.create("https://sqrl-repository-frontend-git-staging-datasqrl.vercel.app");
 
   private final ObjectMapper mapper = SqrlObjectMapper.INSTANCE;
+
+  private final AuthProvider authProvider = new AuthProvider();
+
   private final URI repositoryServerURI;
   @Setter
   private CacheRepository cacheRepository = null;
@@ -54,28 +61,15 @@ public class RemoteRepositoryImplementation implements Repository {
   }
 
   @Override
-  public boolean retrieveDependency(Path targetPath, Dependency dependency) throws IOException {
-    JsonNode result = executeQuery(Query.getDependency, Map.of(
-        PKG_NAME_KEY, dependency.getName(),
-        VERSION_KEY, dependency.getVersion(),
-        VARIANT_KEY, dependency.getVariant()));
-    return getDependencyVersion(result)
-        .map(dep -> downloadDependency(targetPath, dep, dependency))
-        .orElse(false);
-  }
-
-  // Gets the first dependency version from a retrieved package
-  private Optional<JsonNode> getDependencyVersion(JsonNode result) {
-    return getPackageField(result, "versions")
-        .filter(n -> n.isArray() && !n.isEmpty())
-        .map(n -> n.get(0));
+  public boolean retrieveDependency(Path targetPath, Dependency dependency) {
+    JsonNode dependencyInfo = getDependencyInfo(dependency.getName(), dependency.getVersion().get(), dependency.getVariant());
+    return downloadDependency(targetPath, dependencyInfo, dependency);
   }
 
   // Downloads the given Dependency to the specified Path
-  private boolean downloadDependency(Path targetPath, JsonNode dep, Dependency dependency) {
-    String file = dep.get("file").asText();
-    String hash = dep.get("hash").asText();
-    String repoURL = dep.get("repoURL").asText();
+  private boolean downloadDependency(Path targetPath, JsonNode dependencyInfo, Dependency dependency) {
+    String hash = dependencyInfo.get("hash").asText();
+    String repoURL = dependencyInfo.get("repoURL").asText();
 
     try {
       // Create target directory
@@ -85,22 +79,23 @@ public class RemoteRepositoryImplementation implements Repository {
       Path zipFile = Files.createTempFile(targetPath, "package", Zipper.ZIP_EXTENSION);
 
       // Copy the zip file from the repoURL to the temporary file
-      FileUtils.copyURLToFile(
-          new URL(repoURL),
-          zipFile.toFile());
+      FileUtils.copyURLToFile(new URL(repoURL), zipFile.toFile());
 
       // Get the hash for the downloaded file
       String downloadHash = FileHash.getFor(zipFile);
 
       // Ensure the hashes match
-      Preconditions.checkArgument(downloadHash.equals(hash),"File hash [%s] does not match hash"
-          + "of dowloaded file [%s]", hash, downloadHash);
+      Preconditions.checkArgument(
+          downloadHash.equals(hash),
+          "File hash [%s] does not match hash" + "of dowloaded file [%s]",
+          hash,
+          downloadHash);
 
       // Extract the zip file
       new ZipFile(zipFile.toFile()).extractAll(targetPath.toString());
 
       // Cache downloaded package
-      if (cacheRepository!=null) cacheRepository.cacheDependency(zipFile, dependency);
+      if (cacheRepository != null) cacheRepository.cacheDependency(zipFile, dependency);
 
       // Delete the temporary file
       Files.deleteIfExists(zipFile);
@@ -115,68 +110,122 @@ public class RemoteRepositoryImplementation implements Repository {
 
   @Override
   public Optional<Dependency> resolveDependency(String packageName) {
-    JsonNode result = executeQuery(Query.getLatest, Map.of("pkgName", packageName));
-    Optional<JsonNode> latest = getPackageField(result, "latest").filter(n -> !n.isNull() && !n.isEmpty());
-    if (latest.isEmpty()) return Optional.empty();
-    return Optional.of(map(latest.get(), DependencyImpl.class));
+    JsonNode result = getLatestDependencyInfo(packageName);
+    return Optional.of(map(result, DependencyImpl.class));
   }
 
-  private Optional<JsonNode> getPackageField(JsonNode result, String field) {
-    JsonNode packages = result.get("Package");
-    if (!packages.isArray() || packages.isEmpty()) return Optional.empty();
-    return Optional.of(packages.get(0).get(field));
-  }
-
-  public JsonNode executeQuery(Query query, Map<String,Object> payload) {
+  public JsonNode getDependencyInfo(String name, String version, String variant) {
     try {
       HttpClient client = HttpClient.newHttpClient();
-      HttpRequest request = HttpRequest.newBuilder()
-          .header("Content-Type", "application/json")
-          .header("Accept", "application/json")
-          .POST(HttpRequest.BodyPublishers.ofString(mapper
-              .writeValueAsString(
-                  Map.of("query", query.getQueryString(), "variables", payload))))
-          .uri(repositoryServerURI)
-          .timeout(Duration.of(10, ChronoUnit.SECONDS))
-          .build();
-      HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-      return mapper.readValue(response.body(), JsonNode.class).get("data");
+
+      Optional<String> authToken = authProvider.getAccessToken();
+
+      HttpRequest.Builder requestBuilder =
+          HttpRequest.newBuilder()
+              .uri(buildPackageInfoUri(name, version, variant));
+      authToken.ifPresent((t)->requestBuilder.header("Authorization", "Bearer " + authToken));
+      requestBuilder.GET()
+              .timeout(Duration.of(10, ChronoUnit.SECONDS))
+              .build();
+
+      HttpResponse<String> response = client.send(requestBuilder.build(), BodyHandlers.ofString());
+      int statusCode = response.statusCode();
+      if (statusCode != 200) {
+        String message =
+            String.format(
+                "Package [%s] is not available. Check if it exists and you have permission to access it.",
+                name);
+        throw new RuntimeException(message);
+      }
+      return mapper.readValue(response.body(), JsonNode.class);
     } catch (Exception e) {
-      throw new RuntimeException("Could not call remote repository",e);
+      throw new RuntimeException("Could not call remote repository", e);
     }
   }
 
-  private<O> O map(JsonNode node, Class<O> clazz) {
+  public JsonNode getLatestDependencyInfo(String name) {
+    return getDependencyInfo(name, null, null);
+  }
+
+  private URI buildPackageInfoUri(String name, String version, String variant) {
+    if (name == null) {
+      throw new IllegalArgumentException("name cannot be null");
+    }
+
+    StringBuilder uriBuilder = new StringBuilder(repositoryServerURI.toString()).append("/api/packages/").append(name);
+
+    // Append version and variant if provided
+    if (version != null && variant != null) {
+      uriBuilder.append("/").append(version).append("/").append(variant);
+    }
+
+    return URI.create(uriBuilder.toString());
+  }
+
+  private <O> O map(JsonNode node, Class<O> clazz) {
     try {
-      return mapper.treeToValue(node,clazz);
+      mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      return mapper.treeToValue(node, clazz);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Unexpected response from repository server: " + node.toString(), e);
     }
   }
 
+  @Override
   @SneakyThrows
-  private static String loadQuery(String queryFile) {
-    return FileUtil.readResource(queryFile);
+  public boolean publish(Path zipFile, PackageConfiguration pkgConfig) {
+    HttpClient client = HttpClient.newHttpClient();
+
+    String authToken = authProvider.getAccessToken()
+        .orElseThrow(() -> new RuntimeException("Must be logged in to publish. Run `sqrl login`"));
+
+    HttpEntity httpEntity = createHttpEntity(zipFile, pkgConfig);
+
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(repositoryServerURI.resolve("/api/packages"))
+            .header("Content-Type", httpEntity.getContentType().getValue())
+            .header("Authorization", "Bearer " + authToken)
+                .POST(HttpRequest.BodyPublishers.ofInputStream(() -> {
+                    try {
+                        return httpEntity.getContent();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }))
+            .timeout(Duration.of(30, ChronoUnit.SECONDS))
+            .build();
+
+    HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+    if (response.statusCode() == 200) {
+      return true;
+    } else {
+      log.error("An error happened while uploading dependency: status code: {} response: {}", response.statusCode(), response.body());
+      return false;
+    }
   }
 
-  private enum Query {
+  private static HttpEntity createHttpEntity(Path zipFilePath, PackageConfiguration pkgConfig) {
+    Map<String, Object> map = pkgConfig.toMap();
 
-    getDependency("getDependency.graphql"), getLatest("latestPackageByName.graphql");
+    MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      if (entry.getValue() instanceof List) continue;
+      if (entry.getValue() == null) continue;
+      entityBuilder.addTextBody(entry.getKey(), entry.getValue().toString());
+    }
+    
+    File zipFile = zipFilePath.toFile();
+    entityBuilder.addBinaryBody("file", zipFile, ContentType.create("application/zip"), zipFile.getName());
 
-    private final String fileName;
-    private String queryString;
+    //to be removed
+    entityBuilder.addTextBody("orgname", pkgConfig.getName().split("\\.", 2)[0]);
 
-    Query(String fileName) {
-      this.fileName = fileName;
+    List<String> keywords = pkgConfig.getKeywords();
+    for (int i = 0; i < keywords.size(); i++) {
+      entityBuilder.addTextBody(String.format("topics[%d][name]", i), keywords.get(i));
     }
 
-    public synchronized String getQueryString() {
-      if (queryString==null) {
-        queryString = loadQuery(fileName);
-      }
-      return queryString;
-    }
-
+    return entityBuilder.build();
   }
-
 }

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
@@ -22,7 +22,7 @@ public class Zipper {
         ZipFile zip = new ZipFile(zipFile.toFile());
         for (Path p : Files.list(directory).collect(Collectors.toList())) {
             if (Files.isRegularFile(p) && !FileUtil.isExtension(p, ZIP_EXTENSION)) zip.addFile(p.toFile());
-            else if (Files.isDirectory(p)) zip.addFolder(directory.toFile(), zipParameters);
+            else if (Files.isDirectory(p)) zip.addFolder(p.toFile(), zipParameters);
         }
     }
 

--- a/sqrl-tools/sqrl-packager/src/main/resources/getDependency.graphql
+++ b/sqrl-tools/sqrl-packager/src/main/resources/getDependency.graphql
@@ -1,9 +1,0 @@
-query getDependency($pkgName: String!, $version: String!, $variant: String!) {
-Package(name: $pkgName) {
-    name
-    versions(version: $version, variant: $variant) {
-        file
-        hash
-        repoURL
-    }
-}}

--- a/sqrl-tools/sqrl-packager/src/main/resources/latestPackageByName.graphql
+++ b/sqrl-tools/sqrl-packager/src/main/resources/latestPackageByName.graphql
@@ -1,9 +1,0 @@
-query latestPackageByName($pkgName: String!) {
-Package(name: $pkgName) {
-    name
-    latest {
-        name
-        version
-        variant
-    }
-}}

--- a/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/repository/RemoteRepositoryImplementationTest.java
+++ b/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/repository/RemoteRepositoryImplementationTest.java
@@ -1,0 +1,20 @@
+package com.datasqrl.packager.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+class RemoteRepositoryImplementationTest {
+
+  @Test
+  void retrieveDependency() {
+    RemoteRepositoryImplementation remoteRepositoryImplementation =
+        new RemoteRepositoryImplementation();
+    JsonNode dev = remoteRepositoryImplementation.getDependencyInfo(
+        "datasqrl.profiles.flink-1-16",
+        "0.0.1", "dev");
+
+    assertEquals("datasqrl.profiles.flink-1-16", dev.get("name").textValue());
+  }
+}

--- a/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/repository/RepositoryTest.java
+++ b/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/repository/RepositoryTest.java
@@ -131,8 +131,10 @@ public class RepositoryTest {
   }
 
   @Test
+  @Disabled
   @SneakyThrows
   public void remoteRepoTest() {
+    // TODO: package here once we have real public packages in the repo, because for now datasqrl.example.speedshop is a mocked one
     DependencyImpl dependency = new DependencyImpl("datasqrl.seedshop", "0.1.1", "dev");
 
     RemoteRepositoryImplementation remoteRepo = new RemoteRepositoryImplementation(


### PR DESCRIPTION
This PR introduces validation for config files, with initial focus on validating packages being uploaded to the repository. The ultimate goal is to make it extendable for the validation of the entire Sqrl config, hence its placement within _SqrlConfigCommons_. Here are some considerations driving the current design:

- **Individual vs. combined configurations:** We can validate either individual configurations or the resultant `CombinedConfiguration`. While the `CombinedConfiguration` is critical for us, providing validation feedback on individual files may be more beneficial to the user. Hence, every file is validated separately.
  
- **Precedence in configurations:** Given that if a section is present across multiple files, one of them takes precedence over the others, we need to consider if this is valid for the "package" section. Should there be only one "package" section? If so, we may require a "strict" combination rule which doesn't allow overrides for certain use-cases. This requires further thoughts and feedback.
  
- **Validation point:** Validation could be performed either before parsing the file into `Configuration` (validating raw user input) or after (validating `Configuration` object). The latter avoids duplicate file reads from the disk and has been implemented for now.
  
- **Configuration to JsonObject:** The conversion of `Configuration` to `JsonObject` required a custom converter. An alternate approach would utilize `SqrlConfigCommons.toMap` and pass the result to the `JsonObject` constructor, necessitating minor modifications to the `toMap` method. This alternate approach was not chosen to avoid touch-points with `getKeys` and `getAllKeys`, and to retain code readability despite the minor duplication in function.

I look forward to further discussions on these points, particularly on the potential implementation of a "strict" combination rule and the preferred approach for converting `Configuration` to `JsonObject`.
