### PR TITLE
Slim down CLI jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-config.version>2.9.0</commons-config.version>
     <commons-collections.version>4.4</commons-collections.version>
+    <commons-csv.version>1.9.0</commons-csv.version>
     <httpcomponents.version>4.5.14</httpcomponents.version>
     <commons-bean.version>1.9.4</commons-bean.version>
     <h2.version>2.1.214</h2.version>
@@ -316,6 +317,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>${commons-collections.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-csv</artifactId>
+        <version>${commons-csv.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/sqrl-planner/pom.xml
+++ b/sqrl-planner/pom.xml
@@ -22,11 +22,6 @@
 
 
     <!-- Utils -->
-    <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.10.2</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.avro</groupId>
@@ -36,21 +31,12 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
-    </dependency>
 
     <!-- Test -->
     <dependency>
       <groupId>com.theokanning.openai-gpt3-java</groupId>
       <artifactId>service</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-csv</artifactId>
-      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/sqrl-tools/sqrl-cli/pom.xml
+++ b/sqrl-tools/sqrl-cli/pom.xml
@@ -31,20 +31,6 @@
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-planner</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.datasqrl</groupId>
-      <artifactId>sqrl-discovery</artifactId>
-    </dependency>
-
-    <!-- For the time being, include all connectors -->
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-file-sink-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-s3-fs-hadoop</artifactId>
-    </dependency>
 
     <!-- util -->
     <dependency>
@@ -77,6 +63,11 @@
       <artifactId>sqrl-planner</artifactId>
       <groupId>com.datasqrl</groupId>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sqrl-tools/sqrl-discovery/pom.xml
+++ b/sqrl-tools/sqrl-discovery/pom.xml
@@ -14,19 +14,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
 
     <!-- engine dependencies -->
     <dependency>
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-planner</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.datasqrl</groupId>
-      <artifactId>sqrl-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
-      <artifactId>kryo</artifactId>
     </dependency>
 
     <!-- Test jars -->

--- a/sqrl-tools/sqrl-packager/pom.xml
+++ b/sqrl-tools/sqrl-packager/pom.xml
@@ -21,44 +21,6 @@
     </dependency>
     <!-- to be moved out during run service modularization-->
     <!-- Kafka -->
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <classifier>test</classifier>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_${scala.version}</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_${scala.version}</artifactId>
-      <scope>compile</scope>
-      <classifier>test</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-streams</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-streams</artifactId>
-      <scope>compile</scope>
-      <classifier>test</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-streams-test-utils</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
 
     <dependency>
@@ -71,18 +33,6 @@
     </dependency>
 
     <!-- Utils -->
-    <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>


### PR DESCRIPTION
I removed all dependencies that weren't being used in the project. Unfortunately, this didn't significantly reduce the size; it only reduced the jar size by 17MB. If we want to reduce the size more substantially, we need to review other dependencies. We should check how extensively we use a specific dependency, and if it's not used extensively, we should consider dropping it.