### PR TITLE
Add DoubleToVector to the std library

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/functions/vector/StdVectorLibraryImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/functions/vector/StdVectorLibraryImpl.java
@@ -4,6 +4,7 @@ import static com.datasqrl.vector.VectorFunctions.ASCII_TEXT_TEST_EMBED;
 import static com.datasqrl.vector.VectorFunctions.CENTER;
 import static com.datasqrl.vector.VectorFunctions.COSINE_DISTANCE;
 import static com.datasqrl.vector.VectorFunctions.COSINE_SIMILARITY;
+import static com.datasqrl.vector.VectorFunctions.DOUBLE_TO_VECTOR;
 import static com.datasqrl.vector.VectorFunctions.EUCLIDEAN_DISTANCE;
 import static com.datasqrl.vector.VectorFunctions.ONNX_EMBED;
 import static com.datasqrl.vector.VectorFunctions.VEC_TO_DOUBLE;
@@ -28,6 +29,7 @@ public class StdVectorLibraryImpl extends AbstractFunctionModule implements StdL
       COSINE_DISTANCE,
       EUCLIDEAN_DISTANCE,
       VEC_TO_DOUBLE,
+      DOUBLE_TO_VECTOR,
       ONNX_EMBED,
       ASCII_TEXT_TEST_EMBED,
       CENTER


### PR DESCRIPTION
DoubleToVector is missing from the vector module making it unable to import. This PR fixes that.