### PR TITLE
Remove custom test goal from graphql generation

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/inference/GraphqlQueryBuilder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/inference/GraphqlQueryBuilder.java
@@ -52,7 +52,6 @@ public class GraphqlQueryBuilder {
   private final AtomicInteger queryCounter = new AtomicInteger();
 
   SqrlFramework framework;
-  APIConnectorManager apiManager;
   SqlNameUtil nameUtil;
 
   public APIQuery create(List<ArgCombination> arg, SqrlTableMacro macro,


### PR DESCRIPTION
There is snapshot impact because now custom datatypes (e.g. int/float mapping) not backwards compatible. Also custom mutations would need to be extracted since they don't appear in the sqrl script, and subscriptions are not automatically mapped either.