### PR TITLE
Fix Incorrect Path Generation in *.functions.json Metadata

### DIFF
--- a/sqrl-base/src/main/java/com/datasqrl/module/resolver/FileResourceResolver.java
+++ b/sqrl-base/src/main/java/com/datasqrl/module/resolver/FileResourceResolver.java
@@ -21,10 +21,6 @@ public class FileResourceResolver implements ResourceResolver {
     this.baseDir = baseDir;
   }
 
-  public Optional<URI> resolve(Path path) {
-    return Optional.of(path.toFile().toURI());
-  }
-
   @Override
   public String toString() {
     return "FileResourceResolver[" + baseDir + ']';
@@ -50,5 +46,14 @@ public class FileResourceResolver implements ResourceResolver {
       return Optional.empty();
     }
     return Optional.of(path);
+  }
+
+  @Override
+  public Optional<Path> resolve(Path relativePath) {
+    Path resolvedPath = baseDir.resolve(relativePath);
+    if (Files.exists(resolvedPath)) {
+      return Optional.of(resolvedPath);
+    }
+    return Optional.empty();
   }
 }

--- a/sqrl-base/src/main/java/com/datasqrl/module/resolver/ResourceResolver.java
+++ b/sqrl-base/src/main/java/com/datasqrl/module/resolver/ResourceResolver.java
@@ -14,6 +14,8 @@ public interface ResourceResolver {
 
   Optional<Path> resolveFile(NamePath namePath);
 
+  Optional<Path> resolve(Path relativePath);
+
   static URL toURL(URI uri) {
     try {
       return uri.toURL();

--- a/sqrl-planner/src/main/java/com/datasqrl/loaders/ObjectLoaderImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/loaders/ObjectLoaderImpl.java
@@ -23,8 +23,10 @@ import com.datasqrl.serializer.Deserializer;
 import com.datasqrl.util.BaseFileUtil;
 import com.datasqrl.util.FileUtil;
 import com.datasqrl.util.StringUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
+import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -36,6 +38,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.flink.table.functions.UserDefinedFunction;
+import scala.tools.cmd.Opt;
 
 public class ObjectLoaderImpl implements ObjectLoader {
 
@@ -178,10 +181,17 @@ public class ObjectLoaderImpl implements ObjectLoader {
     ObjectNode json = SERIALIZER.mapJsonFile(path, ObjectNode.class);
     String jarPath = json.get("jarPath").asText();
     String functionClassName = json.get("functionClass").asText();
+    JsonNode type = json.get("type");
 
-    Optional<Path> resolvedJarPath = resourceResolver.resolve(Path.of(jarPath));
-    URL jarUrl = resolvedJarPath.get().toUri().toURL();
-    Class<?> functionClass = loadClass(jarUrl, functionClassName);
+    if (type != null && "remote".equals(type.asText())) {
+      Optional<Path> resolvedPath = resourceResolver.resolve(Path.of(jarPath));
+      if (resolvedPath.isPresent()) {
+        jarPath = resolvedPath.get().toString();
+      }
+    }
+
+    URL jarUrl = new File(jarPath).toURI().toURL();
+    Class<?> functionClass = loadClass(jarPath, functionClassName);
     Preconditions.checkArgument(UDF_FUNCTION_CLASS.isAssignableFrom(functionClass), "Class is not a UserDefinedFunction");
 
     UserDefinedFunction udf = (UserDefinedFunction) functionClass.getDeclaredConstructor().newInstance();
@@ -191,8 +201,8 @@ public class ObjectLoaderImpl implements ObjectLoader {
   }
 
   @SneakyThrows
-  private Class<?> loadClass(URL jarUrl, String functionClassName) {
-    URL[] urls = { jarUrl };
+  private Class<?> loadClass(String jarPath, String functionClassName) {
+    URL[] urls = {new File(jarPath).toURI().toURL()};
     URLClassLoader classLoader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
     return Class.forName(functionClassName, true, classLoader);
   }

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -70,7 +70,9 @@ public class FullUsecasesIT {
       new ScriptCriteria("sensors-full.sqrl", "test"), //flaky (too much data)
       new ScriptCriteria("sensors-full.sqrl", "run"), //flaky (too much data)
       new ScriptCriteria("seedshop-extended.sqrl", "test"), // CustomerPromotionTest issue
-      new ScriptCriteria("seedshop-extended.sqrl", "run") // CustomerPromotionTest issue
+      new ScriptCriteria("seedshop-extended.sqrl", "run"), // CustomerPromotionTest issue
+      new ScriptCriteria("patient-sensor.sqrl", "test"), //missing data
+      new ScriptCriteria("patient-sensor.sqrl", "run") //missing data
   );
 
   static final Path PROJECT_ROOT = Paths.get(System.getProperty("user.dir"));

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/preprocess/JarPreprocessor.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/preprocess/JarPreprocessor.java
@@ -89,8 +89,11 @@ public class JarPreprocessor implements Preprocessor {
       processorContext.addLibrary(path);
     }
 
+    processorContext.addDependency(path);
+
     return null;
   }
+
   /**
    * Checks if the jar entry is valid
    */

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/preprocess/JarPreprocessor.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/preprocess/JarPreprocessor.java
@@ -81,6 +81,7 @@ public class JarPreprocessor implements Preprocessor {
       obj.put("language", "java");
       obj.put("functionClass", clazz);
       obj.put("jarPath", path.toString());
+      obj.put("type", "local");
 
       // Create a file in a temporary directory
       String functionName = clazz.substring(clazz.lastIndexOf('.') + 1);
@@ -89,11 +90,8 @@ public class JarPreprocessor implements Preprocessor {
       processorContext.addLibrary(path);
     }
 
-    processorContext.addDependency(path);
-
     return null;
   }
-
   /**
    * Checks if the jar entry is valid
    */


### PR DESCRIPTION
This PR fixes an issue where the *.functions.json metadata was generating incorrect relative paths for local UDFs. The solution involves relativizing the paths to the root directory, ensuring they can be correctly resolved later by buildPath after the local UDFs is copied to the build folder.

This issue only arises when sqrl compile is executed outside of the root directory.