### PR TITLE
Trim collected error stack trace to start with root cause

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/error/CollectedException.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/error/CollectedException.java
@@ -25,10 +25,25 @@ public class CollectedException extends RuntimeException {
     super("Collected exception", cause);
   }
 
-  // TODO: use this in ErrorCollector to pinpoint the actual error
+  /**
+   * Trims the {@code com.datasqrl.error} elements from the top of the stack trace, so the thrown or
+   * printed error will actually point to the root cause.
+   *
+   * @param cause original error
+   * @return error with the trimmed stack trace
+   */
   public static CollectedException withTrimmedStackTrace(Throwable cause) {
     var orig = cause.getStackTrace();
-    StackTraceElement[] trimmed = Arrays.copyOfRange(orig, 4, orig.length);
+
+    var elemsToTrim = 0;
+    for (var stackTraceElement : orig) {
+      if (!stackTraceElement.getClassName().startsWith(CollectedException.class.getPackageName())) {
+        break;
+      }
+      elemsToTrim++;
+    }
+
+    var trimmed = Arrays.copyOfRange(orig, elemsToTrim, orig.length);
     cause.setStackTrace(trimmed);
 
     return new CollectedException(cause);

--- a/sqrl-planner/src/main/java/com/datasqrl/error/ErrorCollector.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/error/ErrorCollector.java
@@ -206,7 +206,7 @@ public class ErrorCollector implements Iterable<ErrorMessage>, Serializable {
     ErrorMessage errorMessage =
         new Implementation(label, ErrorMessage.getMessage(msg, args), location, Severity.FATAL);
     addInternal(errorMessage);
-    return new CollectedException(errorMessage.asException());
+    return CollectedException.withTrimmedStackTrace(errorMessage.asException());
   }
 
   public void checkFatal(boolean condition, String msg, Object... args) {

--- a/sqrl-planner/src/main/java/com/datasqrl/error/ErrorMessage.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/error/ErrorMessage.java
@@ -41,7 +41,7 @@ public interface ErrorMessage {
 
   default String toStringNoSeverity() {
     var loc = getLocation().toString();
-    if (loc == null || loc.trim().isEmpty()) {
+    if (loc != null && !loc.trim().isEmpty()) {
       loc += ": ";
     }
     return loc + getMessage();


### PR DESCRIPTION
Before:
```
java.lang.IllegalArgumentException: Default configuration not found

	at com.datasqrl.error.ErrorMessage.asException(ErrorMessage.java:51)
	at com.datasqrl.error.ErrorCollector.exception(ErrorCollector.java:209)
	at com.datasqrl.error.ErrorCollector.exception(ErrorCollector.java:202)
	at com.datasqrl.util.ConfigLoaderUtils.loadUnresolvedConfig(ConfigLoaderUtils.java:211)
	at com.datasqrl.util.ConfigLoaderUtilsTest.asd(ConfigLoaderUtilsTest.java:208)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

After:
```
java.lang.IllegalArgumentException: Default configuration not found

	at com.datasqrl.util.ConfigLoaderUtils.loadUnresolvedConfig(ConfigLoaderUtils.java:211)
	at com.datasqrl.util.ConfigLoaderUtilsTest.asd(ConfigLoaderUtilsTest.java:208)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```