### PR TITLE
Specify additional sources when creating a package

### DIFF
--- a/sqrl-base/src/main/java/com/datasqrl/config/PackageConfiguration.java
+++ b/sqrl-base/src/main/java/com/datasqrl/config/PackageConfiguration.java
@@ -29,6 +29,8 @@ public interface PackageConfiguration {
 
   List<String> getTopics();
 
+  List<String> getSources();
+
   void checkInitialized();
 
   Dependency asDependency();

--- a/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/PackageConfigurationImpl.java
+++ b/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/PackageConfigurationImpl.java
@@ -48,6 +48,8 @@ public class PackageConfigurationImpl implements PackageConfiguration {
   String description = "";
   @Default
   List<String> topics = List.of();
+  @Default
+  List<String> sources = List.of();
 
   public void checkInitialized() {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(getName()) &&

--- a/sqrl-tools/sqrl-config/src/main/resources/jsonSchema/publishPackageSchema.json
+++ b/sqrl-tools/sqrl-config/src/main/resources/jsonSchema/publishPackageSchema.json
@@ -47,6 +47,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": ["name", "version", "latest"],

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Publisher.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Publisher.java
@@ -33,9 +33,11 @@ public class Publisher {
             PackageConfigurationImpl packageConfig = (PackageConfigurationImpl) pkgConfig.getPackageConfig();
             addReadme(packageRoot, packageConfig);
 
+            Path[] sources = packageConfig.getSources().stream().map(Path::of).toArray(Path[]::new);
+
             Path zipFile = Files.createTempFile(packageRoot, "package", Zipper.ZIP_EXTENSION);
             try {
-                Zipper.compress(zipFile, packageRoot);
+                Zipper.compress(zipFile, packageRoot, sources);
                 if (publishRepo.publish(zipFile, packageConfig)) {
                     return packageConfig;
                 } else {

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/Publication.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/Publication.java
@@ -24,7 +24,7 @@ public class Publication extends PackageConfigurationImpl {
         super(pkg.getName(), pkg.getVersion(), pkg.getVariant(), pkg.getLatest(), orEmpty(pkg.getType()),
             orEmpty(pkg.getLicense()),
             orEmpty(pkg.getRepository()), orEmpty(pkg.getHomepage()), orEmpty(pkg.getDocumentation()),
-            orEmpty(pkg.getReadme()), orEmpty(pkg.getDescription()), pkg.getTopics());
+            orEmpty(pkg.getReadme()), orEmpty(pkg.getDescription()), pkg.getTopics(), pkg.getSources());
         pkg.checkInitialized();
         this.uniqueId = uniqueId;
         this.file = file;

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
@@ -14,7 +14,7 @@ public class Zipper {
 
     public static final String ZIP_EXTENSION = ".zip";
 
-    public static void compress(Path zipFile, Path directory) throws IOException {
+    public static void compress(Path zipFile, Path directory, Path... additionalFiles) throws IOException {
         Files.deleteIfExists(zipFile);
         ExcludeFileFilter excludeFilter = file -> file.getName().endsWith(ZIP_EXTENSION);
         ZipParameters zipParameters = new ZipParameters();
@@ -23,6 +23,10 @@ public class Zipper {
         for (Path p : Files.list(directory).collect(Collectors.toList())) {
             if (Files.isRegularFile(p) && !FileUtil.isExtension(p, ZIP_EXTENSION)) zip.addFile(p.toFile());
             else if (Files.isDirectory(p)) zip.addFolder(p.toFile(), zipParameters);
+        }
+        for (Path additionalFile : additionalFiles) {
+            if (Files.isRegularFile(additionalFile)) zip.addFile(additionalFile.toFile());
+            else if (Files.isDirectory(additionalFile)) zip.addFolder(additionalFile.toFile(), zipParameters);
         }
     }
 


### PR DESCRIPTION
When publishing a package, files are taken from the package root. However, additional sources, like build-generated files (e.g., .jar), may need inclusion. For instance, when publishing a UDF, metadata is stored in the root, while the UDF itself is compiled into a .jar in the target folder. Instead of using a separate script to assemble the package before publishing, it is more robust to include additional sources directly in the package.json. See an example https://github.com/DataSQRL/sqrl-functions/pull/1.