### PR TITLE
Ignore Flink TypeExtractor INFO level logs

### DIFF
--- a/sqrl-cli/src/main/resources/log4j2.properties
+++ b/sqrl-cli/src/main/resources/log4j2.properties
@@ -16,13 +16,15 @@
 
 # Set root logger level
 rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = MainAppender
 
-# Define Console appender
+# Specific logger for TypeExtractor
+logger.typeExtractor.name = org.apache.flink.api.java.typeutils.TypeExtractor
+logger.typeExtractor.level = WARN
+
+# Console appender
+appender.console.name = MainAppender
 appender.console.type = Console
-appender.console.name = Console
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d [%t] %-5level %c - %m%n
-
-# Assign appender to root logger
-rootLogger.appenderRef.console.ref = Console


### PR DESCRIPTION
Local test with the changed Log4j props:
```
% docker run -it -p 8081:8081 -p 8888:8888 --rm -v $PWD:/build -e OPENAI_API_KEY="$OPENAI_API_KEY" datasqrl/cmd:latest compile -c study_api_package_test.json
Executing SQRL command: "compile" ...
Picked up JAVA_TOOL_OPTIONS: --add-exports=java.base/sun.net.util=ALL-UNNAMED   --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED   --add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED   --add-opens=java.base/java.lang=ALL-UNNAMED   --add-opens=java.base/java.net=ALL-UNNAMED   --add-opens=java.base/java.io=ALL-UNNAMED   --add-opens=java.base/java.nio=ALL-UNNAMED   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED   --add-opens=java.base/java.text=ALL-UNNAMED   --add-opens=java.base/java.time=ALL-UNNAMED   --add-opens=java.base/java.util=ALL-UNNAMED   --add-opens=java.base/java.util.concurrent=ALL-UNNAMED   --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED   --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
[WARN] The rowtime column 'timestamp' for this table is nullable
in script:study_api.sqrl [5:1]:
IMPORT masterdata-local.* AS _CDC_;

_ClinicalIndicator := SELECT sensorId, metric, `timestamp` FROM AddClinicalData;
^
The rowtime column is used to advance the watermark and for time-based operations. When it is null, the watermark does not advance and the record can be ignored for time-based operations, leading to unexpected output and performance issues.

Ensure that the rowtime column always has a value by filtering or setting a default. If that is the case but the compiler doesn't recognize it, explicitly cast it in the table definition.
For example:
`rowTime AS COALESCE(TO_TIMESTAMP_LTZ(lastUpdated, 0), TIMESTAMP '1970-01-01 00:00:00.000')`
```