### PR TITLE
Fix RestBridgeVerticle error response handling

### DIFF
--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/RestBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/RestBridgeVerticle.java
@@ -187,6 +187,7 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
                                             .put("path", err.getPath())
                                             .put("extensions", err.getExtensions()))
                                 .toList());
+                        ctx.end(json.encode());
                       } else {
                         Object result = getExecutionData(executionResult, operation);
                         ctx.end(new JsonObject().put(RESULT_DATA_KEY, result).encode());


### PR DESCRIPTION
## Summary
• Add missing ctx.end() call for GraphQL error responses in RestBridgeVerticle

## Test plan
• Verify error responses are properly terminated
• Test GraphQL operations with validation errors