### PR TITLE
Fix flink warnings:

### DIFF
--- a/sqrl-tools/sqrl-run/src/main/java/com/datasqrl/DatasqrlRun.java
+++ b/sqrl-tools/sqrl-run/src/main/java/com/datasqrl/DatasqrlRun.java
@@ -149,10 +149,10 @@ public class DatasqrlRun {
     }
 
     config.putIfAbsent("table.exec.source.idle-timeout", "1 s");
-    config.putIfAbsent("taskmanager.network.memory.max", "800m");
+    config.putIfAbsent("taskmanager.memory.network.max", "800m");
     config.putIfAbsent("execution.checkpointing.interval", "30 s");
     config.putIfAbsent("execution.checkpointing.min-pause", "20 s");
-    config.putIfAbsent("state.backend", "rocksdb");
+    config.putIfAbsent("state.backend.type", "rocksdb");
     config.putIfAbsent("table.exec.resource.default-parallelism", "1");
     config.putIfAbsent("rest.address", "localhost");
     config.putIfAbsent("rest.port", "8081");


### PR DESCRIPTION
```
08:20:14.537 [main] WARN  org.apache.flink.configuration.Configuration - Config uses deprecated configuration key 'taskmanager.network.memory.max' instead of proper key 'taskmanager.memory.network.max'
08:20:13.249 [main] WARN  org.apache.flink.configuration.Configuration - Config uses deprecated configuration key 'state.backend' instead of proper key 'state.backend.type'
```