### PR TITLE
Coordinated Restore at Checkpoint experiment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <log4j.version>2.23.1</log4j.version>
     <scala.version>2.12</scala.version>
     <guava.version>31.1-jre</guava.version>
-    <lombok.version>1.18.24</lombok.version>
+    <lombok.version>1.18.34</lombok.version>
     <commonsio.version>2.11.0</commonsio.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-config.version>2.9.0</commons-config.version>
@@ -51,7 +51,6 @@
     <autoservice.version>1.0.1</autoservice.version>
     <antlr.version>4.9.2</antlr.version>
     <guava.version>31.1-jre</guava.version>
-    <lombok.version>1.18.24</lombok.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <calcite.version>1.27.0</calcite.version>
     <graphql-java.version>19.2</graphql-java.version>

--- a/sqrl-tools/Dockerfile
+++ b/sqrl-tools/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:11.0.22_7-jdk
+FROM azul/zulu-openjdk:17-jdk-crac-latest
 WORKDIR /usr/src/app
 ARG POSTGRES_VERSION=15
 
 RUN apt-get update && \
-    apt-get install -y lsb-release gnupg && \
+    apt-get install -y lsb-release gnupg wget curl criu && \
     rm -rf /var/lib/apt/lists/*
 
 # Add postgresql repo
@@ -25,7 +25,7 @@ RUN service postgresql start && \
 
 
 # Add the Redpanda repository
-RUN curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | bash
+RUN set -x && set -e && curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | bash
 
 # Install Redpanda
 RUN apt-get update && apt-get install -y redpanda

--- a/sqrl-tools/dockerrun.sh
+++ b/sqrl-tools/dockerrun.sh
@@ -7,7 +7,7 @@ export DATA_PATH=/build/build/deploy/flink/data
 export UDF_PATH=/build/build/deploy/flink/lib
 
 echo 'Compiling...this takes about 10 seconds'
-java -jar /opt/sqrl/sqrl-cli.jar ${@}
+java $JVM_OPTS -jar /opt/sqrl/sqrl-cli.jar ${@}
 
 if [ "$1" == "run" ] || [ "$1" == "test" ]; then
    # Determine the jar to run
@@ -52,5 +52,5 @@ if [ "$1" == "run" ] || [ "$1" == "test" ]; then
     echo "All services are up. Starting the main application..."
     echo "$@ $JAR_NAME"
 
-    exec java -jar "/opt/sqrl/$JAR_NAME" "$@"
+    exec java $JVM_OPTS -jar "/opt/sqrl/$JAR_NAME" "$@"
 fi

--- a/sqrl-tools/sqrl-cli/pom.xml
+++ b/sqrl-tools/sqrl-cli/pom.xml
@@ -80,6 +80,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.crac</groupId>
+      <artifactId>crac</artifactId>
+      <version>1.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/DatasqrlCMD.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/DatasqrlCMD.java
@@ -3,16 +3,127 @@
  */
 package com.datasqrl;
 
+import java.util.concurrent.CyclicBarrier;
+
+import org.crac.CheckpointException;
+import org.crac.Core;
+import org.crac.RestoreException;
+import org.crac.management.CRaCMXBean;
+
 import com.datasqrl.cmd.RootCommand;
 
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class DatasqrlCMD {
 
+
+	private static class CracDelegate {
+
+		public CracResourceAdapter registerResource() {
+			log.debug("Registering JVM checkpoint/restore callback for Spring-managed lifecycle beans");
+			CracResourceAdapter resourceAdapter = new CracResourceAdapter();
+			org.crac.Core.getGlobalContext().register(resourceAdapter);
+			return resourceAdapter;
+		}
+
+		public void checkpointRestore() {
+			log.info("Triggering JVM checkpoint/restore");
+			try {
+				Core.checkpointRestore();
+			}
+			catch (UnsupportedOperationException ex) {
+				ex.printStackTrace();
+			}
+			catch (CheckpointException ex) {
+				ex.printStackTrace();
+			}
+			catch (RestoreException ex) {
+				ex.printStackTrace();
+		}
+		}
+	}
+
+	/**
+	 * Resource adapter for Project CRaC, triggering a stop-and-restart cycle
+	 * for Spring-managed lifecycle beans around a JVM checkpoint/restore.
+	 * @since 6.1
+	 * @see #stopForRestart()
+	 * @see #restartAfterStop()
+	 */
+	private static class CracResourceAdapter implements org.crac.Resource {
+
+		private CyclicBarrier barrier;
+
+		@Override
+		public void beforeCheckpoint(org.crac.Context<? extends org.crac.Resource> context) {
+			// A non-daemon thread for preventing an accidental JVM shutdown before the checkpoint
+			initBarrier();
+
+			Thread thread = new Thread(() -> {
+				awaitPreventShutdownBarrier();
+				// Checkpoint happens here
+				awaitPreventShutdownBarrier();
+			}, "prevent-shutdown");
+
+			thread.setDaemon(false);
+			thread.start();
+		}
+
+		private void initBarrier() {
+			this.barrier = new CyclicBarrier(2);
+		}
+
+		@Override
+		public void afterRestore(org.crac.Context<? extends org.crac.Resource> context) {
+			log.info("Restarting Spring-managed lifecycle beans after JVM restore");
+
+			if(barrier != null) {
+				barrier.reset();
+			}
+			// Barrier for prevent-shutdown thread not needed anymore
+			this.barrier = null;
+
+				log.info("Spring-managed lifecycle restart completed (restored JVM running for " +
+						CRaCMXBean.getCRaCMXBean().getUptimeSinceRestore() + " ms)");
+		}
+
+		private void awaitPreventShutdownBarrier() {
+			try {
+				if (this.barrier != null) {
+					this.barrier.await();
+				}
+			}
+			catch (Exception ex) {
+				log.trace("Exception from prevent-shutdown barrier", ex);
+			}
+		}
+	}
+	
   public static void main(String[] args) {
     RootCommand rootCommand = new RootCommand();
+    rootCommand.getCmd().parseArgs(args);
+    
+if(    rootCommand.isWaitForCracEvent() ) {
+    System.out.println("Enabling resource adapter for Project CRaC");
+
+    CracDelegate delegate = new CracDelegate();
+	CracResourceAdapter cracResource = delegate.registerResource();
+	cracResource.initBarrier();
+	
+    int exitCode = rootCommand.getCmd().execute(args);
+    exitCode += (rootCommand.getStatusHook().isSuccess()?0:1);
+    
+    System.out.println("Awaiting crac");
+    cracResource.awaitPreventShutdownBarrier(); 
+    
+
+    System.exit(exitCode);
+} else {
     int exitCode = rootCommand.getCmd().execute(args);
     exitCode += (rootCommand.getStatusHook().isSuccess()?0:1);
     System.exit(exitCode);
+}
   }
 
 }

--- a/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/RootCommand.java
+++ b/sqrl-tools/sqrl-cli/src/main/java/com/datasqrl/cmd/RootCommand.java
@@ -21,6 +21,10 @@ public class RootCommand implements Runnable {
       , scope = ScopeType.INHERIT)
   protected List<Path> packageFiles = Collections.EMPTY_LIST;
 
+  @CommandLine.Option(names = {"--wait-for-crac-event"},
+		  description = "Wait for a Coordinated Restore at Checkpoint event before terminating the JVM" , hidden = true)
+  protected boolean waitForCracEvent = false;
+
   @Override
   public void run() {
     CommandLine.usage(this, System.out);

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/LocalRepositoryImplementation.java
@@ -43,7 +43,9 @@ public class LocalRepositoryImplementation implements Repository, CacheRepositor
     public boolean retrieveDependency(Path targetPath, Dependency dependency) throws IOException {
         Path zipFile = getZipFilePath(dependency);
         if (Files.isRegularFile(zipFile)) {
-            new ZipFile(zipFile.toFile()).extractAll(targetPath.toString());
+            try(ZipFile zf = new ZipFile(zipFile.toFile());){
+            	zf.extractAll(targetPath.toString());
+            }
             return true;
         }
         return false;

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/RemoteRepositoryImplementation.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/repository/RemoteRepositoryImplementation.java
@@ -99,7 +99,9 @@ public class RemoteRepositoryImplementation implements Repository, PublishReposi
           downloadHash);
 
       // Extract the zip file
-      new ZipFile(zipFile.toFile()).extractAll(targetPath.toString());
+      try (ZipFile zf = new ZipFile(zipFile.toFile())) {
+    	zf.extractAll(targetPath.toString());
+      }
 
       // Cache downloaded package
       if (cacheRepository != null) cacheRepository.cacheDependency(zipFile, dependency);

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/util/Zipper.java
@@ -19,10 +19,11 @@ public class Zipper {
         ExcludeFileFilter excludeFilter = file -> file.getName().endsWith(ZIP_EXTENSION);
         ZipParameters zipParameters = new ZipParameters();
         zipParameters.setExcludeFileFilter(excludeFilter);
-        ZipFile zip = new ZipFile(zipFile.toFile());
-        for (Path p : Files.list(directory).collect(Collectors.toList())) {
-            if (Files.isRegularFile(p) && !FileUtil.isExtension(p, ZIP_EXTENSION)) zip.addFile(p.toFile());
-            else if (Files.isDirectory(p)) zip.addFolder(p.toFile(), zipParameters);
+        try(ZipFile zip = new ZipFile(zipFile.toFile());) {
+	        for (Path p : Files.list(directory).collect(Collectors.toList())) {
+	            if (Files.isRegularFile(p) && !FileUtil.isExtension(p, ZIP_EXTENSION)) zip.addFile(p.toFile());
+	            else if (Files.isDirectory(p)) zip.addFolder(p.toFile(), zipParameters);
+	        }
         }
     }
 

--- a/sqrl-tools/sqrl-run/src/main/java/com/datasqrl/DatasqrlRun.java
+++ b/sqrl-tools/sqrl-run/src/main/java/com/datasqrl/DatasqrlRun.java
@@ -193,8 +193,8 @@ public class DatasqrlRun {
 
     StreamExecutionEnvironment sEnv;
 
-    try {
-      sEnv = new StreamExecutionEnvironment(configuration, udfClassLoader);
+    try (StreamExecutionEnvironment env = new StreamExecutionEnvironment(configuration, udfClassLoader)){
+    	sEnv = env;
     } catch (Exception e) {
       throw e;
     }


### PR DESCRIPTION
Initial experimentation with Coordinated Restore at Checkpoint experiment!

I was able to have a stable process that let me run sqrl compiler and wait for `JDK.checkpoint`.

### How to use this branch

1. Build
```
$ mvn clean install -DskipTests=true
$ cd sqrl-tools/
$ docker build -t datasqrl/cmd:crac .
``` 

2. Start compiler with extra flags
  - `JVM_OPTS="-XX:CRaCCheckpointTo=/build/crac"`
  - `--wait-for-crac-event`

```
$ docker rm -f cloud-backend ; docker run --name cloud-backend -p 8888:8888 -p 8081:8081 -p 9092:9092 --rm -v $PWD:/build -e JVM_OPTS="-XX:CRaCCheckpointTo=/build/crac" -e KAFKA_EVENTS_BOOTSTRAP_SERVER="localhost:9092" -e KAFKA_EVENTS_CONSUMER_GROUP=cloud-backend1 -d datasqrl/cmd:crac --wait-for-crac-event compile -c package-dynamic-kafka.json ; docker logs cloud-backend -f
Error response from daemon: No such container: cloud-backend
485109dbf545314d5690855263e941a507003464201131f25d99258df1bfc3e2
Compiling...this takes about 10 seconds
Enabling resource adapter for Project CRaC
...
regular compiler output
...
Awaiting crac
```

3. AFTER the `Awaiting message`, collect a checkpoint

```
$ docker exec -ti cloud-backend jcmd sqrl-cli JDK.checkpoint
7:
An exception during a checkpoint operation:
jdk.internal.crac.mirror.CheckpointException
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=10 type=directory path=/build/build/deployment-observability
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=11 type=directory path=/build/build/deployment-observability
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=12 type=directory path=/build/build/cloud-data
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=13 type=directory path=/build/build/cloud-data
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=14 type=directory path=/build/build/sink
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
        Suppressed: jdk.internal.crac.mirror.impl.CheckpointOpenFileException: FD fd=15 type=directory path=/build/build/sink
                at java.base/jdk.internal.crac.mirror.Core.translateJVMExceptions(Core.java:115)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore1(Core.java:189)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestore(Core.java:315)
                at java.base/jdk.internal.crac.mirror.Core.checkpointRestoreInternal(Core.java:328)
```

Right now, it's all failing due to some file handlers open.

We need to close all file handers before checkpoint, we can use `CracResourceAdapter#beforeCheckpoint` to close them, but I found no way to identify root cause .