### PR TITLE
Fix java type for event_time

### DIFF
--- a/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
+++ b/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
@@ -69,7 +69,7 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
               .onSuccess(sinkResult->{
                 //Add timestamp from sink to result
                 ZonedDateTime dateTime = ZonedDateTime.ofInstant(sinkResult.getSourceTime(), ZoneOffset.UTC);
-                entry.put(ReservedName.MUTATION_TIME.getCanonical(), dateTime.toLocalDateTime());
+                entry.put(ReservedName.MUTATION_TIME.getCanonical(), dateTime.toOffsetDateTime());
 
                 fut.complete(entry);
               })


### PR DESCRIPTION
Got the following error while trying to query `event_time` over graphql 

```
09:52:21.203 [vert.x-eventloop-thread-0] WARN  notprivacysafe.graphql.execution.ExecutionStrategy - Can't serialize value (/CreateDeployment/event_time) : Expected something we can convert to 'java.time.OffsetDateTime' but was 'LocalDateTime'.
graphql.schema.CoercingSerializeException: Expected something we can convert to 'java.time.OffsetDateTime' but was 'LocalDateTime'.
	at graphql.scalars.datetime.DateTimeScalar$1.serialize(DateTimeScalar.java:51) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.scalars.datetime.DateTimeScalar$1.serialize(DateTimeScalar.java:39) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeValueForScalar(ExecutionStrategy.java:593) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:444) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:407) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:213) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2100) ~[?:?]
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:212) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:59) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:670) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:457) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:407) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:213) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2079) ~[?:?]
	at io.vertx.core.Future.lambda$toCompletionStage$3(Future.java:601) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.Promise.complete(Promise.java:66) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at com.datasqrl.graphql.MutationConfigurationImpl$1.lambda$visit$0(MutationConfigurationImpl.java:74) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:310) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.Mapping.onSuccess(Mapping.java:40) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.Mapping.onSuccess(Mapping.java:40) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [sqrl-run.jar:0.5.10-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

Fixes https://github.com/DataSQRL/sqrl/issues/728