### PR TITLE
Quick dirty patch to fix datasqrl/cmd:dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,11 +370,6 @@ jobs:
       - setup-buildx:
           builder_name: "base-builder"
       - run:
-          name: Login to Docker Hub
-          command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-
-      - run:
           name: Skip build if base already exists
           command: |
             set +e
@@ -389,6 +384,11 @@ jobs:
             else
               echo "Tag does not exist yet – will build base image."
             fi
+
+      - run:
+          name: Login to Docker Hub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
       - run:
           name: Build & push datasqrl/base-sqrl:$BASE_TAG
@@ -410,11 +410,6 @@ jobs:
       - setup-buildx:
           builder_name: "mcp-builder"
       - run:
-          name: Login to Docker Hub
-          command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-
-      - run:
           name: Skip build if MCP inspector already exists
           command: |
             set +e
@@ -429,6 +424,11 @@ jobs:
             else
               echo "Tag does not exist yet – will build MCP inspector image."
             fi
+
+      - run:
+          name: Login to Docker Hub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
       - run:
           name: Build & push datasqrl/mcp-inspector:$MCP_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,11 +324,15 @@ jobs:
           builder_name: "sqrl-builder"
 
       - run:
-          name: Login to registries and pull base image
+          name: Pull base image
+          command: |
+            docker pull datasqrl/base-sqrl:$BASE_TAG
+
+      - run:
+          name: Login to registries
           command: |
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
             echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            docker pull datasqrl/base-sqrl:$BASE_TAG
 
       - run:
           name: Build + push Docker images

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCmd.java
@@ -61,6 +61,10 @@ public abstract class AbstractCmd implements Runnable, IExitCodeGenerator {
 
   protected abstract void execute(ErrorCollector errors) throws Exception;
 
+  protected Path getBuildDir() {
+    return cli.rootDir.resolve(SqrlConstants.BUILD_DIR_NAME);
+  }
+
   protected Path getTargetDir() {
     if (targetDir.isAbsolute()) {
       return targetDir;

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
@@ -58,7 +58,7 @@ public class DatasqrlCli implements Runnable {
   }
 
   public DatasqrlCli() {
-    this(Path.of(""));
+    this(Path.of("").toAbsolutePath());
   }
 
   public CommandLine getCmd() {

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
@@ -29,7 +29,7 @@ public class ExecuteCmd extends AbstractCmd {
   protected void execute(ErrorCollector errors) throws Exception {
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
@@ -29,7 +29,7 @@ public class ExecuteCmd extends AbstractCmd {
   protected void execute(ErrorCollector errors) throws Exception {
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
@@ -39,7 +39,7 @@ public class RunCmd extends AbstractCompileCmd {
     // Run
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
@@ -39,7 +39,7 @@ public class RunCmd extends AbstractCompileCmd {
     // Run
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlRun = new DatasqrlRun(planDir, sqrlConfig.getCompilerConfig(), flinkConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -60,7 +60,7 @@ public class TestCmd extends AbstractCompileCmd {
     // Test
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir);
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlTest =

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -60,7 +60,7 @@ public class TestCmd extends AbstractCompileCmd {
     // Test
     var targetDir = getTargetDir();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
-    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, cli.rootDir.resolve("build"));
+    var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
     var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
     var sqrlTest =

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/ExecuteCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/ExecuteCmdTest.java
@@ -55,13 +55,13 @@ class ExecuteCmdTest {
     var mockSqrlConfig = mock(PackageJson.class);
     when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
 
-    Path rootDir = executeCmd.cli.rootDir;
+    Path buildDir = executeCmd.getBuildDir();
     Path planDir = executeCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
       mocked
-          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir))
           .thenReturn(mockSqrlConfig);
 
       mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
@@ -72,7 +72,7 @@ class ExecuteCmdTest {
         executeCmd.execute(errors);
 
         // Verify exact arguments
-        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir));
         mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
 
         DatasqrlRun constructed = datasqrlRunMocked.constructed().get(0);

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
@@ -78,13 +78,13 @@ class RunCmdTest {
     var mockSqrlConfig = mock(PackageJson.class);
     when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
 
-    Path rootDir = runCmd.cli.rootDir;
+    Path buildDir = runCmd.getBuildDir();
     Path planDir = runCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
       mocked
-          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir))
           .thenReturn(mockSqrlConfig);
 
       mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
@@ -95,7 +95,7 @@ class RunCmdTest {
         runCmd.execute(errors);
 
         // Verify exact arguments
-        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir));
         mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
 
         DatasqrlRun constructed = datasqrlRunMocked.constructed().get(0);

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
@@ -71,13 +71,13 @@ class TestCmdTest {
     var mockSqrlConfig = mock(PackageJson.class);
     when(mockSqrlConfig.getCompilerConfig()).thenReturn(sqrlCompilerConfig);
 
-    Path rootDir = testCmd.cli.rootDir;
+    Path buildDir = testCmd.getBuildDir();
     Path planDir = testCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
       mocked
-          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir))
+          .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir))
           .thenReturn(mockSqrlConfig);
 
       mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
@@ -87,7 +87,7 @@ class TestCmdTest {
         testCmd.execute(errors);
 
         // Verify exact arguments
-        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, rootDir));
+        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir));
         mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
 
         DatasqrlTest constructed = datasqrlRunMocked.constructed().get(0);


### PR DESCRIPTION
We had an incident earlier `docker run -it -p 8081:8081 -p 8888:8888 --rm -v $PWD:/build [ghcr.io/datasqrl/cmd:dev](http://ghcr.io/datasqrl/cmd:dev) run -c study_stream_package_test.json`

Produced:

```
java.lang.IllegalArgumentException: Failed to load package.json, it is not a regular file
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfigFromFile(ConfigLoaderUtils.java:93)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfigFromFile(ConfigLoaderUtils.java:88)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfig(ConfigLoaderUtils.java:77)
        at com.datasqrl.cli.RunCmd.execute(RunCmd.java:42)
        at com.datasqrl.cli.AbstractCmd.run(AbstractCmd.java:47)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at com.datasqrl.cli.DatasqrlCli.main(DatasqrlCli.java:70)
java.lang.IllegalArgumentException: Failed to load package.json, it is not a regular file
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfigFromFile(ConfigLoaderUtils.java:93)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfigFromFile(ConfigLoaderUtils.java:88)
        at com.datasqrl.util.ConfigLoaderUtils.loadResolvedConfig(ConfigLoaderUtils.java:77)
        at com.datasqrl.cli.RunCmd.execute(RunCmd.java:42)
        at com.datasqrl.cli.AbstractCmd.run(AbstractCmd.java:47)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at com.datasqrl.cli.DatasqrlCli.main(DatasqrlCli.java:70)
[FATAL] Failed to load package.json, it is not a regular file
```

