### PR TITLE
Enable Separate Validation for the Package Field During Publishing

### DIFF
--- a/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/SqrlConfigCommons.java
+++ b/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/SqrlConfigCommons.java
@@ -355,6 +355,10 @@ public class SqrlConfigCommons implements SqrlConfig {
     return new PackageJsonImpl(fromFiles(errors, "/jsonSchema/packageSchema.json", files));
   }
 
+  public static PackageJson fromFilesPublishPackageJson(ErrorCollector errors, @NonNull List<Path> files) {
+    return new PackageJsonImpl(fromFiles(errors, "/jsonSchema/publishPackageSchema.json", files));
+  }
+
   public static boolean validateJsonFile(Path jsonFilePath, String schemaResourcePath,
       ErrorCollector errors) {
     if (schemaResourcePath == null)

--- a/sqrl-tools/sqrl-config/src/main/resources/jsonSchema/publishPackageSchema.json
+++ b/sqrl-tools/sqrl-config/src/main/resources/jsonSchema/publishPackageSchema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "package": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "variant": {
+          "type": "string"
+        },
+        "latest": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "readme": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri"
+        },
+        "homepage": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string",
+          "format": "uri"
+        },
+        "topics": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["name", "version", "latest"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Publisher.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Publisher.java
@@ -27,7 +27,7 @@ public class Publisher {
         Preconditions.checkArgument(Files.isDirectory(packageRoot));
         Path packageInfo = packageRoot.resolve(Packager.PACKAGE_JSON);
         errors.checkFatal(Files.isRegularFile(packageInfo),"Directory does not contain [%s] package configuration file", packageInfo);
-        PackageJson pkgConfig = SqrlConfigCommons.fromFilesPackageJson(errors, List.of(packageInfo));
+        PackageJson pkgConfig = SqrlConfigCommons.fromFilesPublishPackageJson(errors, List.of(packageInfo));
 
         try {
             PackageConfigurationImpl packageConfig = (PackageConfigurationImpl) pkgConfig.getPackageConfig();

--- a/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/PublisherTest.java
+++ b/sqrl-tools/sqrl-packager/src/test/java/com/datasqrl/packager/PublisherTest.java
@@ -1,0 +1,70 @@
+package com.datasqrl.packager;
+
+import com.datasqrl.config.PackageConfiguration;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.packager.repository.PublishRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PublisherTest {
+
+  private Publisher publisher;
+
+  @Mock
+  private ErrorCollector errorCollector;
+
+  @Mock
+  private PublishRepository publishRepository;
+
+  @BeforeEach
+  void setUp() {
+    publisher = new Publisher(errorCollector);
+  }
+
+  @Test
+  @SneakyThrows
+  void testPublishSuccess_validPackageJson() {
+    // Arrange
+    Path validPackagePath = Paths.get(getClass().getClassLoader().getResource("publisher/valid").toURI());
+
+    when(publishRepository.publish(any(Path.class), any())).thenReturn(true);
+    when(errorCollector.withConfig(any(Path.class))).thenReturn(errorCollector);
+    when(errorCollector.withConfig(any(String.class))).thenReturn(errorCollector);
+
+    // Act
+    PackageConfiguration result = publisher.publish(validPackagePath, publishRepository);
+
+    // Assert
+    assertNotNull(result, "The package should have been published successfully.");
+    verify(errorCollector, never()).checkFatal(anyBoolean(), anyString(), any(Object[].class));
+  }
+
+  @Test
+  @SneakyThrows
+  void testPublishFailure_invalidPackageJson() {
+    // Arrange
+    Path validPackagePath = Paths.get(getClass().getClassLoader().getResource("publisher/invalid").toURI());
+
+    when(errorCollector.withConfig(any(Path.class))).thenReturn(errorCollector);
+    when(errorCollector.abortOnFatal(any(Boolean.class))).thenReturn(errorCollector);
+    when(errorCollector.exception(any(String.class), any())).thenReturn(new RuntimeException("Invalid package.json"));
+
+    // Act & Assert
+    assertThrows(RuntimeException.class, () -> {
+      PackageConfiguration result = publisher.publish(validPackagePath, publishRepository);
+    }, "Expected an exception due to invalid package.json");
+
+    verify(errorCollector, times(1)).fatal(any(String.class), eq("$.package: required property 'name' not found"), any());
+  }
+
+}

--- a/sqrl-tools/sqrl-packager/src/test/resources/publisher/invalid/package.json
+++ b/sqrl-tools/sqrl-packager/src/test/resources/publisher/invalid/package.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "package": {
+    "version": "0.5.5_test",
+    "variant": "default",
+    "latest": true,
+    "type": "source",
+    "license": "ASFv2",
+    "repository": "https://github.com/DataSQRL/datasqrl-examples/tree/main/logistics-shipping-geodata",
+    "homepage": "https://github.com/DataSQRL/datasqrl-examples/tree/main/logistics-shipping-geodata",
+    "description": "A Description",
+    "documentation": "https://github.com/DataSQRL/datasqrl-examples/blob/main/logistics-shipping-geodata/README.md",
+    "topics": ["datasqrl", "example", "logistics", "shipping"]
+  }
+}

--- a/sqrl-tools/sqrl-packager/src/test/resources/publisher/valid/package.json
+++ b/sqrl-tools/sqrl-packager/src/test/resources/publisher/valid/package.json
@@ -1,0 +1,16 @@
+{
+  "version": "1",
+  "package": {
+    "name": "datasqrl.examples.logistics",
+    "version": "0.5.5_test",
+    "variant": "default",
+    "latest": true,
+    "type": "source",
+    "license": "ASFv2",
+    "repository": "https://github.com/DataSQRL/datasqrl-examples/tree/main/logistics-shipping-geodata",
+    "homepage": "https://github.com/DataSQRL/datasqrl-examples/tree/main/logistics-shipping-geodata",
+    "description": "A Description",
+    "documentation": "https://github.com/DataSQRL/datasqrl-examples/blob/main/logistics-shipping-geodata/README.md",
+    "topics": ["datasqrl", "example", "logistics", "shipping"]
+  }
+}


### PR DESCRIPTION
This pull request introduces separate validation for the package field during publishing by adding a new method in SqrlConfigCommons, a new JSON schema, and updating the Publisher class to use this new method.