### PR TITLE
Implement a Math Functions Package

### DIFF
--- a/sqrl-flink-lib/pom.xml
+++ b/sqrl-flink-lib/pom.xml
@@ -31,6 +31,7 @@
     <module>sqrl-flexible-csv</module>
     <module>sqrl-name</module>
     <module>sqrl-errors</module>
+    <module>sqrl-math</module>
   </modules>
 
   <description>Parent pom</description>

--- a/sqrl-flink-lib/sqrl-math/pom.xml
+++ b/sqrl-flink-lib/sqrl-math/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.datasqrl</groupId>
+    <artifactId>sqrl-flink-lib</artifactId>
+    <version>0.5.7-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>sqrl-math</artifactId>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-api-java-bridge</artifactId>
+      <version>1.19.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>3.6.1</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/abs.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/abs.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.AbsFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/cos.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/cos.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.CosFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/exp.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/exp.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.ExpFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/log.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/log.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.LogFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/log10.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/log10.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.Log10Function","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/max.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/max.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.MaxFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/min.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/min.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.MinFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/package.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/package.json
@@ -1,0 +1,16 @@
+{
+  "version": "1",
+  "package": {
+    "name": "datasqrl.functions.math",
+    "version": "0.5.5",
+    "variant": "default",
+    "latest": true,
+    "type": "source",
+    "license": "ASFv2",
+    "repository": "https://todo.com",
+    "homepage": "https://todo.com",
+    "description": "todo",
+    "documentation": "https://todo.com/README.md",
+    "topics": ["datasqrl", "function", "math"]
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/pow.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/pow.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.PowFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/round.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/round.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.RoundFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/sin.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/sin.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.SinFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/sqrt.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/sqrt.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.SqrtFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/tan.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/tan.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.TanFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/to_degress.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/to_degress.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.ToDegreesFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/sqrl-package/to_radians.function.json
+++ b/sqrl-flink-lib/sqrl-math/sqrl-package/to_radians.function.json
@@ -1,0 +1,1 @@
+{"language":"java","functionClass":"com.datasqrl.math.ToRadiansFunction","jarPath":"datasqrl/functions/math/sqrl-math-0.5.7-SNAPSHOT.jar"}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/AbsFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/AbsFunction.java
@@ -1,0 +1,24 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class AbsFunction extends ScalarFunction {
+  public int eval(int x) {
+    return FastMath.abs(x);
+  }
+
+  public long eval(long x) {
+    return FastMath.abs(x);
+  }
+
+  public float eval(float x) {
+    return FastMath.abs(x);
+  }
+
+  public double eval(double x) {
+    return FastMath.abs(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/CosFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/CosFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class CosFunction extends ScalarFunction {
+  public double eval(double x) {
+    return FastMath.cos(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ExpFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ExpFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class ExpFunction extends ScalarFunction{
+  public double eval(double x) {
+    return FastMath.exp(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/Log10Function.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/Log10Function.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class Log10Function extends ScalarFunction {
+  public double eval(double x) {
+    return FastMath.log10(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/LogFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/LogFunction.java
@@ -1,0 +1,11 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class LogFunction extends ScalarFunction {
+  public double eval(double x) {
+    return Math.log(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/MaxFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/MaxFunction.java
@@ -1,0 +1,24 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class MaxFunction extends ScalarFunction {
+  public int eval(int a, int b) {
+    return FastMath.max(a, b);
+  }
+
+  public long eval(long a, long b) {
+    return FastMath.max(a, b);
+  }
+
+  public float eval(float a, float b) {
+    return FastMath.max(a, b);
+  }
+
+  public double eval(double a, double b) {
+    return FastMath.max(a, b);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/MinFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/MinFunction.java
@@ -1,0 +1,24 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class MinFunction extends ScalarFunction {
+  public int eval(int a, int b) {
+    return FastMath.min(a, b);
+  }
+
+  public long eval(long a, long b) {
+    return FastMath.min(a, b);
+  }
+
+  public float eval(float a, float b) {
+    return FastMath.min(a, b);
+  }
+
+  public double eval(double a, double b) {
+    return FastMath.min(a, b);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/PowFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/PowFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class PowFunction extends ScalarFunction {
+  public double eval(double base, double exponent) {
+    return FastMath.pow(base, exponent);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/RoundFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/RoundFunction.java
@@ -1,0 +1,16 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class RoundFunction extends ScalarFunction {
+  public double eval(float x) {
+    return FastMath.round(x);
+  }
+
+  public double eval(double x) {
+    return FastMath.round(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/SinFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/SinFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class SinFunction extends ScalarFunction {
+  public double eval(double x) {
+    return FastMath.sin(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/SqrtFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/SqrtFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class SqrtFunction extends ScalarFunction {
+  public double eval(double x) {
+    return FastMath.sqrt(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/TanFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/TanFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class TanFunction extends ScalarFunction {
+  public double fastTan(double x) {
+    return FastMath.tan(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ToDegreesFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ToDegreesFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class ToDegreesFunction extends ScalarFunction {
+  public double eval(double x) {
+    return FastMath.toDegrees(x);
+  }
+}

--- a/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ToRadiansFunction.java
+++ b/sqrl-flink-lib/sqrl-math/src/main/java/com/datasqrl/math/ToRadiansFunction.java
@@ -1,0 +1,12 @@
+package com.datasqrl.math;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.flink.table.functions.ScalarFunction;
+
+@AutoService(ScalarFunction.class)
+public class ToRadiansFunction extends ScalarFunction{
+  public double eval(double x) {
+    return FastMath.toRadians(x);
+  }
+}


### PR DESCRIPTION
These functions are currently deployed as nsabonyi.functions.math package and can be tested by modifying the udf example:

sqrl:
```
IMPORT myudf.Entry;
IMPORT nsabonyi.examples.udf.MyScalarFunction;
IMPORT nsabonyi.functions.math.ToRadiansFunction;

MyTable := SELECT val, MyScalarFunction(val, val) AS myFnc, ToRadiansFunction(val) AS mySecondFnc
           FROM Entry;
```

graphql:
```
type Query {
  myTable(limit: Int = 10, offset: Int = 0): [MyTable!]
}

type MyTable {
  val: Int!
  myFnc: Int!
  mySecondFnc: Float!
}

type Mutation {
  entry(input: Entry!): EntryResponse!
}

input Entry {
  val: Int!
}

type EntryResponse {
  val: Int!
}

```