### PR TITLE
Exclude like from imported flink functions

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/functions/flink/FlinkStdLibraryImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/functions/flink/FlinkStdLibraryImpl.java
@@ -58,7 +58,8 @@ public class FlinkStdLibraryImpl extends AbstractFunctionModule implements StdLi
       "WITHOUT_COLUMNS",
       "AS",
       "STREAM_RECORD_TIMESTAMP",
-      "RANGE_TO"
+      "RANGE_TO",
+      "LIKE"
   );
 
   private static List<NamespaceObject> SQL_FUNCTIONS = getAllFunctionsFromFlink();


### PR DESCRIPTION
Resolves #949

Like appears to be overloaded in flink to support string types, but we alias string with varchar types so it is not an issue to use our std functions.