### PR TITLE
Fix CLI command init and add unit tests

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -17,7 +17,7 @@ package com.datasqrl.cli;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.PackageJson.CompilerConfig;
 import com.datasqrl.flinkrunner.EnvVarResolver;
 import com.datasqrl.flinkrunner.SqrlRunner;
 import com.datasqrl.graphql.HttpServerVerticle;
@@ -77,7 +77,7 @@ public class DatasqrlRun {
 
   private final Path planPath;
   private final Path build;
-  private final PackageJson.CompilerConfig compilerConfig;
+  private final CompilerConfig compilerConfig;
   private final Configuration flinkConfig;
   private final Map<String, String> env;
   private final boolean testRun;
@@ -86,14 +86,13 @@ public class DatasqrlRun {
   private Vertx vertx;
   private TableResult execute;
 
-  public DatasqrlRun(
-      Path planPath, PackageJson.CompilerConfig compilerConfig, Configuration flinkConfig) {
+  public DatasqrlRun(Path planPath, CompilerConfig compilerConfig, Configuration flinkConfig) {
     this(planPath, compilerConfig, flinkConfig, System.getenv(), false);
   }
 
   public DatasqrlRun(
       Path planPath,
-      PackageJson.CompilerConfig compilerConfig,
+      CompilerConfig compilerConfig,
       Configuration flinkConfig,
       Map<String, String> env,
       boolean testRun) {

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
@@ -29,7 +29,7 @@ public class ExecuteCmd extends AbstractCmd {
   protected void execute(ErrorCollector errors) throws Exception {
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, targetDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
@@ -39,7 +39,7 @@ public class RunCmd extends AbstractCompileCmd {
     // Run
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, targetDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -60,7 +60,7 @@ public class TestCmd extends AbstractCompileCmd {
     // Test
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, targetDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlTest =

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/ExecuteCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/ExecuteCmdTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import static org.mockito.Mockito.*;
+
+import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.util.ConfigLoaderUtils;
+import java.nio.file.Path;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExecuteCmdTest {
+
+  @Mock private ErrorCollector errors;
+  @Mock private PackageJson.CompilerConfig sqrlCompilerConfig;
+  @Mock private Configuration flinkConfig;
+
+  private ExecuteCmd executeCmd;
+
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  void setup() {
+    executeCmd = spy(new ExecuteCmd());
+  }
+
+  @Test
+  void execute_shouldLoadConfigsAndRunDatasqrlRun() throws Exception {
+    executeCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+
+    var mockSqrlConfig = mock(PackageJson.class);
+    when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
+
+    Path rootDir = executeCmd.cli.rootDir;
+    Path planDir = executeCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+
+    // Mock static methods and verify arguments
+    try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
+      mocked
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .thenReturn(mockSqrlConfig);
+
+      mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
+
+      try (MockedConstruction<DatasqrlRun> datasqrlRunMocked =
+          mockConstruction(
+              DatasqrlRun.class, (mock, context) -> when(mock.run(true, true)).thenReturn(null))) {
+        executeCmd.execute(errors);
+
+        // Verify exact arguments
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
+
+        DatasqrlRun constructed = datasqrlRunMocked.constructed().get(0);
+        verify(constructed).run(true, true);
+      }
+    }
+  }
+}

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.plan.validate.ExecutionGoal;
+import com.datasqrl.util.ConfigLoaderUtils;
+import java.nio.file.Path;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RunCmdTest {
+
+  @Mock private ErrorCollector errors;
+  @Mock private PackageJson.CompilerConfig sqrlCompilerConfig;
+  @Mock private Configuration flinkConfig;
+
+  private RunCmd runCmd;
+
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  void setup() {
+    runCmd = spy(new RunCmd());
+  }
+
+  @Test
+  void execute_whenInternalTestExecIsTrue_shouldSkipRunPart() throws Exception {
+    doNothing().when(runCmd).execute(any(), any(), any());
+    runCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, true);
+
+    runCmd.execute(errors);
+
+    // Should call super.execute but skip DatasqrlRun
+    verify(runCmd).execute(errors);
+    verify(runCmd, never()).getTargetDir();
+  }
+
+  @Test
+  void execute_shouldLoadConfigsAndRunDatasqrlRun() throws Exception {
+    doNothing().when(runCmd).execute(any(), any(), any());
+    runCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+
+    var mockSqrlConfig = mock(PackageJson.class);
+    when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
+
+    Path rootDir = runCmd.cli.rootDir;
+    Path planDir = runCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+
+    // Mock static methods and verify arguments
+    try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
+      mocked
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .thenReturn(mockSqrlConfig);
+
+      mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
+
+      try (MockedConstruction<DatasqrlRun> datasqrlRunMocked =
+          mockConstruction(
+              DatasqrlRun.class, (mock, context) -> when(mock.run(true, true)).thenReturn(null))) {
+        runCmd.execute(errors);
+
+        // Verify exact arguments
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
+
+        DatasqrlRun constructed = datasqrlRunMocked.constructed().get(0);
+        verify(constructed).run(true, true);
+      }
+    }
+  }
+
+  @Test
+  void getGoal_shouldReturnRun() {
+    assertThat(runCmd.getGoal()).isEqualTo(ExecutionGoal.RUN);
+  }
+}

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.plan.validate.ExecutionGoal;
+import com.datasqrl.util.ConfigLoaderUtils;
+import java.nio.file.Path;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestCmdTest {
+
+  @Mock private ErrorCollector errors;
+  @Mock private PackageJson.CompilerConfig sqrlCompilerConfig;
+  @Mock private Configuration flinkConfig;
+
+  private TestCmd testCmd;
+
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  void setup() {
+    testCmd = spy(new TestCmd());
+  }
+
+  @Test
+  void execute_whenInternalTestExecIsTrue_shouldSkipTestPart() throws Exception {
+    doNothing().when(testCmd).execute(any(), any(), any());
+    testCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, true);
+
+    testCmd.execute(errors);
+
+    // Should call super.execute but skip DatasqrlTest
+    verify(testCmd).execute(errors);
+    verify(testCmd, never()).getTargetDir();
+  }
+
+  @Test
+  void execute_shouldLoadConfigsAndRunDatasqrlTest() throws Exception {
+    doNothing().when(testCmd).execute(any(), any(), any());
+    testCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+
+    var mockSqrlConfig = mock(PackageJson.class);
+    when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
+
+    Path rootDir = testCmd.cli.rootDir;
+    Path planDir = testCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+
+    // Mock static methods and verify arguments
+    try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
+      mocked
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .thenReturn(mockSqrlConfig);
+
+      mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
+
+      try (MockedConstruction<DatasqrlTest> datasqrlRunMocked =
+          mockConstruction(DatasqrlTest.class, (mock, context) -> when(mock.run()).thenReturn(0))) {
+        testCmd.execute(errors);
+
+        // Verify exact arguments
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
+
+        DatasqrlTest constructed = datasqrlRunMocked.constructed().get(0);
+        verify(constructed).run();
+      }
+    }
+  }
+
+  @Test
+  void getGoal_shouldReturnTest() {
+    assertThat(testCmd.getGoal()).isEqualTo(ExecutionGoal.TEST);
+  }
+}

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlTestContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlTestContainerIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.container.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class SqrlTestContainerIT extends SqrlContainerTestBase {
+
+  @Override
+  protected String getTestCaseName() {
+    return "avro-schema";
+  }
+
+  @Test
+  @SneakyThrows
+  void givenAvroSchemaScript_whenTestCommandExecuted_thenSnapshotsValidateSuccessfully() {
+    var result =
+        sqrlScript(
+            testDir,
+            "test avro-schema.sqrl --snapshots snapshots-avro-schema --tests tests-avro-schema"
+                .split(" "));
+
+    log.info("SQRL test command executed successfully");
+    log.info("Container logs:\n{}", result.logs());
+
+    // Verify the expected success messages are present in the logs
+    assertThat(result.logs())
+        .contains("Snapshot OK for MySchemaQuery")
+        .contains("Snapshot OK for MySchema");
+
+    log.info("All snapshot validations passed successfully");
+  }
+}


### PR DESCRIPTION
The common logic could be extracted in a way to avoid duplication and pretty similar unit tests, but for a quick fix IMO this is sufficient.