### PR TITLE
Adding some more logging to the tests

### DIFF
--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -165,6 +165,14 @@ public class FullUsecasesIT {
       env.putAll(containerHook.getEnv());
       env.put("DATA_PATH", rootDir.resolve("build/deploy/flink/data").toAbsolutePath().toString());
 
+      // Log test run
+      log.info("The test parameters\n" +
+               "Test name: " + param.getTestName() + "\n" +
+               "Test path: " + rootDir + "\n" +
+               "Test sqrl file: " + param.getSqrlFileName() + "\n" +
+               "Test graphql file: " + param.getGraphqlFileName() + "\n"
+      );
+
       //Run the test
       TestEnvContext context = TestEnvContext.builder()
           .env(env)


### PR DESCRIPTION
Added a log to the usecases tst runner, it will make reading the logs easier. 
Previously there was no easy way to check which usecase the output belonged to. 