### PR TITLE
Add vertx config schema to package.json schema

### DIFF
--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -138,6 +138,20 @@
             }
           },
           "additionalProperties": false
+        },
+        "vertx": {
+          "type": "object",
+          "properties": {
+            "authKind": {
+              "type": "string",
+              "enum": ["NONE", "JWT"]
+            },
+            "config": {
+              "type": "object",
+              "minProperties": 1
+            }
+          },
+          "additionalProperties": false
         }
       }
     },


### PR DESCRIPTION
## Summary
- Added vertx config schema to package.json schema definition
- Allows vertx configuration object with minProperties constraint

## Test plan
- [x] Verify schema validates correctly
- [x] Run unit tests to ensure no regressions