### PR TITLE
Timestamp Reassignment

### DIFF
--- a/sqrl-testing/sqrl-flink-1.18/src/test/java/com/datasqrl/DagPlannerIT.java
+++ b/sqrl-testing/sqrl-flink-1.18/src/test/java/com/datasqrl/DagPlannerIT.java
@@ -36,7 +36,7 @@ public class DagPlannerIT {
     File directory = rootPath.toFile();
     if (directory.exists() && directory.isDirectory()) {
       File[] sqrlFiles = directory.listFiles(f->
-          f.getName().endsWith(".sqrl") && !f.getName().contains("disabled"));
+          f.getName().endsWith(".sqrl") && !f.getName().contains("disabled") && !f.getName().contains("fail"));
       if (sqrlFiles != null) {
         return Stream.of(sqrlFiles).map(File::toPath);
       }
@@ -54,7 +54,7 @@ public class DagPlannerIT {
 
   List<String> disabled = List.of("tableFunctionsBasic.sqrl",
       "tableStateJoinTest.sqrl", "tableStreamJoinTest.sqrl",
-      "selectDistinctNestedTest.sqrl");
+      "selectDistinctNestedTest.sqrl", "timestampReassignment.sqrl");
 
   @ParameterizedTest
   @MethodSource("directoryProvider")

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractAssetSnapshotTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractAssetSnapshotTest.java
@@ -158,12 +158,15 @@ public abstract class AbstractAssetSnapshotTest {
   private static final String SQRL_EXTENSION = ".sqrl";
 
   @SneakyThrows
-  public static Stream<Path> getSQRLScripts(Path directory) {
+  public static Stream<Path> getSQRLScripts(Path directory, boolean includeFail) {
     return Files.walk(directory)
         .filter(path -> !Files.isDirectory(path))
         .filter(path -> path.toString().endsWith(SQRL_EXTENSION))
         .filter(path-> !path.toString().contains("/build/"))
-        .filter(path -> TestNameModifier.of(path)!=TestNameModifier.disabled)
+        .filter(path -> {
+          TestNameModifier mod = TestNameModifier.of(path);
+          return mod==TestNameModifier.none || (includeFail && mod==TestNameModifier.fail);
+        })
         .sorted();
   }
 
@@ -189,10 +192,11 @@ public abstract class AbstractAssetSnapshotTest {
   public abstract static class SqrlScriptArgumentsProvider implements ArgumentsProvider {
 
     Path directory;
+    boolean includeFail;
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws IOException {
-      return getSQRLScripts(directory).map(Arguments::of);
+      return getSQRLScripts(directory, includeFail).map(Arguments::of);
     }
   }
 }

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractUseCaseTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/AbstractUseCaseTest.java
@@ -81,11 +81,12 @@ public class AbstractUseCaseTest extends AbstractAssetSnapshotTest {
   public abstract static class SqrlScriptsAndLocalPackages implements ArgumentsProvider {
 
     private final Path directory;
+    private final boolean includeFails;
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       //Look for all package jsons
-      return getSQRLScripts(directory).flatMap(path -> {
+      return getSQRLScripts(directory, includeFails).flatMap(path -> {
         List<Path> pkgFiles = getPackageFiles(path.getParent());
         Collections.sort(pkgFiles);
         if (pkgFiles.isEmpty()) pkgFiles.add(null);

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/DAGPlannerTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/DAGPlannerTest.java
@@ -54,7 +54,7 @@ public class DAGPlannerTest extends AbstractAssetSnapshotTest {
 
   static class DagPlannerSQRLFiles extends SqrlScriptArgumentsProvider {
     public DagPlannerSQRLFiles() {
-      super(SCRIPT_DIR);
+      super(SCRIPT_DIR, true);
     }
   }
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/DAGWriterJsonTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/DAGWriterJsonTest.java
@@ -26,7 +26,7 @@ public class DAGWriterJsonTest extends AbstractUseCaseTest {
 
   static class UseCaseFiles extends SqrlScriptsAndLocalPackages {
     public UseCaseFiles() {
-      super(USECASE_DIR);
+      super(USECASE_DIR, false);
     }
   }
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/ExternalUseCaseTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/ExternalUseCaseTest.java
@@ -30,7 +30,7 @@ public class ExternalUseCaseTest extends AbstractUseCaseTest {
 
   static class UseCaseFiles extends SqrlScriptsAndLocalPackages {
     public UseCaseFiles() {
-      super(USECASE_DIR);
+      super(USECASE_DIR, false);
     }
   }
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -25,7 +25,7 @@ public class UseCaseCompileTest extends AbstractUseCaseTest {
 
   static class UseCaseFiles extends SqrlScriptsAndLocalPackages {
     public UseCaseFiles() {
-      super(USECASE_DIR);
+      super(USECASE_DIR, true);
     }
   }
 }

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/dagplanner/imports-fail.sqrl
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/dagplanner/imports-fail.sqrl
@@ -1,0 +1,3 @@
+IMPORT ecommerceTs.Order;
+
+OrderTable := SELECT * FROM `Order` o JOIN `Order` o2;

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/dagplanner/timestampReassignment.sqrl
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/dagplanner/timestampReassignment.sqrl
@@ -1,0 +1,12 @@
+IMPORT ecommerceTs.Customer;
+IMPORT ecommerceTs.Orders;
+
+-- This correctly makes 'updatedTime' the new timestamp
+Customer2 := SELECT timestamp AS updatedTime, * FROM Customer;
+CustomerByTime2 := DISTINCT Customer2 ON customerid ORDER BY updatedTime DESC;
+OrderCustomerJoin := SELECT * FROM Orders o TEMPORAL JOIN CustomerByTime2 c ON c.customerid = o.customerid;
+
+-- This does not change the timestamp
+Customer3 := SELECT *, timestamp AS updatedTime FROM Customer;
+CustomerByTime3 := DISTINCT Customer3 ON customerid ORDER BY updatedTime DESC;
+

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports-fail.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports-fail.txt
@@ -1,0 +1,5 @@
+[FATAL] Object [Order] not found in module: ecommerceTs.Order
+in script:<script> [1:1]:
+IMPORT ecommerceTs.Order;
+^
+

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampReassignment.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampReassignment.txt
@@ -1,0 +1,1108 @@
+>>>pipeline_explain.txt
+=== Customer2
+ID:     customer2_1
+Type:   stream
+Stage:  flink
+Inputs: customer_2
+Primary Key: customerid, lastUpdated
+Timestamp  : updatedTime
+Schema:
+ - updatedTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Plan:
+LogicalProject(updatedTime=[$4], customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
+  LogicalTableScan(table=[[customer_2]])
+
+=== Customer3
+ID:     customer3_1
+Type:   stream
+Stage:  flink
+Inputs: customer_2
+Primary Key: customerid, lastUpdated
+Timestamp  : timestamp
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - updatedTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Plan:
+LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], updatedTime=[$4])
+  LogicalTableScan(table=[[customer_2]])
+
+=== Customer
+ID:     customer_2
+Type:   stream
+Stage:  flink
+Primary Key: customerid, lastUpdated
+Timestamp  : timestamp
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Plan:
+LogicalTableScan(table=[[customer_1]], hints=[[[WatermarkHint inheritPath:[] options:[4]]]]) hints[WatermarkHint options:[4]]
+
+=== CustomerByTime2
+ID:     customerbytime2_1
+Type:   state
+Stage:  flink
+Inputs: customer2_1
+Primary Key: customerid
+Timestamp  : updatedTime
+Schema:
+ - updatedTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Post Processors:
+ - topN: partition=customerid limit=1 sort=#0: updatedTime TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) DESC 
+Plan:
+LogicalTableScan(table=[[customer2_1]])
+
+=== CustomerByTime3
+ID:     customerbytime3_1
+Type:   state
+Stage:  flink
+Inputs: customer3_1
+Primary Key: customerid
+Timestamp  : timestamp
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - updatedTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Plan:
+LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], updatedTime=[$5])
+  LogicalFilter(condition=[=($6, 1)])
+    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], updatedTime=[$5], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $5 DESC NULLS FIRST)])
+      LogicalTableScan(table=[[customer3_1]])
+
+=== OrderCustomerJoin
+ID:     ordercustomerjoin_1
+Type:   stream
+Stage:  flink
+Inputs: customerbytime2_1, orders_2
+Primary Key: id, time
+Timestamp  : time
+Schema:
+ - id: BIGINT NOT NULL
+ - customerid: BIGINT NOT NULL
+ - time: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - entries: RecordType(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
+ - updatedTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - customerid0: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+Plan:
+LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], updatedTime=[$4], customerid0=[$5], email=[$6], name=[$7], lastUpdated=[$8], timestamp=[$9])
+  LogicalJoin(condition=[=($5, $1)], joinType=[inner]) hints[TemporalJoinHint options:[2]]
+    LogicalTableScan(table=[[orders_2]])
+    LogicalFilter(condition=[=($6, 1)]) hints[DedupHint]
+      LogicalProject(updatedTime=[$0], customerid=[$1], email=[$2], name=[$3], lastUpdated=[$4], timestamp=[$5], _rownum=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $0 DESC NULLS FIRST)])
+        LogicalTableScan(table=[[customerbytime2_1]])
+
+=== Orders
+ID:     orders_2
+Type:   stream
+Stage:  flink
+Primary Key: id, time
+Timestamp  : time
+Schema:
+ - id: BIGINT NOT NULL
+ - customerid: BIGINT NOT NULL
+ - time: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - entries: RecordType(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
+Plan:
+LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] options:[2]]]]) hints[WatermarkHint options:[2]]
+
+>>>flink.json
+{
+  "flinkSql" : [
+    "CREATE TEMPORARY FUNCTION IF NOT EXISTS `ToJson` AS 'com.datasqrl.json.ToJson' LANGUAGE JAVA;",
+    "CREATE TEMPORARY FUNCTION IF NOT EXISTS `epochtotimestamp` AS 'com.datasqrl.time.EpochToTimestamp' LANGUAGE JAVA;",
+    "CREATE TEMPORARY TABLE `customer_1` (\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` AS EPOCHTOTIMESTAMP(`lastUpdated`),\n  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,\n  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND\n) WITH (\n  'format' = 'json',\n  'path' = 'file:/mock',\n  'source.monitor-interval' = '10000',\n  'connector' = 'filesystem',\n  'source.path.regex-pattern' = ''\n);",
+    "CREATE TEMPORARY TABLE `orders_1` (\n  `id` BIGINT NOT NULL,\n  `customerid` BIGINT NOT NULL,\n  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL,\n  PRIMARY KEY (`id`, `time`) NOT ENFORCED,\n  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND\n) WITH (\n  'format' = 'json',\n  'path' = 'file:/mock',\n  'source.monitor-interval' = '10000',\n  'connector' = 'filesystem',\n  'source.path.regex-pattern' = ''\n);",
+    "CREATE TEMPORARY TABLE `customer2_1` (\n  `updatedTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'customer2_1',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `customer3_1` (\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `updatedTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'customer3_1',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `customer_2` (\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'customer_2',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `customerbytime2_1` (\n  `updatedTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`customerid`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'customerbytime2_1',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `customerbytime3_1` (\n  `customerid` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `updatedTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`customerid`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'customerbytime3_1',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `ordercustomerjoin_1` (\n  `id` BIGINT NOT NULL,\n  `customerid` BIGINT NOT NULL,\n  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `entries` RAW('com.datasqrl.json.FlinkJsonType', 'ADFjb20uZGF0YXNxcmwuanNvbi5GbGlua0pzb25UeXBlU2VyaWFsaXplclNuYXBzaG90AAAAAQApY29tLmRhdGFzcXJsLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXI='),\n  `updatedTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `customerid0` BIGINT NOT NULL,\n  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,\n  `lastUpdated` BIGINT NOT NULL,\n  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  PRIMARY KEY (`id`, `time`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'ordercustomerjoin_1',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE TEMPORARY TABLE `orders_2` (\n  `id` BIGINT NOT NULL,\n  `customerid` BIGINT NOT NULL,\n  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,\n  `entries` RAW('com.datasqrl.json.FlinkJsonType', 'ADFjb20uZGF0YXNxcmwuanNvbi5GbGlua0pzb25UeXBlU2VyaWFsaXplclNuYXBzaG90AAAAAQApY29tLmRhdGFzcXJsLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXI='),\n  PRIMARY KEY (`id`, `time`) NOT ENFORCED\n) WITH (\n  'password' = '${JDBC_PASSWORD}',\n  'connector' = 'jdbc-sqrl',\n  'driver' = 'org.postgresql.Driver',\n  'table-name' = 'orders_2',\n  'url' = '${JDBC_URL}',\n  'username' = '${JDBC_USERNAME}'\n);",
+    "CREATE VIEW `table$1`\nAS\nSELECT `timestamp` AS `updatedTime`, `customerid`, `email`, `name`, `lastUpdated`, `timestamp`\nFROM `customer_1`;",
+    "CREATE VIEW `table$2`\nAS\nSELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, `timestamp` AS `updatedTime`\nFROM `customer_1`;",
+    "CREATE VIEW `table$3`\nAS\nSELECT *\nFROM `customer_1`;",
+    "CREATE VIEW `table$4`\nAS\nSELECT `timestamp` AS `updatedTime`, `customerid`, `email`, `name`, `lastUpdated`, `timestamp`\nFROM `customer_1`;",
+    "CREATE VIEW `table$5`\nAS\nSELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, `updatedTime`\nFROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, `updatedTime`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `updatedTime` DESC) AS `_rownum`\n  FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, `timestamp` AS `updatedTime`\n    FROM `customer_1`) AS `t`) AS `t0`\nWHERE `_rownum` = 1;",
+    "CREATE VIEW `table$6`\nAS\nSELECT *\nFROM (SELECT `updatedTime`, `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `updatedTime` DESC) AS `_rownum`\n  FROM (SELECT `timestamp` AS `updatedTime`, `customerid`, `email`, `name`, `lastUpdated`, `timestamp`\n    FROM `customer_1`) AS `t`) AS `t0`\nWHERE `_rownum` = 1;",
+    "CREATE VIEW `table$7`\nAS\nSELECT `$cor0`.`id`, `$cor0`.`customerid`, `$cor0`.`time`, TOJSON(`$cor0`.`entries`) AS `entries`, `t1`.`updatedTime`, `t1`.`customerid` AS `customerid0`, `t1`.`email`, `t1`.`name`, `t1`.`lastUpdated`, `t1`.`timestamp`\nFROM `orders_1` AS `$cor0`\n INNER JOIN `table$6` FOR SYSTEM_TIME AS OF `$cor0`.`time` AS `t1` ON `t1`.`customerid` = `$cor0`.`customerid`;",
+    "CREATE VIEW `table$8`\nAS\nSELECT `id`, `customerid`, `time`, TOJSON(`entries`) AS `entries`\nFROM `orders_1`;",
+    "EXECUTE STATEMENT SET BEGIN\nINSERT INTO `customer2_1`\n(SELECT *\n FROM `table$1`)\n;\nINSERT INTO `customer3_1`\n (SELECT *\n  FROM `table$2`)\n ;\n INSERT INTO `customer_2`\n  (SELECT *\n   FROM `table$3`)\n  ;\n  INSERT INTO `customerbytime2_1`\n   (SELECT *\n    FROM `table$4`)\n   ;\n   INSERT INTO `customerbytime3_1`\n    (SELECT *\n     FROM `table$5`)\n    ;\n    INSERT INTO `ordercustomerjoin_1`\n     (SELECT *\n      FROM `table$7`)\n     ;\n     INSERT INTO `orders_2`\n      (SELECT *\n       FROM `table$8`)\n      ;\n      END;"
+  ],
+  "connectors" : [
+    "jdbc-sqrl",
+    "filesystem"
+  ],
+  "formats" : [
+    "json"
+  ]
+}
+>>>kafka.json
+{
+  "topics" : [ ]
+}
+>>>postgres.json
+{
+  "ddl" : [
+    {
+      "name" : "customer2_1",
+      "columns" : [
+        "\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"customerid\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"customerid\"",
+        "\"lastUpdated\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS customer2_1 (\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL,\"customerid\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"customerid\",\"lastUpdated\"));"
+    },
+    {
+      "name" : "customer3_1",
+      "columns" : [
+        "\"customerid\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"customerid\"",
+        "\"lastUpdated\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS customer3_1 (\"customerid\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL,\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"customerid\",\"lastUpdated\"));"
+    },
+    {
+      "name" : "customer_2",
+      "columns" : [
+        "\"customerid\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"customerid\"",
+        "\"lastUpdated\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS customer_2 (\"customerid\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"customerid\",\"lastUpdated\"));"
+    },
+    {
+      "name" : "customerbytime2_1",
+      "columns" : [
+        "\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"customerid\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"customerid\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS customerbytime2_1 (\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL,\"customerid\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"customerid\"));"
+    },
+    {
+      "name" : "customerbytime3_1",
+      "columns" : [
+        "\"customerid\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"customerid\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS customerbytime3_1 (\"customerid\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL,\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"customerid\"));"
+    },
+    {
+      "name" : "ordercustomerjoin_1",
+      "columns" : [
+        "\"id\" BIGINT NOT NULL",
+        "\"customerid\" BIGINT NOT NULL",
+        "\"time\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"entries\" JSONB NOT NULL",
+        "\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"customerid0\" BIGINT NOT NULL",
+        "\"email\" TEXT NOT NULL",
+        "\"name\" TEXT NOT NULL",
+        "\"lastUpdated\" BIGINT NOT NULL",
+        "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"id\"",
+        "\"time\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS ordercustomerjoin_1 (\"id\" BIGINT NOT NULL,\"customerid\" BIGINT NOT NULL,\"time\" TIMESTAMP WITH TIME ZONE NOT NULL,\"entries\" JSONB NOT NULL,\"updatedTime\" TIMESTAMP WITH TIME ZONE NOT NULL,\"customerid0\" BIGINT NOT NULL,\"email\" TEXT NOT NULL,\"name\" TEXT NOT NULL,\"lastUpdated\" BIGINT NOT NULL,\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL , PRIMARY KEY (\"id\",\"time\"));"
+    },
+    {
+      "name" : "orders_2",
+      "columns" : [
+        "\"id\" BIGINT NOT NULL",
+        "\"customerid\" BIGINT NOT NULL",
+        "\"time\" TIMESTAMP WITH TIME ZONE NOT NULL",
+        "\"entries\" JSONB NOT NULL"
+      ],
+      "primaryKeys" : [
+        "\"id\"",
+        "\"time\""
+      ],
+      "sql" : "CREATE TABLE IF NOT EXISTS orders_2 (\"id\" BIGINT NOT NULL,\"customerid\" BIGINT NOT NULL,\"time\" TIMESTAMP WITH TIME ZONE NOT NULL,\"entries\" JSONB NOT NULL , PRIMARY KEY (\"id\",\"time\"));"
+    },
+    {
+      "indexName" : "customer2_1_hash_c4",
+      "tableName" : "customer2_1",
+      "columns" : [
+        "lastUpdated"
+      ],
+      "type" : "HASH",
+      "sql" : "CREATE INDEX IF NOT EXISTS customer2_1_hash_c4 ON customer2_1 USING hash (\"lastUpdated\");"
+    },
+    {
+      "indexName" : "customer3_1_hash_c3",
+      "tableName" : "customer3_1",
+      "columns" : [
+        "lastUpdated"
+      ],
+      "type" : "HASH",
+      "sql" : "CREATE INDEX IF NOT EXISTS customer3_1_hash_c3 ON customer3_1 USING hash (\"lastUpdated\");"
+    },
+    {
+      "indexName" : "customer_2_hash_c3",
+      "tableName" : "customer_2",
+      "columns" : [
+        "lastUpdated"
+      ],
+      "type" : "HASH",
+      "sql" : "CREATE INDEX IF NOT EXISTS customer_2_hash_c3 ON customer_2 USING hash (\"lastUpdated\");"
+    },
+    {
+      "indexName" : "ordercustomerjoin_1_hash_c2",
+      "tableName" : "ordercustomerjoin_1",
+      "columns" : [
+        "time"
+      ],
+      "type" : "HASH",
+      "sql" : "CREATE INDEX IF NOT EXISTS ordercustomerjoin_1_hash_c2 ON ordercustomerjoin_1 USING hash (\"time\");"
+    },
+    {
+      "indexName" : "orders_2_hash_c2",
+      "tableName" : "orders_2",
+      "columns" : [
+        "time"
+      ],
+      "type" : "HASH",
+      "sql" : "CREATE INDEX IF NOT EXISTS orders_2_hash_c2 ON orders_2 USING hash (\"time\");"
+    }
+  ]
+}
+>>>vertx.json
+{
+  "model" : {
+    "coords" : [
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Customer",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nORDER BY \"timestamp\" DESC NULLS LAST, \"customerid\", \"lastUpdated\"",
+              "parameters" : [ ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                },
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"lastUpdated\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST, \"customerid\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST, \"lastUpdated\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Customer2",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer2_1\"\nORDER BY \"updatedTime\" DESC NULLS LAST, \"customerid\", \"lastUpdated\"",
+              "parameters" : [ ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer2_1\"\nWHERE \"customerid\" = $1\nORDER BY \"updatedTime\" DESC NULLS LAST, \"lastUpdated\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer2_1\"\nWHERE \"lastUpdated\" = $1\nORDER BY \"updatedTime\" DESC NULLS LAST, \"customerid\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"updatedTime\", \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer2_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"updatedTime\" DESC NULLS LAST, 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                },
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Customer3",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer3_1\"\nWHERE \"customerid\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST, \"lastUpdated\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer3_1\"\nWHERE \"lastUpdated\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST, \"customerid\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "lastUpdated"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", \"updatedTime\", 1 AS \"__pk\"\nFROM \"customer3_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                },
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "lastUpdated"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customer3_1\"\nORDER BY \"timestamp\" DESC NULLS LAST, \"customerid\", \"lastUpdated\"",
+              "parameters" : [ ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "CustomerByTime2",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customerbytime2_1\"\nORDER BY \"customerid\"",
+              "parameters" : [ ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"updatedTime\", \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbytime2_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "CustomerByTime3",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "customerid"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", \"updatedTime\", 1 AS \"__pk\"\nFROM \"customerbytime3_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "customerid"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"customerbytime3_1\"\nORDER BY \"customerid\"",
+              "parameters" : [ ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "OrderCustomerJoin",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "id"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"ordercustomerjoin_1\"\nWHERE \"id\" = $1\nORDER BY \"time\" DESC NULLS LAST",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "id"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"ordercustomerjoin_1\"\nORDER BY \"time\" DESC NULLS LAST, \"id\"",
+              "parameters" : [ ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "time"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"ordercustomerjoin_1\"\nWHERE \"time\" = $1\nORDER BY \"time\" DESC NULLS LAST, \"id\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "time"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "id"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "time"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"updatedTime\", \"customerid0\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"ordercustomerjoin_1\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "id"
+                },
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "time"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Orders",
+        "matchs" : [
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "id"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "time"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "id"
+                },
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "time"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "time"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"time\" = $1\nORDER BY \"time\" DESC NULLS LAST, \"id\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "time"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "id"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1\nORDER BY \"time\" DESC NULLS LAST",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "type" : "arg",
+                  "path" : "id"
+                }
+              ]
+            }
+          },
+          {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "PagedJdbcQuery",
+              "type" : "PagedJdbcQuery",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nORDER BY \"time\" DESC NULLS LAST, \"id\"",
+              "parameters" : [ ]
+            }
+          }
+        ]
+      }
+    ],
+    "mutations" : [ ],
+    "subscriptions" : [ ],
+    "schema" : {
+      "type" : "string",
+      "type" : "string",
+      "schema" : "type Customer {\n  customerid: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n}\n\ntype Customer2 {\n  updatedTime: DateTime!\n  customerid: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n}\n\ntype Customer3 {\n  customerid: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n  updatedTime: DateTime!\n}\n\ntype CustomerByTime2 {\n  updatedTime: DateTime!\n  customerid: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n}\n\ntype CustomerByTime3 {\n  customerid: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n  updatedTime: DateTime!\n}\n\n\"An RFC-3339 compliant DateTime Scalar\"\nscalar DateTime\n\ntype OrderCustomerJoin {\n  id: Float!\n  customerid: Float!\n  time: DateTime!\n  updatedTime: DateTime!\n  customerid0: Float!\n  email: String!\n  name: String!\n  lastUpdated: Float!\n  timestamp: DateTime!\n  entries(limit: Int = 10, offset: Int = 0): [entries!]\n}\n\ntype Orders {\n  id: Float!\n  customerid: Float!\n  time: DateTime!\n  entries(limit: Int = 10, offset: Int = 0): [entries!]\n}\n\ntype Query {\n  Customer(customerid: Float, lastUpdated: Float, limit: Int = 10, offset: Int = 0): [Customer!]\n  Customer2(customerid: Float, lastUpdated: Float, limit: Int = 10, offset: Int = 0): [Customer2!]\n  Customer3(customerid: Float, lastUpdated: Float, limit: Int = 10, offset: Int = 0): [Customer3!]\n  CustomerByTime2(customerid: Float, limit: Int = 10, offset: Int = 0): [CustomerByTime2!]\n  CustomerByTime3(customerid: Float, limit: Int = 10, offset: Int = 0): [CustomerByTime3!]\n  OrderCustomerJoin(id: Float, time: DateTime, limit: Int = 10, offset: Int = 0): [OrderCustomerJoin!]\n  Orders(id: Float, time: DateTime, limit: Int = 10, offset: Int = 0): [Orders!]\n}\n\ntype entries {\n  productid: Float!\n  quantity: Float!\n  unit_price: Float!\n  discount: Float\n}\n\ntype entries_ {\n  productid: Float!\n  quantity: Float!\n  unit_price: Float!\n  discount: Float\n}\n"
+    }
+  }
+}


### PR DESCRIPTION
I thought there was an issue with timestamp reassignment, but it behaves correctly: We always fix the first timestamp candidate for a table when there are multiple so the timestamp is unique.

I added a test case to encode this properly.

I also added a test case for missing imports.