### PR TITLE
Fix `node` version in the MCP docker image

### DIFF
--- a/Dockerfile.mcp-inspector
+++ b/Dockerfile.mcp-inspector
@@ -1,6 +1,6 @@
 # MCP Inspector Docker Image
 # Pre-installs @modelcontextprotocol/inspector for faster test execution
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Update npm to latest version and install MCP inspector globally
 RUN npm install -g npm@11.4.2 && \


### PR DESCRIPTION
It seems the `node` minimum version requirement for `npm@11` changed to `20`, and that broke the MCP docker img.

Error from CircleCI:
```
 => ERROR [linux/amd64 2/4] RUN npm install -g npm@11.4.2 &&     npm inst  0.8s
 => CANCELED [linux/arm64 2/4] RUN npm install -g npm@11.4.2 &&     npm i  0.7s
------
 > [linux/amd64 2/4] RUN npm install -g npm@11.4.2 &&     npm install -g @modelcontextprotocol/inspector:
0.603 npm error code EBADENGINE
0.603 npm error engine Unsupported engine
0.603 npm error engine Not compatible with your version of node/npm: npm@11.4.2
0.603 npm error notsup Not compatible with your version of node/npm: npm@11.4.2
0.603 npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
0.603 npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
0.605 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-07-25T17_20_59_740Z-debug-0.log
------
Dockerfile.mcp-inspector:6
--------------------
   5 |     # Update npm to latest version and install MCP inspector globally
   6 | >>> RUN npm install -g npm@11.4.2 && \
   7 | >>>     npm install -g @modelcontextprotocol/inspector
   8 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install -g npm@11.4.2 &&     npm install -g @modelcontextprotocol/inspector" did not complete successfully: exit code: 1
```