### PR TITLE
Store Flink config in `FlinkPhysicalPlan`, generate YAML of its content

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/EnginePhysicalPlan.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/EnginePhysicalPlan.java
@@ -20,7 +20,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.Value;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 
 /** A jackson serializable object */
 public interface EnginePhysicalPlan {
@@ -30,10 +31,7 @@ public interface EnginePhysicalPlan {
     return List.of();
   }
 
-  @Value
-  class DeploymentArtifact {
-    String fileSuffix;
-    Object content;
+  record DeploymentArtifact(String fileSuffix, Object content) {
 
     public static String toSqlString(Stream<String> statements) {
       return statements.collect(Collectors.joining(";\n"));
@@ -41,6 +39,10 @@ public interface EnginePhysicalPlan {
 
     public static String toSqlString(Collection<String> statements) {
       return toSqlString(statements.stream());
+    }
+
+    public static String toYamlString(Configuration config) {
+      return String.join("\n", ConfigurationUtils.convertConfigToWritableLines(config, false));
     }
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/CombinedEnginePlan.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/CombinedEnginePlan.java
@@ -19,7 +19,6 @@ import com.datasqrl.engine.EnginePhysicalPlan;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
@@ -41,10 +40,10 @@ public class CombinedEnginePlan implements EnginePhysicalPlan {
                         artifact ->
                             new DeploymentArtifact(
                                 name.isBlank()
-                                    ? artifact.getFileSuffix()
-                                    : ("-" + name + artifact.getFileSuffix()),
-                                artifact.getContent()))
-                    .collect(Collectors.toList())));
+                                    ? artifact.fileSuffix()
+                                    : ("-" + name + artifact.fileSuffix()),
+                                artifact.content()))
+                    .toList()));
     return combined;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPhysicalPlan.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPhysicalPlan.java
@@ -19,15 +19,18 @@ import com.datasqrl.engine.EnginePhysicalPlan;
 import com.datasqrl.planner.tables.FlinkConnectorConfig;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Value;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
@@ -56,33 +59,34 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
   @JsonIgnore Optional<String> compiledPlan;
   @JsonIgnore Optional<String> explainedPlan;
   @JsonIgnore List<String> flinkSqlNoFunctions;
+  @JsonIgnore Configuration config;
 
   @Override
   public List<DeploymentArtifact> getDeploymentArtifacts() {
-    List<DeploymentArtifact> deploymentArtifacts = new ArrayList<>();
-    deploymentArtifacts.add(
-        new DeploymentArtifact("-sql.sql", DeploymentArtifact.toSqlString(flinkSql)));
-    deploymentArtifacts.add(
+    var builder = ImmutableList.<DeploymentArtifact>builder();
+    builder.add(
+        new DeploymentArtifact("-config.yaml", DeploymentArtifact.toYamlString(config)),
+        new DeploymentArtifact("-sql.sql", DeploymentArtifact.toSqlString(flinkSql)),
         new DeploymentArtifact(
-            "-sql-no-functions.sql", DeploymentArtifact.toSqlString(flinkSqlNoFunctions)));
-    deploymentArtifacts.add(
+            "-sql-no-functions.sql", DeploymentArtifact.toSqlString(flinkSqlNoFunctions)),
         new DeploymentArtifact("-functions.sql", DeploymentArtifact.toSqlString(functions)));
-    compiledPlan.map(
-        plan -> deploymentArtifacts.add(new DeploymentArtifact("-compiled-plan.json", plan)));
-    explainedPlan.map(
-        plan -> deploymentArtifacts.add(new DeploymentArtifact("-explained-plan.txt", plan)));
-    return deploymentArtifacts;
+
+    compiledPlan.map(plan -> builder.add(new DeploymentArtifact("-compiled-plan.json", plan)));
+    explainedPlan.map(plan -> builder.add(new DeploymentArtifact("-explained-plan.txt", plan)));
+
+    return builder.build();
   }
 
-  @Value
+  @Data
   public static class Builder {
-    List<String> flinkSql = new ArrayList<>();
-    List<String> flinkSqlNoFunctions = new ArrayList<>();
-    List<SqlNode> nodes = new ArrayList<>();
-    Set<String> connectors = new HashSet<>();
-    Set<String> formats = new HashSet<>();
-    Set<String> fullyResolvedFunctions = new HashSet<>();
-    List<RichSqlInsert> statementSet = new ArrayList<>();
+    private final List<String> flinkSql = new ArrayList<>();
+    private final List<String> flinkSqlNoFunctions = new ArrayList<>();
+    private final List<SqlNode> nodes = new ArrayList<>();
+    private final Set<String> connectors = new HashSet<>();
+    private final Set<String> formats = new HashSet<>();
+    private final Set<String> fullyResolvedFunctions = new HashSet<>();
+    private final List<RichSqlInsert> statementSet = new ArrayList<>();
+    private Configuration config = new Configuration();
 
     public void addInsert(RichSqlInsert insert) {
       statementSet.add(insert);
@@ -138,7 +142,8 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
           fullyResolvedFunctions,
           compiledPlan.map(CompiledPlan::asJsonString),
           explainedPlan,
-          flinkSqlNoFunctions);
+          flinkSqlNoFunctions,
+          config);
     }
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -95,7 +95,10 @@ import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.sql.parser.ddl.SqlAlterViewAs;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlCreateTableLike;
@@ -181,28 +184,28 @@ public class Sqrl2FlinkSQLTranslator {
     // Create a UDF class loader and configure
     ClassLoader udfClassLoader =
         new URLClassLoader(jarUrls.toArray(new URL[0]), getClass().getClassLoader());
-    Map<String, String> config = flink.getBaseConfiguration();
-    config.put(
-        "pipeline.classpaths",
-        jarUrls.stream().map(URL::toString).collect(Collectors.joining(",")));
-    // Set up execution environment
-    var sEnv = StreamExecutionEnvironment.getExecutionEnvironment(Configuration.fromMap(config));
-    // Create environment settings with class loader
-    // Configure batch or streaming environment
-    EnvironmentSettings.Builder settingsBuilder =
-        EnvironmentSettings.newInstance()
-            .withConfiguration(Configuration.fromMap(config))
-            .withClassLoader(udfClassLoader);
 
-    if (executionMode == ExecutionMode.STREAMING) {
-      sEnv.setRuntimeMode(org.apache.flink.api.common.RuntimeExecutionMode.STREAMING);
-      settingsBuilder.inStreamingMode();
-    } else {
-      sEnv.setRuntimeMode(org.apache.flink.api.common.RuntimeExecutionMode.BATCH);
-      settingsBuilder.inBatchMode();
+    // Init Flink config
+    var config = Configuration.fromMap(flink.getBaseConfiguration());
+    if (!jarUrls.isEmpty()) {
+      config.set(
+          ExecutionOptions.RUNTIME_MODE,
+          executionMode == ExecutionMode.STREAMING
+              ? RuntimeExecutionMode.STREAMING
+              : RuntimeExecutionMode.BATCH);
     }
-    var tEnvConfig = settingsBuilder.build();
+    config.set(
+        PipelineOptions.CLASSPATHS,
+        jarUrls.stream().map(URL::toString).collect(Collectors.toList()));
+    planBuilder.setConfig(config.clone());
 
+    // Set up table environment
+    var sEnv = StreamExecutionEnvironment.getExecutionEnvironment(config);
+    var tEnvConfig =
+        EnvironmentSettings.newInstance()
+            .withConfiguration(config)
+            .withClassLoader(udfClassLoader)
+            .build();
     this.tEnv = (StreamTableEnvironmentImpl) StreamTableEnvironment.create(sEnv, tEnvConfig);
 
     // Extract a number of classes we need access to for planning

--- a/sqrl-tools/sqrl-config/src/main/resources/default-package.json
+++ b/sqrl-tools/sqrl-config/src/main/resources/default-package.json
@@ -3,6 +3,7 @@
   "enabled-engines": ["vertx", "postgres", "kafka", "flink"],
   "engines" : {
     "flink" : {
+      "config": {},
       "connectors": {
         "postgres": {
           "connector": "jdbc-sqrl",

--- a/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Packager.java
+++ b/sqrl-tools/sqrl-packager/src/main/java/com/datasqrl/packager/Packager.java
@@ -380,11 +380,11 @@ public class Packager {
         ListUtils.union(
             plan.getDeploymentArtifacts(), List.of(new DeploymentArtifact(".json", plan)));
     for (DeploymentArtifact artifact : artifacts) {
-      Path filePath = planDir.resolve(name + artifact.getFileSuffix()).toAbsolutePath();
-      if (artifact.getContent() instanceof String) {
+      Path filePath = planDir.resolve(name + artifact.fileSuffix()).toAbsolutePath();
+      if (artifact.content() instanceof String) {
         Files.writeString(
             filePath,
-            (String) artifact.getContent(),
+            (String) artifact.content(),
             StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING,
             StandardOpenOption.WRITE);


### PR DESCRIPTION
## Main changes
- Store Flink `Configuration` obj in `FlinkPhysicalPlan`, allow setting it via builder
- Generate a `DeploymentArtifact` from it, YAML string conversion via Flink util
- Base Flink config can be put into `default-package.json`
- Minor simplifications in `Sqrl2FlinkSQLTranslator`