### PR TITLE
Improve error message during package config validation to show the actual error(s)

### DIFF
--- a/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/SqrlConfig.java
+++ b/sqrl-tools/sqrl-config/src/main/java/com/datasqrl/config/SqrlConfig.java
@@ -17,6 +17,7 @@ package com.datasqrl.config;
 
 import com.datasqrl.error.CollectedException;
 import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.error.ErrorMessage;
 import com.datasqrl.error.ResourceFileUtil;
 import com.datasqrl.util.JsonMergeUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -165,7 +166,11 @@ public class SqrlConfig {
       }
     }
     if (!valid) {
-      throw errors.exception("Configuration file invalid: %s", files);
+      throw errors.exception(
+          errors
+              .getErrors()
+              .combineMessages(
+                  ErrorMessage.Severity.FATAL, "Failed to load package configuration:\n\n", "\n"));
     }
     var merged = MAPPER.createObjectNode();
     jsons.forEach(node -> JsonMergeUtils.merge(merged, node));


### PR DESCRIPTION
Example what it writes exactly with 1 error:
```
java.lang.IllegalArgumentException: Failed to load package configuration:

[FATAL] config/src/test/resources/usecases/sensors/build/package.json$.engines.flink.config: must have at least 1 properties at location [$.engines.flink.config]

	at com.datasqrl.error.ErrorMessage.asException(ErrorMessage.java:51)
	at com.datasqrl.error.ErrorCollector.exception(ErrorCollector.java:209)
	at com.datasqrl.error.ErrorCollector.exception(ErrorCollector.java:202)
	at com.datasqrl.config.SqrlConfig.getPackageConfig(SqrlConfig.java:169)
	at com.datasqrl.config.SqrlConfig.fromFilesPackageJson(SqrlConfig.java:95)
	at com.datasqrl.FullUseCasesIT.useCase(FullUseCasesIT.java:215)
	at com.datasqrl.FullUseCasesIT.runTestCaseByName(FullUseCasesIT.java:345)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```