### PR TITLE
Add jwt token auth to vertx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-auth-jwt</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
         <version>${vertx.version}</version>
       </dependency>

--- a/sqrl-server/sqrl-server-vertx/pom.xml
+++ b/sqrl-server/sqrl-server-vertx/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-auth-jwt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
       <!-- JUnit 4 is no longer necessary, so we exclude it -->

--- a/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
@@ -2,10 +2,10 @@ package com.datasqrl.graphql.config;
 
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.handler.graphql.ApolloWSOptions;
 import io.vertx.ext.web.handler.graphql.GraphQLHandlerOptions;
 import io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions;
-import io.vertx.jdbcclient.JDBCConnectOptions;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.sqlclient.PoolOptions;
 import javax.annotation.Nullable;
@@ -35,6 +35,7 @@ public class ServerConfig {
   PoolOptions poolOptions;
   CorsHandlerOptions corsHandlerOptions;
   ApolloWSOptions apolloWSOptions;
+  JWTAuthOptions JWTAuthOptions;
 
   public JsonObject toJson() {
     JsonObject json = new JsonObject();

--- a/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/config/ServerConfigOptionsConverter.java
+++ b/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/config/ServerConfigOptionsConverter.java
@@ -2,6 +2,7 @@ package com.datasqrl.graphql.config;
 
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.handler.graphql.ApolloWSOptions;
 import io.vertx.ext.web.handler.graphql.GraphQLHandlerOptions;
 import io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions;
@@ -38,6 +39,9 @@ public class ServerConfigOptionsConverter {
     serverConfig.setApolloWSOptions(
         new ApolloWSOptions(json.getJsonObject("apolloWSOptions") == null
             ? new JsonObject() : json.getJsonObject("apolloWSOptions")));
+    if (json.containsKey("JWTAuthOptions")) {
+      serverConfig.setJWTAuthOptions(new JWTAuthOptions(json.getJsonObject("JWTAuthOptions")));
+    }
   }
 
   public static void toJson(ServerConfig serverConfig, JsonObject json) {


### PR DESCRIPTION
This PR adds jwt authentication to the vertx endpoints.

To test it manually, add this section to the server-config.json:
```json
  "JWTAuthOptions": {
    "pubSecKeys": [
      {
        "algorithm": "HS256",
        "buffer": "dGVzdA=="
      }
    ]
  }
```

Call the endpoint with this header:
`Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTY5OTM0ODR9.t0YrUb6K-aiAMpdTQh0-ORwJTdRrrLmiU43oSE1kFkQ`

"buffer" is the BASE64 encoded value of "test".