### PR TITLE
Add container tests for HTTP request tracing functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,13 +255,9 @@ jobs:
             - m2-{{ checksum "pom.xml" }}
       - generate-settings
       - install-jdk
-      - compute-mcp-tag
-      - run:
-          name: Auth ghcr
-          command: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
       - run:
           name: Run Integration Tests
-          command: mvn -U -T2 -B install -DonlyITs -Dmcp.inspector.version=$MCP_TAG
+          command: mvn -U -T2 -B install -DonlyITs
       - save-test-results
 
   container-e2e-test:
@@ -273,15 +269,20 @@ jobs:
             - m2-{{ checksum "pom.xml" }}
       - generate-settings
       - install-jdk
+      - compute-mcp-tag
+      - run:
+          name: Auth ghcr
+          command: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
       - run:
           name: Build with Docker images
-          command: mvn -U clean -T1C -B install -DonlyImages -Ddocker.image.tag=${CIRCLE_SHA1}
+          command: mvn -U clean -T1C -B install -DonlyImages -Ddocker.image.tag=local-${CIRCLE_SHA1}
       - run:
           name: Run container tests using TestContainers
           command: |
             mvn -B install -DonlyContainerE2E \
               -pl :sqrl-container-testing \
-              -Ddocker.image.tag=${CIRCLE_SHA1}
+              -Ddocker.image.tag=local-${CIRCLE_SHA1} \
+              -Dmcp.inspector.version=$MCP_TAG
 
   deploy:
     docker:
@@ -471,6 +472,7 @@ workflows:
               ignore: /.*/
           requires:
             - download-maven-dependencies
+            - docker-build-mcp-inspector
       - integration-tests:
           <<: *job-defaults
           filters:
@@ -484,7 +486,6 @@ workflows:
               test_sharding_index: [0, 1]
           requires:
             - download-maven-dependencies
-            - docker-build-mcp-inspector
       - build-images:
           <<: *job-defaults
           requires:

--- a/Dockerfile.mcp-inspector
+++ b/Dockerfile.mcp-inspector
@@ -2,8 +2,9 @@
 # Pre-installs @modelcontextprotocol/inspector for faster test execution
 FROM node:18-alpine
 
-# Install MCP inspector globally
-RUN npm install -g @modelcontextprotocol/inspector
+# Update npm to latest version and install MCP inspector globally
+RUN npm install -g npm@11.4.2 && \
+    npm install -g @modelcontextprotocol/inspector
 
 # Add curl for health checks and debugging
 RUN apk add --no-cache curl

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/DetailedRequestTracer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/DetailedRequestTracer.java
@@ -44,6 +44,10 @@ public class DetailedRequestTracer implements Handler<RoutingContext> {
 
     // Capture request body
     var body = context.body();
+    log.debug("DEBUG [{}] - context.body() returned: {}", requestId, body);
+    if (body != null) {
+      log.debug("DEBUG [{}] - body.buffer() returned: {}", requestId, body.buffer());
+    }
     logRequestBody(body != null ? body.buffer() : null, requestId);
 
     // Hook into response end to log final details
@@ -82,13 +86,13 @@ public class DetailedRequestTracer implements Handler<RoutingContext> {
 
   private void logRequestBody(Buffer body, String requestId) {
     if (body == null) {
-      log.info("REQUEST BODY [{}] - No body", requestId);
+      log.info("REQUEST BODY [{}] - No body (null)", requestId);
       return;
     }
 
     var bodyStr = body.toString();
     if (bodyStr.isEmpty()) {
-      log.info("REQUEST BODY [{}] - Size: 0 bytes, Content: [EMPTY]", requestId);
+      log.info("REQUEST BODY [{}] - Size: {} bytes, Content: [EMPTY]", requestId, body.length());
       return;
     }
 

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/DetailedRequestTracer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/DetailedRequestTracer.java
@@ -44,9 +44,9 @@ public class DetailedRequestTracer implements Handler<RoutingContext> {
 
     // Capture request body
     var body = context.body();
-    log.debug("DEBUG [{}] - context.body() returned: {}", requestId, body);
+    log.debug("[{}] - context.body() returned: {}", requestId, body);
     if (body != null) {
-      log.debug("DEBUG [{}] - body.buffer() returned: {}", requestId, body.buffer());
+      log.debug("[{}] - body.buffer() returned: {}", requestId, body.buffer());
     }
     logRequestBody(body != null ? body.buffer() : null, requestId);
 

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
@@ -123,7 +123,7 @@ public class HttpServerVerticle extends AbstractVerticle {
     root.route().handler(BodyHandler.create());
 
     // Use detailed tracing if enabled, otherwise use standard logging (must be after BodyHandler)
-    if (Boolean.parseBoolean(System.getenv().getOrDefault("DATASQRL_TRACE_REQUESTS", "false"))) {
+    if (Boolean.parseBoolean(System.getenv().getOrDefault("SQRL_TRACE_REQUESTS", "false"))) {
       root.route().handler(DetailedRequestTracer.create());
     } else {
       root.route().handler(LoggerHandler.create());

--- a/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/SqrlLauncher.java
+++ b/sqrl-server/sqrl-server-vertx/src/main/java/com/datasqrl/graphql/SqrlLauncher.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.graphql;
 
+import com.datasqrl.env.GlobalEnvironmentStore;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.vertx.launcher.application.HookContext;
@@ -26,6 +27,8 @@ import io.vertx.micrometer.MicrometerMetricsFactory;
 public class SqrlLauncher implements VertxApplicationHooks {
 
   public static void main(String[] args) {
+    GlobalEnvironmentStore.putAll(System.getenv());
+
     if (args == null || args.length == 0) {
       args = new String[] {HttpServerVerticle.class.getName()};
     }

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
@@ -71,6 +71,7 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
     cmd = cmdContainer.withCommand("test", "flink_kafka.sqrl");
 
     log.info("Starting compilation with external Redpanda container");
+    log.info(getDockerRunCommand(cmd, testDir));
     log.info(
         "DataSQRL container environment: KAFKA_HOST={}, KAFKA_PORT={},"
             + " PROPERTIES_BOOTSTRAP_SERVERS={}",

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
@@ -70,7 +70,8 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
 
     log.info("Starting compilation with external Redpanda container");
     log.info(
-        "DataSQRL container environment: KAFKA_HOST={}, KAFKA_PORT={}, PROPERTIES_BOOTSTRAP_SERVERS={}",
+        "DataSQRL container environment: KAFKA_HOST={}, KAFKA_PORT={},"
+            + " PROPERTIES_BOOTSTRAP_SERVERS={}",
         REDPANDA_CONTAINER_NAME,
         REDPANDA_PORT,
         REDPANDA_CONTAINER_NAME + ":" + REDPANDA_PORT);

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlContainerTestBase.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlContainerTestBase.java
@@ -352,9 +352,7 @@ public abstract class SqrlContainerTestBase {
   }
 
   protected void compileAndStartServer(
-      String scriptName,
-      Path testDir,
-      java.util.function.Consumer<GenericContainer<?>> containerCustomizer)
+      String scriptName, Path testDir, Consumer<GenericContainer<?>> containerCustomizer)
       throws Exception {
     compileSqrlScript(scriptName, testDir);
     startGraphQLServer(testDir, containerCustomizer);

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlContainerTestBase.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/SqrlContainerTestBase.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -205,9 +206,16 @@ public abstract class SqrlContainerTestBase {
   }
 
   protected void startGraphQLServer(Path workingDir) {
+    startGraphQLServer(workingDir, c -> {});
+  }
+
+  protected void startGraphQLServer(
+      Path workingDir, Consumer<GenericContainer<?>> containerCustomizer) {
     log.info("Docker run command to reproduce:");
     log.info(getDockerRunCommand(workingDir, SQRL_SERVER_IMAGE, getImageTag(), true));
     serverContainer = createServerContainer(workingDir);
+
+    containerCustomizer.accept(serverContainer);
 
     try {
       serverContainer.start();
@@ -341,6 +349,15 @@ public abstract class SqrlContainerTestBase {
   protected void compileAndStartServer(String scriptName, Path testDir) throws Exception {
     compileSqrlScript(scriptName, testDir);
     startGraphQLServer(testDir);
+  }
+
+  protected void compileAndStartServer(
+      String scriptName,
+      Path testDir,
+      java.util.function.Consumer<GenericContainer<?>> containerCustomizer)
+      throws Exception {
+    compileSqrlScript(scriptName, testDir);
+    startGraphQLServer(testDir, containerCustomizer);
   }
 
   protected HttpResponse executeGraphQLQuery(String query) throws Exception {

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.container.testing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import lombok.SneakyThrows;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
@@ -47,7 +49,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
     var response = executeGraphQLQuery(testQuery);
     validateBasicGraphQLResponse(response);
 
-    verifyLogContains(serverContainer, "REQUEST BODY");
+    assertThat(serverContainer.getLogs()).contains("REQUEST BODY");
   }
 
   @Test
@@ -64,7 +66,8 @@ public class VertxContainerIT extends SqrlContainerTestBase {
 
     sharedHttpClient.execute(request);
 
-    verifyLogContains(serverContainer, "REQUEST BODY");
-    verifyLogContains(serverContainer, randomPath);
+    assertThat(serverContainer.getLogs()).contains("REQUEST BODY")
+    .contains(testBody)
+    .contains(randomPath);
   }
 }

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
@@ -46,7 +46,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
   @SneakyThrows
   void givenTraceRequestsEnabled_whenGraphQLRequestSent_thenRequestBodyLoggedInServerLogs() {
     compileAndStartServer(
-        "myudf.sqrl", testDir, container -> container.withEnv("DATASQRL_TRACE_REQUESTS", "true"));
+        "myudf.sqrl", testDir, container -> container.withEnv("SQRL_TRACE_REQUESTS", "true"));
 
     var testQuery = "{\"query\":\"query { __typename }\"}";
     var response = executeGraphQLQuery(testQuery);
@@ -59,7 +59,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
   @SneakyThrows
   void givenTraceRequestsEnabled_whenHttpRequestsMade_thenLogPathAndBody() {
     compileAndStartServer(
-        "myudf.sqrl", testDir, container -> container.withEnv("DATASQRL_TRACE_REQUESTS", "true"));
+        "myudf.sqrl", testDir, container -> container.withEnv("SQRL_TRACE_REQUESTS", "true"));
 
     var testQuery = "{\"query\":\"query { __typename }\"}";
     var response = executeGraphQLQuery(testQuery);

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
@@ -17,14 +17,13 @@ package com.datasqrl.container.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import lombok.SneakyThrows;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
-
-import lombok.SneakyThrows;
 
 public class VertxContainerIT extends SqrlContainerTestBase {
 
@@ -82,7 +81,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
         .contains("REQUEST BODY")
         .contains(testBody)
         .contains(randomPath);
-        
+
     var graphiqlResponse = sharedHttpClient.execute(new HttpGet(getBaseUrl() + "/graphiql/"));
 
     assertThat(graphiqlResponse.getStatusLine().getStatusCode()).isEqualTo(200);
@@ -102,7 +101,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
         .contains("static/js/main.")
         .contains("static/css/main.")
         .contains("<div id=\"root\"></div>");
-        
+
     assertThat(serverContainer.getLogs())
         .contains("INCOMING REQUEST")
         .contains("Method: GET")

--- a/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
+++ b/sqrl-testing/sqrl-container-testing/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
@@ -17,11 +17,14 @@ package com.datasqrl.container.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import lombok.SneakyThrows;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+
+import lombok.SneakyThrows;
 
 public class VertxContainerIT extends SqrlContainerTestBase {
 
@@ -54,20 +57,55 @@ public class VertxContainerIT extends SqrlContainerTestBase {
 
   @Test
   @SneakyThrows
-  void givenTraceRequestsEnabled_whenPostToRandomPath_thenPathAndBodyLoggedInServerLogs() {
+  void givenTraceRequestsEnabled_whenHttpRequestsMade_thenLogPathAndBody() {
     compileAndStartServer(
         "myudf.sqrl", testDir, container -> container.withEnv("DATASQRL_TRACE_REQUESTS", "true"));
+
+    var testQuery = "{\"query\":\"query { __typename }\"}";
+    var response = executeGraphQLQuery(testQuery);
+    validateBasicGraphQLResponse(response);
+
+    assertThat(serverContainer.getLogs())
+        .contains("REQUEST BODY")
+        .contains(testQuery)
+        .contains("/graphql");
 
     var randomPath = "/random/test/path/12345";
     var testBody = "{\"test\":\"data\",\"random\":\"content\"}";
 
-    var request = new HttpPost(getBaseUrl() + randomPath);
-    request.setEntity(new StringEntity(testBody, ContentType.APPLICATION_JSON));
+    var randomRequest = new HttpPost(getBaseUrl() + randomPath);
+    randomRequest.setEntity(new StringEntity(testBody, ContentType.APPLICATION_JSON));
 
-    sharedHttpClient.execute(request);
+    sharedHttpClient.execute(randomRequest);
 
-    assertThat(serverContainer.getLogs()).contains("REQUEST BODY")
-    .contains(testBody)
-    .contains(randomPath);
+    assertThat(serverContainer.getLogs())
+        .contains("REQUEST BODY")
+        .contains(testBody)
+        .contains(randomPath);
+        
+    var graphiqlResponse = sharedHttpClient.execute(new HttpGet(getBaseUrl() + "/graphiql/"));
+
+    assertThat(graphiqlResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+    assertThat(graphiqlResponse.getFirstHeader("Content-Type").getValue()).contains("text/html");
+
+    var graphiql = EntityUtils.toString(graphiqlResponse.getEntity());
+
+    assertThat(graphiql)
+        .contains("<!doctype html>")
+        .contains("<html lang=\"en\">")
+        .contains("<title>GraphiQL</title>")
+        .contains("window.VERTX_GRAPHIQL_CONFIG")
+        .contains("\"httpEnabled\":true")
+        .contains("\"graphQLUri\":\"/graphql\"")
+        .contains("\"graphQLWSEnabled\":true")
+        .contains("\"graphQLWSUri\":\"/graphql\"")
+        .contains("static/js/main.")
+        .contains("static/css/main.")
+        .contains("<div id=\"root\"></div>");
+        
+    assertThat(serverContainer.getLogs())
+        .contains("INCOMING REQUEST")
+        .contains("Method: GET")
+        .contains("URI: /graphiql/");
   }
 }


### PR DESCRIPTION
Add test to verify `DATASQRL_TRACE_REQUESTS=true` logs GraphQL request bodies  