### PR TITLE
Add test for connector/format dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,6 +904,14 @@
         <version>${flink.version}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>com.datasqrl.flinkrunner</groupId>
+        <artifactId>flinkrunner-bom</artifactId>
+        <version>${flinkrunner.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <!--    <scm>-->

--- a/sqrl-planner/src/main/java/com/datasqrl/v2/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/v2/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -277,8 +277,6 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
   protected RelNode setProcessResult(RelNodeAnalysis analysis) {
     this.intermediateAnalysis = analysis;
     RelNode result = analysis.relNode;
-    //Some sanity checks
-    errors.checkFatal(analysis.type!=TableType.LOOKUP || result instanceof LogicalTableScan, "Lookup tables can only be used in temporal joins");
     return result;
   }
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -81,6 +81,8 @@ public class FullUsecasesIT {
       new ScriptCriteria("postgres-log-disabled.sqrl", "run"),
       new ScriptCriteria("seedshop-extended.sqrl", "test"), // CustomerPromotionTest issue TODO
       new ScriptCriteria("seedshop-extended.sqrl", "run"), // CustomerPromotionTest issue TODO
+      new ScriptCriteria("avro-schema.sqrl", "test"), // FIXME github runners are too slow, remove once we move to circle CI
+      new ScriptCriteria("avro-schema.sqrl", "run"), // FIXME github runners are too slow, remove once we move to circle CI
       new ScriptCriteria("connectors.sqrl", "test") // should not be executed
   );
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -283,7 +283,9 @@ public class FullUsecasesIT {
   @MethodSource("useCaseProvider")
   @Disabled
   public void runTestCaseByName(UseCaseTestParameter param, TestInfo testInfo) {
-	  if(param.sqrlFileName.equals("connectors.sqrl") && param.goal.equals("run")) {
+	  if(param.sqrlFileName.equals("avro-schema.sqrl") 
+//			  && param.goal.equals("run")
+			  ) {
 		  testUseCase(param, testInfo);
 	  } else {
 		  assumeFalse(true);

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -1,5 +1,6 @@
 package com.datasqrl;
 
+import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Files;
@@ -80,8 +81,7 @@ public class FullUsecasesIT {
       new ScriptCriteria("postgres-log-disabled.sqrl", "run"),
       new ScriptCriteria("seedshop-extended.sqrl", "test"), // CustomerPromotionTest issue TODO
       new ScriptCriteria("seedshop-extended.sqrl", "run"), // CustomerPromotionTest issue TODO
-      new ScriptCriteria("connectors.sqrl", "test"), // should not be executed
-      new ScriptCriteria("connectors.sqrl", "run") // should not be executed
+      new ScriptCriteria("connectors.sqrl", "test") // should not be executed
   );
 
   static final Path PROJECT_ROOT = Path.of(System.getProperty("user.dir"));
@@ -266,6 +266,8 @@ public class FullUsecasesIT {
     System.out.println(testNo + ":" + param);
     if (i == testNo) {
       testUseCase(param, testInfo);
+    } else {
+      assumeFalse(true);
     }
   }
 
@@ -275,6 +277,17 @@ public class FullUsecasesIT {
   public void printUseCaseNumbers(UseCaseTestParameter param) {
     testNo++;
     System.out.println(testNo + ":" + param);
+  }
+
+  @ParameterizedTest
+  @MethodSource("useCaseProvider")
+  @Disabled
+  public void runTestCaseByName(UseCaseTestParameter param, TestInfo testInfo) {
+	  if(param.sqrlFileName.equals("connectors.sqrl") && param.goal.equals("run")) {
+		  testUseCase(param, testInfo);
+	  } else {
+		  assumeFalse(true);
+	  }
   }
 
   static List<UseCaseTestParameter> useCaseProvider() throws Exception {

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/FullUsecasesIT.java
@@ -79,7 +79,9 @@ public class FullUsecasesIT {
       new ScriptCriteria("postgres-log-disabled.sqrl", "test"),
       new ScriptCriteria("postgres-log-disabled.sqrl", "run"),
       new ScriptCriteria("seedshop-extended.sqrl", "test"), // CustomerPromotionTest issue TODO
-      new ScriptCriteria("seedshop-extended.sqrl", "run") // CustomerPromotionTest issue TODO
+      new ScriptCriteria("seedshop-extended.sqrl", "run"), // CustomerPromotionTest issue TODO
+      new ScriptCriteria("connectors.sqrl", "test"), // should not be executed
+      new ScriptCriteria("connectors.sqrl", "run") // should not be executed
   );
 
   static final Path PROJECT_ROOT = Path.of(System.getProperty("user.dir"));

--- a/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-integration-tests/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -1,9 +1,15 @@
 package com.datasqrl;
 
+import static org.junit.Assume.assumeFalse;
+
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.datasqrl.FullUsecasesIT.UseCaseTestParameter;
 
 import lombok.SneakyThrows;
 

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
@@ -1,0 +1,343 @@
+>>>pipeline_explain.txt
+=== iceberg_parquet_table
+ID:     default_catalog.default_database.iceberg_parquet_table
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.iceberg_parquet_table__def
+Primary Key: -
+Timestamp  : -
+Schema:
+ - user_id: INTEGER
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, iceberg_parquet_table__def]])
+SQL: CREATE VIEW `iceberg_parquet_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`iceberg_parquet_table__def`
+=== kafka_avro_table
+ID:     default_catalog.default_database.kafka_avro_table
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.kafka_avro_table__def
+Primary Key: -
+Timestamp  : -
+Schema:
+ - user_id: INTEGER
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, kafka_avro_table__def]])
+SQL: CREATE VIEW `kafka_avro_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_avro_table__def`
+=== kafka_debezium_table
+ID:     default_catalog.default_database.kafka_debezium_table
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.kafka_debezium_table__def
+Primary Key: -
+Timestamp  : -
+Schema:
+ - user_id: INTEGER
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, kafka_debezium_table__def]])
+SQL: CREATE VIEW `kafka_debezium_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_debezium_table__def`
+=== upsert_kafka_confluent_avro
+ID:     default_catalog.default_database.upsert_kafka_confluent_avro
+Type:   state
+Stage:  flink
+Inputs: default_catalog.default_database.upsert_kafka_confluent_avro__def
+Primary Key: user_id
+Timestamp  : -
+Schema:
+ - user_id: INTEGER NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, upsert_kafka_confluent_avro__def]])
+SQL: CREATE VIEW `upsert_kafka_confluent_avro`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro__def`
+>>>flink-sql-no-functions.sql
+CREATE TABLE `kafka_avro_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+) WITH (
+  'connector' = 'kafka',
+  'topic' = 'users-avro',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'properties.group.id' = 'flink-kafka-avro-group',
+  'format' = 'avro'
+);
+CREATE VIEW `kafka_avro_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_avro_table__def`;
+CREATE TABLE `upsert_kafka_confluent_avro__def` (
+  `user_id` INTEGER,
+  `name` STRING,
+  PRIMARY KEY (`user_id`) NOT ENFORCED
+) WITH (
+  'connector' = 'upsert-kafka',
+  'topic' = 'users-upsert',
+  'properties.group.id' = 'flink-kafka-avro-group',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'key.format' = 'avro-confluent',
+  'key.avro-confluent.schema-registry.url' = 'http://localhost:8081',
+  'value.format' = 'avro-confluent',
+  'value.avro-confluent.schema-registry.url' = 'http://localhost:8081'
+);
+CREATE VIEW `upsert_kafka_confluent_avro`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro__def`;
+CREATE TABLE `kafka_debezium_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+) WITH (
+  'connector' = 'kafka',
+  'topic' = 'users-debezium',
+  'properties.group.id' = 'flink-kafka-avro-group',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'format' = 'debezium-json'
+);
+CREATE VIEW `kafka_debezium_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_debezium_table__def`;
+CREATE TABLE `iceberg_parquet_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+)
+PARTITIONED BY (`user_id`)
+WITH (
+  'connector' = 'iceberg',
+  'catalog-name' = 'local_fs',
+  'catalog-type' = 'hadoop',
+  'warehouse' = 'file:///tmp/iceberg/warehouse',
+  'format-version' = '2',
+  'write.format.default' = 'parquet'
+);
+CREATE VIEW `iceberg_parquet_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`iceberg_parquet_table__def`;
+CREATE TABLE `_jdbc_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+) WITH (
+  'connector' = 'jdbc',
+  'url' = 'jdbc:postgresql://localhost:5432/mydb',
+  'table-name' = 'users',
+  'username' = 'myuser',
+  'password' = 'mypassword'
+);
+CREATE VIEW `_jdbc_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`_jdbc_table__def`;
+CREATE TABLE `iceberg_parquet_table_1` (
+  `user_id` INTEGER,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'iceberg_parquet_table_1'
+);
+CREATE TABLE `kafka_avro_table_2` (
+  `user_id` INTEGER,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'kafka_avro_table_2'
+);
+CREATE TABLE `kafka_debezium_table_3` (
+  `user_id` INTEGER,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'kafka_debezium_table_3'
+);
+CREATE TABLE `upsert_kafka_confluent_avro_4` (
+  `user_id` INTEGER NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`user_id`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'upsert_kafka_confluent_avro_4'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`iceberg_parquet_table_1`
+(SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
+ FROM `default_catalog`.`default_database`.`iceberg_parquet_table`)
+;
+INSERT INTO `default_catalog`.`default_database`.`kafka_avro_table_2`
+ (SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
+  FROM `default_catalog`.`default_database`.`kafka_avro_table`)
+ ;
+ INSERT INTO `default_catalog`.`default_database`.`kafka_debezium_table_3`
+  (SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
+   FROM `default_catalog`.`default_database`.`kafka_debezium_table`)
+  ;
+  INSERT INTO `default_catalog`.`default_database`.`upsert_kafka_confluent_avro_4`
+   (SELECT *
+    FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro`)
+   ;
+   END
+>>>kafka.json
+{
+  "topics" : [ ]
+}
+>>>postgres-schema.sql
+CREATE TABLE IF NOT EXISTS "iceberg_parquet_table_1" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "kafka_avro_table_2" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "kafka_debezium_table_3" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro_4" ("user_id" INTEGER NOT NULL, "name" TEXT  , PRIMARY KEY ("user_id"))
+>>>postgres-views.sql
+CREATE OR REPLACE VIEW "iceberg_parquet_table"("user_id", "name") AS SELECT "user_id", "name"
+FROM "iceberg_parquet_table_1";
+CREATE OR REPLACE VIEW "kafka_avro_table"("user_id", "name") AS SELECT "user_id", "name"
+FROM "kafka_avro_table_2";
+CREATE OR REPLACE VIEW "kafka_debezium_table"("user_id", "name") AS SELECT "user_id", "name"
+FROM "kafka_debezium_table_3";
+CREATE OR REPLACE VIEW "upsert_kafka_confluent_avro"("user_id", "name") AS SELECT *
+FROM "upsert_kafka_confluent_avro_4"
+>>>vertx.json
+{
+  "model" : {
+    "queries" : [
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "iceberg_parquet_table",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"user_id\", \"name\"\nFROM \"iceberg_parquet_table_1\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "kafka_avro_table",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"user_id\", \"name\"\nFROM \"kafka_avro_table_2\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "kafka_debezium_table",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"user_id\", \"name\"\nFROM \"kafka_debezium_table_3\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "upsert_kafka_confluent_avro",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT *\nFROM \"upsert_kafka_confluent_avro_4\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      }
+    ],
+    "mutations" : [ ],
+    "subscriptions" : [ ],
+    "schema" : {
+      "type" : "string",
+      "schema" : "\"An arbitrary precision signed integer\"\nscalar GraphQLBigInteger\n\ntype Query {\n  iceberg_parquet_table(limit: Int = 10, offset: Int = 0): [iceberg_parquet_table!]\n  kafka_avro_table(limit: Int = 10, offset: Int = 0): [kafka_avro_table!]\n  kafka_debezium_table(limit: Int = 10, offset: Int = 0): [kafka_debezium_table!]\n  upsert_kafka_confluent_avro(limit: Int = 10, offset: Int = 0): [upsert_kafka_confluent_avro!]\n}\n\ntype iceberg_parquet_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_avro_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_debezium_table {\n  user_id: Int\n  name: String\n}\n\ntype upsert_kafka_confluent_avro {\n  user_id: Int!\n  name: String\n}\n"
+    }
+  }
+}

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
@@ -50,6 +50,40 @@ SQL: CREATE VIEW `kafka_debezium_table`
 AS
 SELECT *
 FROM `default_catalog`.`default_database`.`kafka_debezium_table__def`
+=== kafka_safe_csv_table
+ID:     default_catalog.default_database.kafka_safe_csv_table
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.kafka_safe_csv_table__def
+Primary Key: -
+Timestamp  : -
+Schema:
+ - user_id: INTEGER
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, kafka_safe_csv_table__def]])
+SQL: CREATE VIEW `kafka_safe_csv_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_safe_csv_table__def`
+=== kafka_safe_json_table
+ID:     default_catalog.default_database.kafka_safe_json_table
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.kafka_safe_json_table__def
+Primary Key: -
+Timestamp  : -
+Schema:
+ - user_id: INTEGER
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Plan:
+LogicalProject(user_id=[$0], name=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, kafka_safe_json_table__def]])
+SQL: CREATE VIEW `kafka_safe_json_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_safe_json_table__def`
 === upsert_kafka_confluent_avro
 ID:     default_catalog.default_database.upsert_kafka_confluent_avro
 Type:   state
@@ -82,6 +116,34 @@ CREATE VIEW `kafka_avro_table`
 AS
 SELECT *
 FROM `default_catalog`.`default_database`.`kafka_avro_table__def`;
+CREATE TABLE `kafka_safe_json_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+) WITH (
+  'connector' = 'kafka-safe',
+  'topic' = 'users-json-avro',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'properties.group.id' = 'test',
+  'format' = 'flexible-json'
+);
+CREATE VIEW `kafka_safe_json_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_safe_json_table__def`;
+CREATE TABLE `kafka_safe_csv_table__def` (
+  `user_id` INTEGER,
+  `name` STRING
+) WITH (
+  'connector' = 'kafka-safe',
+  'topic' = 'users-json-avro',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'properties.group.id' = 'test',
+  'format' = 'flexible-csv'
+);
+CREATE VIEW `kafka_safe_csv_table`
+AS
+SELECT *
+FROM `default_catalog`.`default_database`.`kafka_safe_csv_table__def`;
 CREATE TABLE `upsert_kafka_confluent_avro__def` (
   `user_id` INTEGER,
   `name` STRING,
@@ -184,7 +246,33 @@ CREATE TABLE `kafka_debezium_table_3` (
   'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
   'table-name' = 'kafka_debezium_table_3'
 );
-CREATE TABLE `upsert_kafka_confluent_avro_4` (
+CREATE TABLE `kafka_safe_csv_table_4` (
+  `user_id` INTEGER,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'kafka_safe_csv_table_4'
+);
+CREATE TABLE `kafka_safe_json_table_5` (
+  `user_id` INTEGER,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'password' = '${JDBC_PASSWORD}',
+  'driver' = 'org.postgresql.Driver',
+  'username' = '${JDBC_USERNAME}',
+  'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
+  'table-name' = 'kafka_safe_json_table_5'
+);
+CREATE TABLE `upsert_kafka_confluent_avro_6` (
   `user_id` INTEGER NOT NULL,
   `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
   PRIMARY KEY (`user_id`) NOT ENFORCED
@@ -194,7 +282,7 @@ CREATE TABLE `upsert_kafka_confluent_avro_4` (
   'driver' = 'org.postgresql.Driver',
   'username' = '${JDBC_USERNAME}',
   'url' = 'jdbc:postgresql://${JDBC_AUTHORITY}',
-  'table-name' = 'upsert_kafka_confluent_avro_4'
+  'table-name' = 'upsert_kafka_confluent_avro_6'
 );
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`iceberg_parquet_table_1`
@@ -209,11 +297,19 @@ INSERT INTO `default_catalog`.`default_database`.`kafka_avro_table_2`
   (SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
    FROM `default_catalog`.`default_database`.`kafka_debezium_table`)
   ;
-  INSERT INTO `default_catalog`.`default_database`.`upsert_kafka_confluent_avro_4`
-   (SELECT *
-    FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro`)
+  INSERT INTO `default_catalog`.`default_database`.`kafka_safe_csv_table_4`
+   (SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
+    FROM `default_catalog`.`default_database`.`kafka_safe_csv_table`)
    ;
-   END
+   INSERT INTO `default_catalog`.`default_database`.`kafka_safe_json_table_5`
+    (SELECT `user_id`, `name`, HASHCOLUMNS(`user_id`, `name`) AS `__pk_hash`
+     FROM `default_catalog`.`default_database`.`kafka_safe_json_table`)
+    ;
+    INSERT INTO `default_catalog`.`default_database`.`upsert_kafka_confluent_avro_6`
+     (SELECT *
+      FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro`)
+     ;
+     END
 >>>kafka.json
 {
   "topics" : [ ]
@@ -222,7 +318,9 @@ INSERT INTO `default_catalog`.`default_database`.`kafka_avro_table_2`
 CREATE TABLE IF NOT EXISTS "iceberg_parquet_table_1" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
 CREATE TABLE IF NOT EXISTS "kafka_avro_table_2" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
 CREATE TABLE IF NOT EXISTS "kafka_debezium_table_3" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
-CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro_4" ("user_id" INTEGER NOT NULL, "name" TEXT  , PRIMARY KEY ("user_id"))
+CREATE TABLE IF NOT EXISTS "kafka_safe_csv_table_4" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "kafka_safe_json_table_5" ("user_id" INTEGER , "name" TEXT , "__pk_hash" TEXT  , PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro_6" ("user_id" INTEGER NOT NULL, "name" TEXT  , PRIMARY KEY ("user_id"))
 >>>postgres-views.sql
 CREATE OR REPLACE VIEW "iceberg_parquet_table"("user_id", "name") AS SELECT "user_id", "name"
 FROM "iceberg_parquet_table_1";
@@ -230,8 +328,12 @@ CREATE OR REPLACE VIEW "kafka_avro_table"("user_id", "name") AS SELECT "user_id"
 FROM "kafka_avro_table_2";
 CREATE OR REPLACE VIEW "kafka_debezium_table"("user_id", "name") AS SELECT "user_id", "name"
 FROM "kafka_debezium_table_3";
+CREATE OR REPLACE VIEW "kafka_safe_csv_table"("user_id", "name") AS SELECT "user_id", "name"
+FROM "kafka_safe_csv_table_4";
+CREATE OR REPLACE VIEW "kafka_safe_json_table"("user_id", "name") AS SELECT "user_id", "name"
+FROM "kafka_safe_json_table_5";
 CREATE OR REPLACE VIEW "upsert_kafka_confluent_avro"("user_id", "name") AS SELECT *
-FROM "upsert_kafka_confluent_avro_4"
+FROM "upsert_kafka_confluent_avro_6"
 >>>vertx.json
 {
   "model" : {
@@ -311,6 +413,54 @@ FROM "upsert_kafka_confluent_avro_4"
       {
         "type" : "args",
         "parentType" : "Query",
+        "fieldName" : "kafka_safe_csv_table",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"user_id\", \"name\"\nFROM \"kafka_safe_csv_table_4\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "kafka_safe_json_table",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"user_id\", \"name\"\nFROM \"kafka_safe_json_table_5\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
         "fieldName" : "upsert_kafka_confluent_avro",
         "exec" : {
           "arguments" : [
@@ -325,7 +475,7 @@ FROM "upsert_kafka_confluent_avro_4"
           ],
           "query" : {
             "type" : "SqlQuery",
-            "sql" : "SELECT *\nFROM \"upsert_kafka_confluent_avro_4\"",
+            "sql" : "SELECT *\nFROM \"upsert_kafka_confluent_avro_6\"",
             "parameters" : [ ],
             "pagination" : "LIMIT_AND_OFFSET",
             "database" : "POSTGRES"
@@ -337,7 +487,7 @@ FROM "upsert_kafka_confluent_avro_4"
     "subscriptions" : [ ],
     "schema" : {
       "type" : "string",
-      "schema" : "\"An arbitrary precision signed integer\"\nscalar GraphQLBigInteger\n\ntype Query {\n  iceberg_parquet_table(limit: Int = 10, offset: Int = 0): [iceberg_parquet_table!]\n  kafka_avro_table(limit: Int = 10, offset: Int = 0): [kafka_avro_table!]\n  kafka_debezium_table(limit: Int = 10, offset: Int = 0): [kafka_debezium_table!]\n  upsert_kafka_confluent_avro(limit: Int = 10, offset: Int = 0): [upsert_kafka_confluent_avro!]\n}\n\ntype iceberg_parquet_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_avro_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_debezium_table {\n  user_id: Int\n  name: String\n}\n\ntype upsert_kafka_confluent_avro {\n  user_id: Int!\n  name: String\n}\n"
+      "schema" : "\"An arbitrary precision signed integer\"\nscalar GraphQLBigInteger\n\ntype Query {\n  iceberg_parquet_table(limit: Int = 10, offset: Int = 0): [iceberg_parquet_table!]\n  kafka_avro_table(limit: Int = 10, offset: Int = 0): [kafka_avro_table!]\n  kafka_debezium_table(limit: Int = 10, offset: Int = 0): [kafka_debezium_table!]\n  kafka_safe_csv_table(limit: Int = 10, offset: Int = 0): [kafka_safe_csv_table!]\n  kafka_safe_json_table(limit: Int = 10, offset: Int = 0): [kafka_safe_json_table!]\n  upsert_kafka_confluent_avro(limit: Int = 10, offset: Int = 0): [upsert_kafka_confluent_avro!]\n}\n\ntype iceberg_parquet_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_avro_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_debezium_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_safe_csv_table {\n  user_id: Int\n  name: String\n}\n\ntype kafka_safe_json_table {\n  user_id: Int\n  name: String\n}\n\ntype upsert_kafka_confluent_avro {\n  user_id: Int!\n  name: String\n}\n"
     }
   }
 }

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--.txt
@@ -135,7 +135,7 @@ CREATE TABLE `kafka_safe_csv_table__def` (
   `name` STRING
 ) WITH (
   'connector' = 'kafka-safe',
-  'topic' = 'users-json-avro',
+  'topic' = 'users-csv-avro',
   'properties.bootstrap.servers' = 'localhost:9092',
   'properties.group.id' = 'test',
   'format' = 'flexible-csv'

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/avro-schema/package.json
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/avro-schema/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
   "test-runner": {
-    "delay-sec": 2
+    "delay-sec": -1
   }
 }

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/avro-schema/package.json
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/avro-schema/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
   "test-runner": {
-    "delay-sec": -1
+    "delay-sec": 2
   }
 }

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/connectors-test/connectors.sqrl
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/connectors-test/connectors.sqrl
@@ -13,6 +13,30 @@ CREATE TABLE kafka_avro_table (
     'format' = 'avro'
       );
 
+-- ========== KAFKA-safe (with json) ==========
+CREATE TABLE kafka_safe_json_table (
+                                  user_id INT,
+                                  name STRING
+) WITH (
+    'connector' = 'kafka-safe',
+    'topic' = 'users-json-avro',
+    'properties.bootstrap.servers' = 'localhost:9092',
+    'properties.group.id' = 'test',
+    'format' = 'flexible-json'
+      );
+
+-- ========== KAFKA-safe (with csv) ==========
+CREATE TABLE kafka_safe_csv_table (
+                                  user_id INT,
+                                  name STRING
+) WITH (
+    'connector' = 'kafka-safe',
+    'topic' = 'users-csv-avro',
+    'properties.bootstrap.servers' = 'localhost:9092',
+    'properties.group.id' = 'test',
+    'format' = 'flexible-csv'
+      );
+
 -- ========== UPSERT KAFKA (with Confluent Avro) ==========
 CREATE TABLE upsert_kafka_confluent_avro (
                                              user_id INT,

--- a/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/connectors-test/connectors.sqrl
+++ b/sqrl-testing/sqrl-integration-tests/src/test/resources/usecases/connectors-test/connectors.sqrl
@@ -1,0 +1,90 @@
+-- The point of this test case is to instantiate the various connectors and formats DataSQRL supports
+-- not to actually connect to those systems at runtime
+
+-- ========== KAFKA (with Avro) ==========
+CREATE TABLE kafka_avro_table (
+                                  user_id INT,
+                                  name STRING
+) WITH (
+    'connector' = 'kafka',
+    'topic' = 'users-avro',
+    'properties.bootstrap.servers' = 'localhost:9092',
+    'properties.group.id' = 'flink-kafka-avro-group',
+    'format' = 'avro'
+      );
+
+-- ========== UPSERT KAFKA (with Confluent Avro) ==========
+CREATE TABLE upsert_kafka_confluent_avro (
+                                             user_id INT,
+                                             name STRING,
+                                             PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+      'connector' = 'upsert-kafka',
+      'topic' = 'users-upsert',
+      'properties.group.id' = 'flink-kafka-avro-group',
+      'properties.bootstrap.servers' = 'localhost:9092',
+      'key.format' = 'avro-confluent',
+      'key.avro-confluent.schema-registry.url' = 'http://localhost:8081',
+      'value.format' = 'avro-confluent',
+      'value.avro-confluent.schema-registry.url' = 'http://localhost:8081'
+      );
+
+-- ========== KAFKA (with Debezium JSON) ==========
+CREATE TABLE kafka_debezium_table (
+                                      user_id INT,
+                                      name STRING
+) WITH (
+      'connector' = 'kafka',
+      'topic' = 'users-debezium',
+      'properties.group.id' = 'flink-kafka-avro-group',
+      'properties.bootstrap.servers' = 'localhost:9092',
+      'format' = 'debezium-json'
+      );
+
+-- ========== ICEBERG (with Parquet) ==========
+CREATE TABLE iceberg_parquet_table (
+                                       user_id INT,
+                                       name STRING
+) PARTITIONED BY (user_id)
+WITH (
+  'connector' = 'iceberg',
+  'catalog-name' = 'local_fs',
+  'catalog-type' = 'hadoop',
+  'warehouse' = 'file:///tmp/iceberg/warehouse',
+  'format-version' = '2',
+  'write.format.default' = 'parquet'
+);
+
+-- ========== JDBC for temporal join ==========
+CREATE TABLE _jdbc_table (
+                            user_id INT,
+                            name STRING
+) WITH (
+      'connector' = 'jdbc',
+      'url' = 'jdbc:postgresql://localhost:5432/mydb',
+      'table-name' = 'users',
+      'username' = 'myuser',
+      'password' = 'mypassword'
+      );
+
+-- ========== KINESIS (with JSON) ==========
+-- CREATE TABLE kinesis_json_table (
+--                                     user_id INT,
+--                                     name STRING
+-- ) WITH (
+--       'connector' = 'kinesis',
+--       'stream' = 'users-stream',
+--       'aws.region' = 'us-west-2',
+--       'scan.stream.initpos' = 'LATEST',
+--       'format' = 'json'
+--       );
+
+-- ========== DYNAMODB (via Amazon DynamoDB connector) ==========
+-- CREATE TABLE dynamodb_table (
+--                                 user_id INT,
+--                                 name STRING
+-- ) WITH (
+--       'connector' = 'dynamodb',
+--       'table-name' = 'users-table',
+--       'aws.region' = 'us-west-2'
+--       );

--- a/sqrl-tools/sqrl-run/pom.xml
+++ b/sqrl-tools/sqrl-run/pom.xml
@@ -75,21 +75,6 @@
       <version>1.19.1</version>
     </dependency>
     <dependency>
-      <groupId>com.datasqrl.flinkrunner</groupId>
-      <artifactId>postgresql-connector</artifactId>
-      <version>${flinkrunner.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.datasqrl.flinkrunner</groupId>
-      <artifactId>flexible-json-format</artifactId>
-      <version>${flinkrunner.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.datasqrl.flinkrunner</groupId>
-      <artifactId>flexible-csv-format</artifactId>
-      <version>${flinkrunner.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-secure</artifactId>
     </dependency>
@@ -306,6 +291,36 @@
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-statebackend-rocksdb</artifactId>
       <version>1.19.1</version>
+    </dependency>
+
+
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>flexible-csv-format</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>system-functions-discovery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>json-type</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>flexible-json-format</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>vector-type</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>kafka-safe-connector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>postgresql-connector</artifactId>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
by having a single sqrl/FlinkSQL script that defines a bunch of connectors and formats.
This test is not runnable but if it compiles, we have validation that the dependencies are present.

I added the UseCaseCompileTest.
@velo Can you add a test inside the run module to ensure that the dependencies are present in the runner for execution by datasqrl's run command or in the flink-sql-runner itself? We only need to test that it compiles.