### PR TITLE
Pre-loaded Profiles

### DIFF
--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/AbstractCompilerCommand.java
@@ -25,6 +25,7 @@ import com.datasqrl.packager.repository.CompositeRepositoryImpl;
 import com.datasqrl.packager.repository.LocalRepositoryImplementation;
 import com.datasqrl.packager.repository.RemoteRepositoryImplementation;
 import com.datasqrl.packager.repository.Repository;
+import com.datasqrl.packager.repository.StaticRepository;
 import com.datasqrl.plan.validate.ExecutionGoal;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.jdbc.SqrlSchema;
+import org.apache.calcite.util.Static;
 import org.apache.commons.lang3.tuple.Pair;
 import picocli.CommandLine;
 
@@ -162,12 +164,13 @@ public abstract class AbstractCompilerCommand extends AbstractCommand {
   }
 
   protected Repository createRepository(ErrorCollector errors) {
+    StaticRepository staticRepo = new StaticRepository();
     LocalRepositoryImplementation localRepo = LocalRepositoryImplementation.of(errors,
         root.rootDir);
     //TODO: read remote repository URLs from configuration?
     RemoteRepositoryImplementation remoteRepo = new RemoteRepositoryImplementation();
     remoteRepo.setCacheRepository(localRepo);
-    return new CompositeRepositoryImpl(List.of(localRepo, remoteRepo));
+    return new CompositeRepositoryImpl(List.of(staticRepo, localRepo, remoteRepo));
   }
 
   public abstract ExecutionGoal getGoal();

--- a/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/DependencyImpl.java
+++ b/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/DependencyImpl.java
@@ -21,15 +21,16 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class DependencyImpl implements Dependency {
-//
+
   @Constraints.Default
   String name = null;
   String version;
   @Constraints.Default
-  String variant = "default";
+  String variant = PackageConfigurationImpl.DEFAULT_VARIANT;
 
   public DependencyImpl() {
   }
+
   public DependencyImpl(SqrlConfig sqrlConfig) {
     name = sqrlConfig.asString("name").getOptional()
         .orElse(null);

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
@@ -43,7 +43,9 @@ public class LocalRepositoryImplementation implements Repository, CacheRepositor
     public boolean retrieveDependency(Path targetPath, Dependency dependency) throws IOException {
         Path zipFile = getZipFilePath(dependency);
         if (Files.isRegularFile(zipFile)) {
-            new ZipFile(zipFile.toFile()).extractAll(targetPath.toString());
+            try (ZipFile zip = new ZipFile(zipFile.toFile())) {
+                zip.extractAll(targetPath.toString());
+            }
             return true;
         }
         return false;

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/StaticRepository.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/StaticRepository.java
@@ -1,0 +1,73 @@
+package com.datasqrl.packager.repository;
+
+import com.datasqrl.config.Dependency;
+import com.datasqrl.config.DependencyImpl;
+import com.datasqrl.config.PackageConfigurationImpl;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import net.lingala.zip4j.ZipFile;
+import lombok.Value;
+
+public class StaticRepository implements Repository {
+
+  private static final String VERSION = "0.5.9"; //TODO: Automatically replace during release or read from somewhere?
+  private static final String RESOURCE_DIR = "profiles/";
+  private static final List<StaticDependency> STATIC_DEPENDENCIES = List.of(
+      StaticDependency.of("datasqrl.profile.default", "default.zip"));
+
+  @Override
+  public boolean retrieveDependency(Path targetPath, Dependency dependency) throws IOException {
+    Optional<StaticDependency> optDep = STATIC_DEPENDENCIES.stream().filter(dep -> dep.matches(dependency)).findFirst();
+    if (optDep.isPresent()) {
+      StaticDependency staticDep = optDep.get();
+
+      // Load zip file to temporary file for extraction
+      InputStream inputStream = StaticRepository.class.getResourceAsStream(staticDep.getResourceFile());
+      Path tempZipFile = Files.createTempFile("static-profile-", ".zip");
+      Files.copy(inputStream, tempZipFile, StandardCopyOption.REPLACE_EXISTING);
+
+      try (ZipFile zipFile = new ZipFile(tempZipFile.toFile())) {
+        // Extract to a desired location
+        zipFile.extractAll(targetPath.toString());
+      } finally {
+        // Delete temp file
+        Files.deleteIfExists(tempZipFile);
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public Optional<Dependency> resolveDependency(String packageName) {
+    return STATIC_DEPENDENCIES.stream().filter(dep -> dep.matches(packageName)).map(StaticDependency::getDependency).findFirst();
+  }
+
+
+  @Value
+  private static class StaticDependency {
+
+    Dependency dependency;
+    String resourceFile;
+
+    public static StaticDependency of(String packageName, String resourceFile) {
+      return new StaticDependency(new DependencyImpl(packageName, VERSION, PackageConfigurationImpl.DEFAULT_VARIANT), RESOURCE_DIR + resourceFile);
+    }
+
+    public boolean matches(String packageName) {
+      return packageName.equalsIgnoreCase(dependency.getName());
+    }
+
+    public boolean matches(Dependency dependency) {
+      return matches(dependency.getName());
+    }
+
+  }
+
+}


### PR DESCRIPTION
Currently, we have to download the default profile from the remote repository in order to compile a SQRL project. This has a number of downsides:
1) We have to remember to always publish a profile for the current version as part of the release
2) If the user is offline it won't work

This draft shows how we could ship default profiles through a `StaticRepository` so they can be included in the release directly and don't require repository access.