### PR TITLE
Don't add static primary key to queries

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/plan/SqrlPlanningTableFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/SqrlPlanningTableFactory.java
@@ -110,6 +110,8 @@ public class SqrlPlanningTableFactory implements SqrlTableFactory {
     Pair<List<OptimizerHint>,List<SqlHint>> analyzedHints = OptimizerHint.fromSqlHints(hints, errors);
     //TODO: put other SQLHints back on the relnode after we are done, i.e. pass them through
     SqrlConverterConfig.SqrlConverterConfigBuilder configBuilder = SqrlConverterConfig.builder();
+    //Add default primary key if it has none
+    configBuilder.addDefaultPrimaryKey(true);
     //Apply only generic optimizer hints (pipeline optimization happens in the DAGPlanner)
     StreamUtil.filterByClass(analyzedHints.getKey(), ConverterHint.class)
         .forEach(h -> h.add2Config(configBuilder, errors));

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/rules/AnnotatedLP.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/rules/AnnotatedLP.java
@@ -441,7 +441,7 @@ public class AnnotatedLP implements RelHolder {
         }
         chosenPks.add(newChosenPkIdx);
       }
-      if (input.primaryKey.getLength() == 0) {
+      if (input.primaryKey.getLength() == 0 && config.addDefaultPrimaryKey) {
         //If we don't have a primary key, we add a static one to resolve uniqueness in the database
         chosenPks = List.of(projectIndexes.size());
         projectIndexes.add(PK_LITERAL_IDENTIFIER);

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/rules/SqrlConverterConfig.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/rules/SqrlConverterConfig.java
@@ -21,17 +21,36 @@ public class SqrlConverterConfig {
   @Builder.Default
   int slideWindowPanes = SQRLConverter.DEFAULT_SLIDING_WINDOW_PANES;
 
+  /**
+   * Overwrite the field names with the ones from the relnode
+   */
   @Builder.Default
   boolean setOriginalFieldnames = false;
 
+  /**
+   * Overwrite the field names with these given ones
+   */
   @Builder.Default
   List<String> fieldNames = null;
 
+  /**
+   * Whether to inline pullups instead of pulling them up
+   */
   @Builder.Default
   boolean inlinePullups = false;
 
+  /**
+   * Overwrite the primary key names with these given ones
+   */
   @Builder.Default
   List<String> primaryKeyNames = null;
+
+  /**
+   * Whether to add a static literal as primary key when the table doesn't have one.
+   * This is needed to write tables to the database
+   */
+  @Builder.Default
+  boolean addDefaultPrimaryKey = false;
 
   public SqrlConverterConfig withStage(ExecutionStage stage) {
     return toBuilder().stage(stage).build();

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
@@ -351,7 +351,7 @@ LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], col1=[/(+($0, 
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"col1\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
@@ -244,7 +244,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"count\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"orderagg1_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orderagg1_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -322,7 +322,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"timestamp\", \"count\", 1 AS \"__pk\"\nFROM \"orderagg2_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orderagg2_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -360,7 +360,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"count\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"orderagg3_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orderagg3_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -438,7 +438,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"timestamp\", \"count\", 1 AS \"__pk\"\nFROM \"orderagg4_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orderagg4_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -481,7 +481,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -626,7 +626,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"ordersstate_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordersstate_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
@@ -270,7 +270,7 @@ LogicalProject(id=[$0], time=[$2], cc=[CASE(IS NULL($7), 0:BIGINT, $7)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -431,7 +431,7 @@ LogicalProject(id=[$0], time=[$2], cc=[CASE(IS NULL($7), 0:BIGINT, $7)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -592,7 +592,7 @@ LogicalProject(id=[$0], time=[$2], cc=[CASE(IS NULL($7), 0:BIGINT, $7)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT SINGLE_VALUE(\"customerid\") AS \"$f0\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo') AS \"t0\" ON \"orders_2\".\"customerid\" > \"t0\".\"$f0\") AS \"t1\"\nWHERE \"t1\".\"id\" = $1 AND \"t1\".\"time\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT SINGLE_VALUE(\"customerid\") AS \"$f0\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo') AS \"t0\" ON \"orders_2\".\"customerid\" > \"t0\".\"$f0\") AS \"t1\"\nWHERE \"t1\".\"id\" = $1 AND \"t1\".\"time\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -852,7 +852,7 @@ LogicalProject(id=[$0], time=[$2], cc=[CASE(IS NULL($7), 0:BIGINT, $7)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo'\n    GROUP BY \"customerid\") AS \"t0\" ON \"orders_2\".\"customerid\" = \"t0\".\"customerid\") AS \"t1\"\nWHERE \"t1\".\"id\" = $1 AND \"t1\".\"time\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo'\n    GROUP BY \"customerid\") AS \"t0\" ON \"orders_2\".\"customerid\" = \"t0\".\"customerid\") AS \"t1\"\nWHERE \"t1\".\"id\" = $1 AND \"t1\".\"time\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -982,7 +982,7 @@ LogicalProject(id=[$0], time=[$2], cc=[CASE(IS NULL($7), 0:BIGINT, $7)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", \"cc\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\", CASE WHEN \"t6\".\"EXPR$0\" IS NULL THEN 0 ELSE \"t6\".\"EXPR$0\" END AS \"cc\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo'\n    GROUP BY \"customerid\") AS \"t0\" ON \"orders_2\".\"customerid\" = \"t0\".\"customerid\"\n   LEFT JOIN (SELECT \"t4\".\"customerid\" AS \"customerid0\", COUNT(*) AS \"EXPR$0\", MAX(CASE WHEN \"customer_20\".\"timestamp\" < \"t4\".\"__timestamp\" THEN \"t4\".\"__timestamp\" ELSE \"customer_20\".\"timestamp\" END) AS \"__timestamp\"\n    FROM \"customer_2\" AS \"customer_20\"\n     INNER JOIN (SELECT \"orders_20\".\"customerid\", MAX(CASE WHEN \"orders_20\".\"time\" < \"t2\".\"__timestamp\" THEN \"t2\".\"__timestamp\" ELSE \"orders_20\".\"time\" END) AS \"__timestamp\"\n      FROM \"orders_2\" AS \"orders_20\"\n       INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n        FROM \"customer_2\"\n        WHERE \"name\" = 'foo'\n        GROUP BY \"customerid\") AS \"t2\" ON \"orders_20\".\"customerid\" = \"t2\".\"customerid\"\n      GROUP BY \"orders_20\".\"customerid\") AS \"t4\" ON \"customer_20\".\"customerid\" > \"t4\".\"customerid\"\n    GROUP BY \"t4\".\"customerid\") AS \"t6\" ON \"orders_2\".\"customerid\" = \"t6\".\"customerid0\") AS \"t7\"\nWHERE \"t7\".\"id\" = $1 AND \"t7\".\"time\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\", CASE WHEN \"t6\".\"EXPR$0\" IS NULL THEN 0 ELSE \"t6\".\"EXPR$0\" END AS \"cc\"\n  FROM \"orders_2\"\n   INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n    FROM \"customer_2\"\n    WHERE \"name\" = 'foo'\n    GROUP BY \"customerid\") AS \"t0\" ON \"orders_2\".\"customerid\" = \"t0\".\"customerid\"\n   LEFT JOIN (SELECT \"t4\".\"customerid\" AS \"customerid0\", COUNT(*) AS \"EXPR$0\", MAX(CASE WHEN \"customer_20\".\"timestamp\" < \"t4\".\"__timestamp\" THEN \"t4\".\"__timestamp\" ELSE \"customer_20\".\"timestamp\" END) AS \"__timestamp\"\n    FROM \"customer_2\" AS \"customer_20\"\n     INNER JOIN (SELECT \"orders_20\".\"customerid\", MAX(CASE WHEN \"orders_20\".\"time\" < \"t2\".\"__timestamp\" THEN \"t2\".\"__timestamp\" ELSE \"orders_20\".\"time\" END) AS \"__timestamp\"\n      FROM \"orders_2\" AS \"orders_20\"\n       INNER JOIN (SELECT \"customerid\", MAX(\"timestamp\") AS \"__timestamp\"\n        FROM \"customer_2\"\n        WHERE \"name\" = 'foo'\n        GROUP BY \"customerid\") AS \"t2\" ON \"orders_20\".\"customerid\" = \"t2\".\"customerid\"\n      GROUP BY \"orders_20\".\"customerid\") AS \"t4\" ON \"customer_20\".\"customerid\" > \"t4\".\"customerid\"\n    GROUP BY \"t4\".\"customerid\") AS \"t6\" ON \"orders_2\".\"customerid\" = \"t6\".\"customerid0\") AS \"t7\"\nWHERE \"t7\".\"id\" = $1 AND \"t7\".\"time\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/conditions.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/conditions.txt
@@ -333,7 +333,7 @@ LogicalFilter(condition=[ARRAY_CONTAINS(split('one, two', ','), $1)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1538,7 +1538,7 @@ LogicalFilter(condition=[ARRAY_CONTAINS(split('one, two', ','), $1)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"productfilter1_1\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"productfilter1_1\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1944,7 +1944,7 @@ LogicalFilter(condition=[ARRAY_CONTAINS(split('one, two', ','), $1)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"productfilter2_1\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"productfilter2_1\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
@@ -413,7 +413,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -523,7 +523,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbymultiple_1\"\nWHERE \"customerid\" = $1 AND \"email\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbymultiple_1\"\nWHERE \"customerid\" = $1 AND \"email\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -653,7 +653,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbymultipletime_1\"\nWHERE \"customerid\" = $1 AND \"email\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbymultipletime_1\"\nWHERE \"customerid\" = $1 AND \"email\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -798,7 +798,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbytime_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbytime_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -856,7 +856,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbytime2_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbytime2_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -914,7 +914,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbytimeasc_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbytimeasc_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -972,7 +972,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbyupdated_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbyupdated_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1030,7 +1030,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbyupdatedasc_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbyupdatedasc_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1068,7 +1068,7 @@ LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"timestamp\", \"name\", 1 AS \"__pk\"\nFROM \"explicitdistinct_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"explicitdistinct_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportStreamTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportStreamTest.txt
@@ -305,7 +305,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -473,7 +473,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1013,7 +1013,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
@@ -164,7 +164,7 @@ LogicalProject(productid=[$0], name=[$1], description=[$2], category=[$3], _inge
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", \"badWords\", \"searchResult\", \"format\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importWithNaturalTimestampTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importWithNaturalTimestampTest.txt
@@ -261,7 +261,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -422,7 +422,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -921,7 +921,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
@@ -840,7 +840,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1118,7 +1118,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1509,7 +1509,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/innerNonIntervalJoinExport.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/innerNonIntervalJoinExport.txt
@@ -1056,7 +1056,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
@@ -922,7 +922,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1826,7 +1826,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1889,7 +1889,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTypesTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTypesTest.txt
@@ -262,7 +262,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -537,7 +537,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
@@ -427,7 +427,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -795,7 +795,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1447,7 +1447,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
@@ -586,7 +586,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -954,7 +954,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1606,7 +1606,7 @@ LogicalProject(obj=[toJson('{"a": 1}')], _customerid=[$0], _timestamp=[$4])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedAggregationAndSelfJoinTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedAggregationAndSelfJoinTest.txt
@@ -411,7 +411,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -449,7 +449,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_customerid\", \"day\", \"total_price\", \"total_num\", \"__timestamp\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"orders_by_day_1\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t\"\nWHERE \"day\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"orders_by_day_1\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t\"\nWHERE \"day\" = $2",
               "parameters" : [
                 {
                   "type" : "source",
@@ -502,7 +502,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -813,7 +813,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -845,7 +845,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"__pk2_customerid\", \"__pk3_time\", \"price\", \"num\", \"discount\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"total_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk2_customerid\" = $2 AND \"__pk3_time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"total_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk2_customerid\" = $2 AND \"__pk3_time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -877,7 +877,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1034,7 +1034,7 @@ LogicalProject(__pk1_id=[$0], __pk2_customerid=[$1], __pk3_time=[$2], price=[$4]
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"price\", \"num\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"ordersinline_1\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordersinline_1\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
@@ -185,7 +185,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -243,7 +243,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"__pk3_time\", \"price\", \"saving\", 1 AS \"__pk\"\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -270,7 +270,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nowAggregateTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nowAggregateTest.txt
@@ -564,7 +564,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -674,7 +674,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\nFROM \"orderagg1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orderagg1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -882,7 +882,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", \"order_count\", 1 AS \"__pk\"\nFROM \"orderaugment_1\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orderaugment_1\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -961,7 +961,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\n  FROM \"ordernow1_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '777600' SECOND(9))\nORDER BY \"bucket\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"ordernow1_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '777600' SECOND(9))\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1106,7 +1106,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"bucket\", \"order_count\", 1 AS \"__pk\"\n  FROM \"ordernow2_1\"\n  WHERE \"bucket\" = $1) AS \"t0\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '777600' SECOND(9))\nORDER BY \"bucket\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"ordernow2_1\"\n  WHERE \"bucket\" = $1) AS \"t\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '777600' SECOND(9))\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1164,7 +1164,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"order_count\", \"_time\", 1 AS \"__pk\"\nFROM \"ordernow3_1\"\nWHERE \"customer\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordernow3_1\"\nWHERE \"customer\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1207,7 +1207,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1419,7 +1419,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\nFROM \"ordertime1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordertime1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1938,7 +1938,7 @@ LogicalProject(total=[$1], quantity=[$2], __pk=[1], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nowFilterTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nowFilterTest.txt
@@ -473,7 +473,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -583,7 +583,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\n  FROM \"historicorders_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP <= (\"time\" + INTERVAL '86313600' SECOND(11))\nORDER BY \"time\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"historicorders_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP <= (\"time\" + INTERVAL '86313600' SECOND(11))\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -733,7 +733,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\n  FROM \"orderagg1_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '86401' SECOND(8))\nORDER BY \"bucket\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"orderagg1_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '86401' SECOND(8))\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -874,7 +874,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\n  FROM \"orderagg2_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '86401' SECOND(8))\nORDER BY \"bucket\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"orderagg2_1\"\n  WHERE \"customer\" = $1 AND \"bucket\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP < (\"bucket\" + INTERVAL '86401' SECOND(8))\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -973,7 +973,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\n  FROM \"orderfilter_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP < (\"time\" + INTERVAL '86400' SECOND(8))\nORDER BY \"time\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"orderfilter_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP < (\"time\" + INTERVAL '86400' SECOND(8))\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1134,7 +1134,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1601,7 +1601,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1977,7 +1977,7 @@ LogicalTableScan(table=[[orders_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT *\nFROM (SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\n  FROM \"recentorders_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t0\"\nWHERE CURRENT_TIMESTAMP <= (\"time\" + INTERVAL '1' SECOND(4))\nORDER BY \"time\" DESC NULLS LAST, \"__pk\"",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"recentorders_1\"\n  WHERE \"id\" = $1 AND \"time\" = $2) AS \"t\"\nWHERE CURRENT_TIMESTAMP <= (\"time\" + INTERVAL '1' SECOND(4))\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctNestedTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctNestedTest.txt
@@ -355,7 +355,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -516,7 +516,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1148,7 +1148,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1272,7 +1272,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"_time\", 1 AS \"__pk\"\nFROM \"productid_1\"\nWHERE \"productid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"productid_1\"\nWHERE \"productid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1336,7 +1336,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_productid\", \"orderid\", \"numOrders\", \"lastOrder\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"suborders_1\"\n  WHERE \"__pk1_productid\" = $1) AS \"t\"\nWHERE \"orderid\" = $2\nORDER BY \"__pk1_productid\", \"numOrders\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"suborders_1\"\n  WHERE \"__pk1_productid\" = $1) AS \"t\"\nWHERE \"orderid\" = $2\nORDER BY \"__pk1_productid\", \"numOrders\" DESC",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1363,7 +1363,7 @@ LogicalAggregate(group=[{0, 1}], numOrders=[COUNT()], lastOrder=[MAX($2)])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"productid\", \"_time\", 1 AS \"__pk\"\nFROM \"productid_1\"\nWHERE \"productid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"productid_1\"\nWHERE \"productid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
@@ -325,7 +325,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -450,7 +450,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"_timestamp\", 1 AS \"__pk\"\nFROM \"customerid_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerid_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -551,7 +551,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1111,7 +1111,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/setOperationRelationTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/setOperationRelationTest.txt
@@ -345,7 +345,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -455,7 +455,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1098,7 +1098,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
@@ -236,7 +236,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", 1 AS \"__pk\"\nFROM \"numbers_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"numbers_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -294,7 +294,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", 1 AS \"__pk\"\nFROM \"numbers2_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"numbers2_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -352,7 +352,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", 1 AS \"__pk\"\nFROM \"numberslarge_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"numberslarge_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -446,7 +446,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN \"numbers_1\" ON \"orders_2\".\"customerid\" = CAST(\"numbers_1\".\"id\" AS BIGINT)) AS \"t\"\nWHERE \"t\".\"id\" = $1 AND \"t\".\"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN \"numbers_1\" ON \"orders_2\".\"customerid\" = CAST(\"numbers_1\".\"id\" AS BIGINT)) AS \"t\"\nWHERE \"t\".\"id\" = $1 AND \"t\".\"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -545,7 +545,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (VALUES  (1),\n      (2),\n      (3),\n      (4),\n      (4)) AS \"t\" (\"id\") ON \"orders_2\".\"customerid\" = CAST(\"t\".\"id\" AS BIGINT)) AS \"t0\"\nWHERE \"t0\".\"id\" = $1 AND \"t0\".\"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\"\n  FROM \"orders_2\"\n   INNER JOIN (VALUES  (1),\n      (2),\n      (3),\n      (4),\n      (4)) AS \"t\" (\"id\") ON \"orders_2\".\"customerid\" = CAST(\"t\".\"id\" AS BIGINT)) AS \"t0\"\nWHERE \"t0\".\"id\" = $1 AND \"t0\".\"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -851,7 +851,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"time\", \"pk\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\", \"t\".\"pk\"\n  FROM \"orders_2\",\n    (VALUES  (1, 1),\n      (2, 2),\n      (3, 3),\n      (4, 4),\n      (4, 4)) AS \"t\" (\"id\", \"pk\")) AS \"t0\"\nWHERE \"t0\".\"id\" = $1 AND \"t0\".\"time\" = $2 AND \"t0\".\"pk\" = $3\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"id\", \"orders_2\".\"time\", \"t\".\"pk\"\n  FROM \"orders_2\",\n    (VALUES  (1, 1),\n      (2, 2),\n      (3, 3),\n      (4, 4),\n      (4, 4)) AS \"t\" (\"id\", \"pk\")) AS \"t0\"\nWHERE \"t0\".\"id\" = $1 AND \"t0\".\"time\" = $2 AND \"t0\".\"pk\" = $3\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1181,7 +1181,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
@@ -444,7 +444,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -549,7 +549,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"order_count\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"orderagg1_1\"\nWHERE \"customer\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orderagg1_1\"\nWHERE \"customer\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -670,7 +670,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -851,7 +851,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\nFROM \"ordertime1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordertime1_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -981,7 +981,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\nFROM \"ordertime2_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordertime2_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1029,7 +1029,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customer\", \"bucket\", \"order_count\", 1 AS \"__pk\"\nFROM \"ordertime3_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordertime3_1\"\nWHERE \"customer\" = $1 AND \"bucket\" = $2\nORDER BY \"bucket\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1445,7 +1445,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamStateAggregateTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamStateAggregateTest.txt
@@ -300,7 +300,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"orders_2\".\"customerid\" AS \"customer\", COUNT(*) AS \"order_count\", MAX(\"orders_2\".\"time\") AS \"__timestamp\", 1 AS \"__pk\"\nFROM \"orders_2\"\n INNER JOIN \"customer_2\" ON \"orders_2\".\"customerid\" = \"customer_2\".\"customerid\"\nGROUP BY \"orders_2\".\"customerid\"\nHAVING \"orders_2\".\"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT \"orders_2\".\"customerid\" AS \"customer\", COUNT(*) AS \"order_count\", MAX(\"orders_2\".\"time\") AS \"__timestamp\"\nFROM \"orders_2\"\n INNER JOIN \"customer_2\" ON \"orders_2\".\"customerid\" = \"customer_2\".\"customerid\"\nGROUP BY \"orders_2\".\"customerid\"\nHAVING \"orders_2\".\"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -343,7 +343,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -531,7 +531,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1091,7 +1091,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableFunctionsBasic.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableFunctionsBasic.txt
@@ -261,7 +261,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -422,7 +422,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -926,7 +926,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
@@ -372,7 +372,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -738,7 +738,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1339,7 +1339,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
@@ -509,7 +509,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -567,7 +567,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"time\", \"id\", \"name\", \"customerid\", 1 AS \"__pk\"\nFROM \"ordercustomer_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordercustomer_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -605,7 +605,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"time\", \"id\", \"name\", \"customerid\", 1 AS \"__pk\"\nFROM \"ordercustomerconstant_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordercustomerconstant_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -663,7 +663,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"lastUpdated\", \"id\", \"name\", \"customerid\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"ordercustomerleft_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordercustomerleft_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -721,7 +721,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"time\", \"id\", \"customerid\", 1 AS \"__pk\"\nFROM \"ordercustomerleftexcluded_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordercustomerleftexcluded_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -837,7 +837,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"lastUpdated\", \"customerid\", \"name\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"ordercustomerrightexcluded_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"ordercustomerrightexcluded_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -895,7 +895,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orders_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1511,7 +1511,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
@@ -389,7 +389,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -899,7 +899,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"time\", \"id\", \"customerid\", 1 AS \"__pk\"\nFROM (SELECT \"orders_2\".\"time\", \"orders_2\".\"id\", \"orders_2\".\"customerid\"\n  FROM \"orders_2\"\n   LEFT JOIN \"customer_2\" ON \"orders_2\".\"customerid\" = \"customer_2\".\"customerid\"\n  WHERE \"customer_2\".\"customerid\" IS NULL AND \"customer_2\".\"lastUpdated\" IS NULL) AS \"t0\"\nWHERE \"t0\".\"time\" = $1 AND \"t0\".\"id\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT \"orders_2\".\"time\", \"orders_2\".\"id\", \"orders_2\".\"customerid\"\n  FROM \"orders_2\"\n   LEFT JOIN \"customer_2\" ON \"orders_2\".\"customerid\" = \"customer_2\".\"customerid\"\n  WHERE \"customer_2\".\"customerid\" IS NULL AND \"customer_2\".\"lastUpdated\" IS NULL) AS \"t0\"\nWHERE \"t0\".\"time\" = $1 AND \"t0\".\"id\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1025,7 +1025,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"lastUpdated\", \"customerid\", \"name\", \"__timestamp\", 1 AS \"__pk\"\nFROM (SELECT \"customer_2\".\"lastUpdated\", \"customer_2\".\"customerid\", \"customer_2\".\"name\", CASE WHEN \"customer_2\".\"timestamp\" < \"orders_2\".\"time\" THEN \"orders_2\".\"time\" ELSE \"customer_2\".\"timestamp\" END AS \"__timestamp\"\n  FROM \"customer_2\"\n   LEFT JOIN \"orders_2\" ON \"customer_2\".\"customerid\" = \"orders_2\".\"customerid\"\n  WHERE \"orders_2\".\"id\" IS NULL AND \"orders_2\".\"time\" IS NULL) AS \"t0\"\nWHERE \"t0\".\"lastUpdated\" = $1 AND \"t0\".\"customerid\" = $2\nORDER BY \"__timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT \"customer_2\".\"lastUpdated\", \"customer_2\".\"customerid\", \"customer_2\".\"name\", CASE WHEN \"customer_2\".\"timestamp\" < \"orders_2\".\"time\" THEN \"orders_2\".\"time\" ELSE \"customer_2\".\"timestamp\" END AS \"__timestamp\"\n  FROM \"customer_2\"\n   LEFT JOIN \"orders_2\" ON \"customer_2\".\"customerid\" = \"orders_2\".\"customerid\"\n  WHERE \"orders_2\".\"id\" IS NULL AND \"orders_2\".\"time\" IS NULL) AS \"t0\"\nWHERE \"t0\".\"lastUpdated\" = $1 AND \"t0\".\"customerid\" = $2\nORDER BY \"__timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1166,7 +1166,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1746,7 +1746,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableTemporalJoinWithTimeFilterTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableTemporalJoinWithTimeFilterTest.txt
@@ -274,7 +274,7 @@ LogicalProject(__pk1_customerid=[$1], category=[$2], num=[$3], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -312,7 +312,7 @@ LogicalProject(__pk1_customerid=[$1], category=[$2], num=[$3], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_customerid\", \"category\", \"num\", \"_time\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"totals_1\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t\"\nWHERE \"category\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"totals_1\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t\"\nWHERE \"category\" = $2",
               "parameters" : [
                 {
                   "type" : "source",
@@ -365,7 +365,7 @@ LogicalProject(__pk1_customerid=[$1], category=[$2], num=[$3], _time=[$0])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_3\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customer_3\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -428,7 +428,7 @@ LogicalProject(__pk1_customerid=[$1], category=[$2], num=[$3], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -533,7 +533,7 @@ LogicalProject(__pk1_customerid=[$1], category=[$2], num=[$3], _time=[$0])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_3\"\nWHERE \"productid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"product_3\"\nWHERE \"productid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
@@ -945,7 +945,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1049,7 +1049,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"num\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customeragg1_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customeragg1_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1127,7 +1127,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", COUNT(*) AS \"num\", MAX(\"_ingest_time\") AS \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE CURRENT_TIMESTAMP < (\"_ingest_time\" + INTERVAL '3600' SECOND(7))\nGROUP BY \"customerid\"\nHAVING \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT \"customerid\", COUNT(*) AS \"num\", MAX(\"_ingest_time\") AS \"__timestamp\"\nFROM \"customer_2\"\nWHERE CURRENT_TIMESTAMP < (\"_ingest_time\" + INTERVAL '3600' SECOND(7))\nGROUP BY \"customerid\"\nHAVING \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1185,7 +1185,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"num\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customeragg3_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customeragg3_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1418,7 +1418,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2075,7 +2075,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampColumnDefinitionWithPropagation.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampColumnDefinitionWithPropagation.txt
@@ -164,7 +164,7 @@ LogicalProject(month=[endOfMonth(endOfMonth($4))], timestamp=[$4], _customerid=[
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampReassignment.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/timestampReassignment.txt
@@ -381,7 +381,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -573,7 +573,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"updatedTime\", \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer2_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"updatedTime\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer2_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"updatedTime\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -683,7 +683,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", \"updatedTime\", 1 AS \"__pk\"\nFROM \"customer3_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer3_1\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -766,7 +766,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"updatedTime\", \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerbytime2_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbytime2_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -804,7 +804,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", \"updatedTime\", 1 AS \"__pk\"\nFROM \"customerbytime3_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerbytime3_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -949,7 +949,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"updatedTime\", \"customerid0\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"ordercustomerjoin_1\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordercustomerjoin_1\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -997,7 +997,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/topNTest.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/topNTest.txt
@@ -479,7 +479,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -604,7 +604,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -668,7 +668,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_customerid\", \"id\", \"_time\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"_time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_rownum\", RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_rank\", DENSE_RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_denserank\"\n      FROM \"distinctorders_1\") AS \"t\"\n    WHERE \"_rownum\" = \"_rank\" AND \"_denserank\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2\nORDER BY 1",
+              "sql" : "SELECT \"__pk1_customerid\", \"id\", \"_time\"\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"_time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_rownum\", RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_rank\", DENSE_RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"id\" DESC) AS \"_denserank\"\n      FROM \"distinctorders_1\") AS \"t\"\n    WHERE \"_rownum\" = \"_rank\" AND \"_denserank\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2",
               "parameters" : [
                 {
                   "type" : "source",
@@ -695,7 +695,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -836,7 +836,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_customerid\", \"id\", \"time\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_rownum\", RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_rank\", DENSE_RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_denserank\"\n      FROM \"distinctorderstime_1\") AS \"t\"\n    WHERE \"_rownum\" = \"_rank\" AND \"_denserank\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2 AND \"time\" = $3\nORDER BY 1",
+              "sql" : "SELECT \"__pk1_customerid\", \"id\", \"time\"\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_rownum\", RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_rank\", DENSE_RANK() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC, \"id\") AS \"_denserank\"\n      FROM \"distinctorderstime_1\") AS \"t\"\n    WHERE \"_rownum\" = \"_rank\" AND \"_denserank\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2 AND \"time\" = $3",
               "parameters" : [
                 {
                   "type" : "source",
@@ -868,7 +868,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -947,7 +947,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_customerid\", \"id\", \"time\", 1 AS \"__pk\", \"_rownum\"\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC) AS \"_rownum\"\n      FROM \"recentorders_1\") AS \"t\"\n    WHERE \"_rownum\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2 AND \"time\" = $3\nORDER BY \"__pk1_customerid\", \"_rownum\", 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM (SELECT *\n    FROM (SELECT \"__pk1_customerid\", \"id\", \"time\", ROW_NUMBER() OVER (PARTITION BY \"__pk1_customerid\" ORDER BY \"time\" DESC) AS \"_rownum\"\n      FROM \"recentorders_1\") AS \"t\"\n    WHERE \"_rownum\" <= 10) AS \"t0\"\n  WHERE \"__pk1_customerid\" = $1) AS \"t1\"\nWHERE \"id\" = $2 AND \"time\" = $3\nORDER BY \"__pk1_customerid\", \"_rownum\"",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1041,7 +1041,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerdistinct_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1079,7 +1079,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"_timestamp\", 1 AS \"__pk\"\nFROM \"customerid_1\"\nWHERE \"customerid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerid_1\"\nWHERE \"customerid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1195,7 +1195,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"orders_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1524,7 +1524,7 @@ LogicalProject(__pk1_customerid=[$4], id=[$0], time=[$2])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
@@ -331,7 +331,7 @@ LogicalAggregate(group=[{0}], num=[COUNT()])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"lastUpdated\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -450,7 +450,7 @@ LogicalAggregate(group=[{0}], num=[COUNT()])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1093,7 +1093,7 @@ LogicalAggregate(group=[{0}], num=[COUNT()])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
@@ -948,7 +948,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"email\", \"name\", \"lastUpdated\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customer_2\"\nWHERE \"customerid\" = $1 AND \"email\" = $2 AND \"name\" = $3 AND \"lastUpdated\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1011,7 +1011,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"entries\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"customerid\" = $2 AND \"time\" = $3\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1566,7 +1566,7 @@ LogicalTableScan(table=[[product_1]], hints=[[[WatermarkHint inheritPath:[] opti
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"name\", \"description\", \"category\", \"_ingest_time\", 1 AS \"__pk\"\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"product_2\"\nWHERE \"productid\" = $1 AND \"name\" = $2 AND \"description\" = $3 AND \"category\" = $4\nORDER BY \"_ingest_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb--package.txt
@@ -232,7 +232,7 @@ LogicalProject(id=[$0], hello=['hello world'], _updated_at=[$6])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan--.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan--.txt
@@ -282,7 +282,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -412,7 +412,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"phone\", \"address\", \"date_of_birth\", \"updated_at\", 1 AS \"__pk\"\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -460,7 +460,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"description\", \"interest_rate\", \"max_amount\", \"min_amount\", \"max_duration\", \"min_duration\", \"updated_at\", 1 AS \"__pk\"\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan-loan-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan-loan-package.txt
@@ -519,7 +519,7 @@ LogicalProject(__pk1_id=[$0], loan_type_id=[$1], total_amount=[$2], total_loans=
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"applications_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -563,7 +563,7 @@ LogicalProject(__pk1_id=[$0], loan_type_id=[$1], total_amount=[$2], total_loans=
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_3\"\nWHERE $1 = \"id\"\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"applications_3\"\nWHERE $1 = \"id\"",
               "parameters" : [
                 {
                   "type" : "source",
@@ -585,7 +585,7 @@ LogicalProject(__pk1_id=[$0], loan_type_id=[$1], total_amount=[$2], total_loans=
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"description\", \"interest_rate\", \"max_amount\", \"min_amount\", \"max_duration\", \"min_duration\", \"updated_at\", 1 AS \"__pk\"\nFROM \"loantypes_3\"\nWHERE $1 = \"id\"\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"loantypes_3\"\nWHERE $1 = \"id\"",
               "parameters" : [
                 {
                   "type" : "source",
@@ -613,7 +613,7 @@ LogicalProject(__pk1_id=[$0], loan_type_id=[$1], total_amount=[$2], total_loans=
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"phone\", \"address\", \"date_of_birth\", \"updated_at\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -696,7 +696,7 @@ LogicalProject(__pk1_id=[$0], loan_type_id=[$1], total_amount=[$2], total_loans=
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"description\", \"interest_rate\", \"max_amount\", \"min_amount\", \"max_duration\", \"min_duration\", \"updated_at\", 1 AS \"__pk\"\nFROM \"loantypes_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"loantypes_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-kafka-logging-kafka-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-kafka-logging-kafka-package.txt
@@ -132,7 +132,7 @@ LogicalTableScan(table=[[reuseddata_1]], hints=[[[WatermarkHint inheritPath:[] o
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"epoch_timestamp\", \"some_value\", \"timestamp\", 1 AS \"__pk\"\nFROM \"data_2\"\nWHERE \"id\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"data_2\"\nWHERE \"id\" = $1\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -210,7 +210,7 @@ LogicalTableScan(table=[[reuseddata_1]], hints=[[[WatermarkHint inheritPath:[] o
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"epoch_timestamp\", \"some_value\", \"timestamp\", \"ts\", 1 AS \"__pk\"\nFROM \"reuseddata_2\"\nWHERE \"id\" = $1\nORDER BY \"ts\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"reuseddata_2\"\nWHERE \"id\" = $1\nORDER BY \"ts\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/metrics--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/metrics--package.txt
@@ -239,7 +239,7 @@ type CreatedReading {
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"sensorid\", MAX(\"temp\") AS \"maxTemp\", MAX(\"__timestamp\") AS \"__timestamp\", 1 AS \"__pk\"\nFROM \"secreading_1\"\nWHERE \"timeSec\" >= CURRENT_TIMESTAMP - INTERVAL '1' MINUTE * 1\nGROUP BY \"sensorid\"\nHAVING \"sensorid\" = $1\nORDER BY 1",
+              "sql" : "SELECT \"sensorid\", MAX(\"temp\") AS \"maxTemp\", MAX(\"__timestamp\") AS \"__timestamp\"\nFROM \"secreading_1\"\nWHERE \"timeSec\" >= CURRENT_TIMESTAMP - INTERVAL '1' MINUTE * 1\nGROUP BY \"sensorid\"\nHAVING \"sensorid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/patient-sensor-patient-sensor-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/patient-sensor-patient-sensor-package.txt
@@ -372,7 +372,7 @@ Inputs: tempalert_1
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_groupId\", \"__pk3_created\", \"maxTemp\", \"minTemp\", 1 AS \"__pk\"\nFROM \"lasthour_1\"\nWHERE \"__pk1_groupId\" = $1 AND \"__pk3_created\" = $2\nORDER BY \"__pk3_created\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"lasthour_1\"\nWHERE \"__pk1_groupId\" = $1 AND \"__pk3_created\" = $2\nORDER BY \"__pk3_created\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -443,7 +443,7 @@ Inputs: tempalert_1
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"patientid\", \"avgTemp\", \"maxTemp\", \"minTemp\", \"_timeMin\", 1 AS \"__pk\"\nFROM \"patientlasthour_1\"\nWHERE \"patientid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"patientlasthour_1\"\nWHERE \"patientid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/postgres-log--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/postgres-log--package.txt
@@ -193,7 +193,7 @@ LogicalTableScan(table=[[event_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"_uuid\", \"ID\", \"EPOCH_TIMESTAMP\", \"SOME_VALUE\", \"TIMESTAMP\", \"event_time\", 1 AS \"__pk\"\nFROM \"data_2\"\nWHERE \"ID\" = $1\nORDER BY \"TIMESTAMP\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"data_2\"\nWHERE \"ID\" = $1\nORDER BY \"TIMESTAMP\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repo-repo-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repo-repo-package.txt
@@ -260,7 +260,7 @@ LogicalAggregate(group=[{0}], numPackages=[COUNT(DISTINCT $1)], __timestamp=[MAX
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"name\", \"_submissionTime\", 1 AS \"__pk\"\nFROM \"package_1\"\nWHERE \"name\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"package_1\"\nWHERE \"name\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -471,7 +471,7 @@ LogicalAggregate(group=[{0}], numPackages=[COUNT(DISTINCT $1)], __timestamp=[MAX
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"topicName\", \"numPackages\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"topicsearch_1\"\nWHERE \"topicName\" = $1\nORDER BY \"numPackages\" DESC, 1",
+              "sql" : "SELECT *\nFROM \"topicsearch_1\"\nWHERE \"topicName\" = $1\nORDER BY \"numPackages\" DESC",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro--package.txt
@@ -141,7 +141,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"timeSec\", \"number\", \"volume\", 1 AS \"__pk\"\nFROM \"ordercount_1\"\nWHERE \"timeSec\" = $1\nORDER BY \"timeSec\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"ordercount_1\"\nWHERE \"timeSec\" = $1\nORDER BY \"timeSec\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -204,7 +204,7 @@ LogicalTableScan(table=[[orders_1]], hints=[[[WatermarkHint inheritPath:[] optio
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"items\", \"_source_time\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"_source_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"_source_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-docs--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-docs--package.txt
@@ -801,7 +801,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -823,7 +823,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"first_order\", \"total_spend\", \"total_saved\", \"num_orders\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"order_stats_1\"\nWHERE \"__pk1_id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"order_stats_1\"\nWHERE \"__pk1_id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -845,7 +845,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -909,7 +909,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"productid\", \"num_orders\", \"total_quantity\", \"__timestamp\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC",
               "parameters" : [
                 {
                   "type" : "source",
@@ -936,7 +936,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1002,7 +1002,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE $1 = \"id\"\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE $1 = \"id\"",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1024,7 +1024,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"__pk3_time\", \"price\", \"saving\", 1 AS \"__pk\"\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1051,7 +1051,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"items\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1094,7 +1094,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"week\", \"spend\", \"saved\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"spending_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"week\" = $2\nORDER BY \"__pk1_id\", \"week\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"spending_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"week\" = $2\nORDER BY \"__pk1_id\", \"week\" DESC",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1147,7 +1147,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1205,7 +1205,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"email\", \"spend\", \"__timestamp16\", 1 AS \"__pk\"\nFROM \"customerswithspending_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customerswithspending_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1243,7 +1243,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"email\", \"__timestamp16\", 1 AS \"__pk\"\nFROM \"highspendingusers_1\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"highspendingusers_1\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1531,7 +1531,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"items\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1574,7 +1574,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1637,7 +1637,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"country\", \"month\", \"quantity\", \"spend\", \"weight\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"monthly_by_country_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"country\" = $2 AND \"month\" = $3\nORDER BY \"month\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"monthly_by_country_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"country\" = $2 AND \"month\" = $3\nORDER BY \"month\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1767,7 +1767,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package.txt
@@ -640,7 +640,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -662,7 +662,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"first_order\", \"total_spend\", \"total_saved\", \"num_orders\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"order_stats_1\"\nWHERE \"__pk1_id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"order_stats_1\"\nWHERE \"__pk1_id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -684,7 +684,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -748,7 +748,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"productid\", \"num_orders\", \"total_quantity\", \"__timestamp\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC",
               "parameters" : [
                 {
                   "type" : "source",
@@ -775,7 +775,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -841,7 +841,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE $1 = \"id\"\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE $1 = \"id\"",
               "parameters" : [
                 {
                   "type" : "source",
@@ -863,7 +863,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"__pk3_time\", \"price\", \"saving\", 1 AS \"__pk\"\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -890,7 +890,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"items\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -933,7 +933,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"week\", \"spend\", \"saved\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"spending_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"week\" = $2\nORDER BY \"__pk1_id\", \"week\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"spending_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"week\" = $2\nORDER BY \"__pk1_id\", \"week\" DESC",
               "parameters" : [
                 {
                   "type" : "source",
@@ -986,7 +986,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1138,7 +1138,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"items\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1201,7 +1201,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -1280,7 +1280,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"country\", \"month\", \"quantity\", \"spend\", \"weight\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"monthly_by_country_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"country\" = $2 AND \"month\" = $3\nORDER BY \"month\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"monthly_by_country_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"country\" = $2 AND \"month\" = $3\nORDER BY \"month\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -1374,7 +1374,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-mutation-seedshop-mutation-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-mutation-seedshop-mutation-package.txt
@@ -510,7 +510,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"category\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"category\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -551,7 +551,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"name\" = $2\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"name\" = $2",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -628,7 +628,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -751,7 +751,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"sizing\", \"weight_in_gram\", \"type\", \"category\", \"usda_id\", \"updated\", 1 AS \"__pk\"\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"name\" = $2 AND \"category\" = $3\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"products_3\"\nWHERE \"id\" = $1 AND \"name\" = $2 AND \"category\" = $3",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -858,7 +858,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"ip_address\", \"country\", \"changed_on\", \"timestamp\", \"country0\", 1 AS \"__pk\"\nFROM \"customers_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"customers_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -913,7 +913,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"__pk3_time\", \"price\", \"saving\", 1 AS \"__pk\"\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"totals_1\"\nWHERE \"__pk1_id\" = $1 AND \"__pk3_time\" = $2\nORDER BY \"__pk3_time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "source",
@@ -968,7 +968,7 @@ LogicalProject(__pk1_id=[$0], __pk3_time=[$1], price=[$2], saving=[$3])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"productid\", \"num_orders\", \"total_quantity\", \"__timestamp\", 1 AS \"__pk\"\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC, 1",
+              "sql" : "SELECT *\nFROM (SELECT *\n  FROM \"past_purchases_1\"\n  WHERE \"__pk1_id\" = $1) AS \"t\"\nWHERE \"productid\" = $2\nORDER BY \"__pk1_id\", \"num_orders\" DESC, \"total_quantity\" DESC",
               "parameters" : [
                 {
                   "type" : "source",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-teaser--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-teaser--package.txt
@@ -199,7 +199,7 @@ Inputs: productrevenue_1
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"week\", \"total\", \"saved\", 1 AS \"__pk\"\nFROM \"customerspending_1\"\nWHERE \"customerid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customerspending_1\"\nWHERE \"customerid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -380,7 +380,7 @@ Inputs: productrevenue_1
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"productid\", \"quantity\", \"unit_price\", \"discount\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -541,7 +541,7 @@ Inputs: productrevenue_1
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"week\", \"revenue\", 1 AS \"__pk\"\nFROM \"productrevenue_1\"\nWHERE \"productid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"productrevenue_1\"\nWHERE \"productid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-teaser-simple--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-teaser-simple--package.txt
@@ -195,7 +195,7 @@ LogicalAggregate(group=[{0, 1}], revenue=[SUM($2)]) hints[TumbleAggregationHint 
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"customerid\", \"week\", \"total\", \"saved\", 1 AS \"__pk\"\nFROM \"customerspending_1\"\nWHERE \"customerid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC, 1",
+              "sql" : "SELECT *\nFROM \"customerspending_1\"\nWHERE \"customerid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -376,7 +376,7 @@ LogicalAggregate(group=[{0, 1}], revenue=[SUM($2)]) hints[TumbleAggregationHint 
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customerid\", \"time\", \"productid\", \"quantity\", \"unit_price\", \"discount\", \"total\", 1 AS \"__pk\"\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"orders_2\"\nWHERE \"id\" = $1 AND \"time\" = $2\nORDER BY \"time\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -537,7 +537,7 @@ LogicalAggregate(group=[{0, 1}], revenue=[SUM($2)]) hints[TumbleAggregationHint 
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"productid\", \"week\", \"revenue\", 1 AS \"__pk\"\nFROM \"productrevenue_1\"\nWHERE \"productid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC, 1",
+              "sql" : "SELECT *\nFROM \"productrevenue_1\"\nWHERE \"productid\" = $1 AND \"week\" = $2\nORDER BY \"week\" DESC",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full--package.txt
@@ -375,7 +375,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"machineid\", \"sensorid\", \"temp\", \"timeSec\", 1 AS \"__pk\"\nFROM \"hightemp_1\"\nWHERE \"sensorid\" = $1 AND \"timeSec\" = $2\nORDER BY \"timeSec\" DESC, 1",
+              "sql" : "SELECT *\nFROM \"hightemp_1\"\nWHERE \"sensorid\" = $1 AND \"timeSec\" = $2\nORDER BY \"timeSec\" DESC",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -480,7 +480,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"machineid\", \"maxTemp\", \"avgTemp\", \"_timeSec\", 1 AS \"__pk\"\nFROM \"machine_1\"\nWHERE \"machineid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"machine_1\"\nWHERE \"machineid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -555,7 +555,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"__pk1_id\", \"maxTemp\", \"avgTemp\", \"_timeSec\", 1 AS \"__pk\"\nFROM \"lasthour_1\"\nWHERE \"__pk1_id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"lasthour_1\"\nWHERE \"__pk1_id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -577,7 +577,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"id\", \"machineId\", \"placed\", \"timestamp\", 1 AS \"__pk\"\nFROM \"sensors_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"sensors_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "source",
@@ -673,7 +673,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"sensorid\", \"timeSec\", \"temp\", 1 AS \"__pk\"\nFROM \"secreading_1\"\nWHERE \"sensorid\" = $1 AND \"timeSec\" = $2\nORDER BY \"timeSec\" DESC, 1",
+              "sql" : "SELECT *\nFROM \"secreading_1\"\nWHERE \"sensorid\" = $1 AND \"timeSec\" = $2\nORDER BY \"timeSec\" DESC",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -811,7 +811,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"sensorid\", \"time\", \"temperature\", \"humidity\", \"timestamp\", 1 AS \"__pk\"\nFROM \"sensorreading_2\"\nWHERE \"sensorid\" = $1 AND \"time\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"sensorreading_2\"\nWHERE \"sensorid\" = $1 AND \"time\" = $2\nORDER BY \"timestamp\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -956,7 +956,7 @@ LogicalTableScan(table=[[sensors_2]])
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"machineId\", \"placed\", \"timestamp\", 1 AS \"__pk\"\nFROM \"sensors_3\"\nWHERE \"id\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"sensors_3\"\nWHERE \"id\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-sensors-mutation-package.txt
@@ -194,7 +194,7 @@ LogicalTableScan(table=[[sensorreading_1]], hints=[[[WatermarkHint inheritPath:[
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"sensorid\", \"maxTemp\", \"__timestamp\", 1 AS \"__pk\"\nFROM \"sensormaxtemp_1\"\nWHERE \"sensorid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"sensormaxtemp_1\"\nWHERE \"sensorid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-sensors-teaser-package.txt
@@ -162,7 +162,7 @@ LogicalTableScan(table=[[sensorreading_1]], hints=[[[WatermarkHint inheritPath:[
             "query" : {
               "type" : "JdbcQuery",
               "type" : "JdbcQuery",
-              "sql" : "SELECT \"sensorid\", \"maxTemp\", \"_timeSec\", 1 AS \"__pk\"\nFROM \"sensormaxtemp_1\"\nWHERE \"sensorid\" = $1\nORDER BY 1",
+              "sql" : "SELECT *\nFROM \"sensormaxtemp_1\"\nWHERE \"sensorid\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/snowflake--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/snowflake--package.txt
@@ -101,7 +101,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
         },
         {
           "name" : "Query.MyIcebergTable-8",
-          "sql" : "CREATE OR REPLACE VIEW Query.MyIcebergTable-8(id, customer_id, loan_type_id, amount, duration, application_date, updated_at, __pk)\nAS SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1"
+          "sql" : "CREATE OR REPLACE VIEW Query.MyIcebergTable-8(id, customer_id, loan_type_id, amount, duration, application_date, updated_at)\nAS SELECT *\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST"
         },
         {
           "name" : "Query.MyIcebergTable-7",
@@ -117,7 +117,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
         },
         {
           "name" : "Query.applications-4",
-          "sql" : "CREATE OR REPLACE VIEW Query.applications-4(id, customer_id, loan_type_id, amount, duration, application_date, updated_at, __pk)\nAS SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM applications_2\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1"
+          "sql" : "CREATE OR REPLACE VIEW Query.applications-4(id, customer_id, loan_type_id, amount, duration, application_date, updated_at)\nAS SELECT *\nFROM applications_2\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST"
         },
         {
           "name" : "Query.applications-3",
@@ -133,7 +133,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
         },
         {
           "name" : "Query.MySnowflakeTable-12",
-          "sql" : "CREATE OR REPLACE VIEW Query.MySnowflakeTable-12(id, customer_id, loan_type_id, amount, duration, application_date, updated_at, __pk)\nAS SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1"
+          "sql" : "CREATE OR REPLACE VIEW Query.MySnowflakeTable-12(id, customer_id, loan_type_id, amount, duration, application_date, updated_at)\nAS SELECT *\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST"
         },
         {
           "name" : "Query.MySnowflakeTable-11",
@@ -233,7 +233,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
             "query" : {
               "type" : "PagedSnowflakeDbQuery",
               "type" : "PagedSnowflakeDbQuery",
-              "sql" : "SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM applications_2\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM applications_2\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -363,7 +363,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
             "query" : {
               "type" : "PagedSnowflakeDbQuery",
               "type" : "PagedSnowflakeDbQuery",
-              "sql" : "SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -462,7 +462,7 @@ LogicalTableScan(table=[[myicebergtable_1]])
             "query" : {
               "type" : "PagedSnowflakeDbQuery",
               "type" : "PagedSnowflakeDbQuery",
-              "sql" : "SELECT id, customer_id, loan_type_id, amount, duration, application_date, updated_at, 1 AS __pk\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM myicebergtable_1\nWHERE id = ? AND updated_at = ?\nORDER BY updated_at DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/src--.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/src--.txt
@@ -282,7 +282,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -412,7 +412,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"phone\", \"address\", \"date_of_birth\", \"updated_at\", 1 AS \"__pk\"\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -460,7 +460,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"description\", \"interest_rate\", \"max_amount\", \"min_amount\", \"max_duration\", \"min_duration\", \"updated_at\", 1 AS \"__pk\"\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/src--package.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/src--package.txt
@@ -282,7 +282,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"customer_id\", \"loan_type_id\", \"amount\", \"duration\", \"application_date\", \"updated_at\", 1 AS \"__pk\"\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"applications_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -412,7 +412,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"first_name\", \"last_name\", \"email\", \"phone\", \"address\", \"date_of_birth\", \"updated_at\", 1 AS \"__pk\"\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"customers_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -460,7 +460,7 @@ LogicalTableScan(table=[[loantypes_1]], hints=[[[WatermarkHint inheritPath:[] op
             "query" : {
               "type" : "PagedJdbcQuery",
               "type" : "PagedJdbcQuery",
-              "sql" : "SELECT \"id\", \"name\", \"description\", \"interest_rate\", \"max_amount\", \"min_amount\", \"max_duration\", \"min_duration\", \"updated_at\", 1 AS \"__pk\"\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST, 1",
+              "sql" : "SELECT *\nFROM \"loantypes_2\"\nWHERE \"id\" = $1 AND \"updated_at\" = $2\nORDER BY \"updated_at\" DESC NULLS LAST",
               "parameters" : [
                 {
                   "type" : "arg",


### PR DESCRIPTION
Don't add a static primary key for queries, since we only need those for tables that are written to the database.