### PR TITLE
Fix silently ignored JSON parsing exceptions in ServerConfigUtil

### DIFF
--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfigUtil.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfigUtil.java
@@ -62,13 +62,7 @@ public class ServerConfigUtil {
     if (fieldValue == null) {
       return defaultVal.get();
     }
-    try {
-      return ctor.apply(fieldValue);
-    } catch (Exception e) {
-      log.warn(
-          "Failed to parse configuration field '{}', using default: {}", fieldName, e.getMessage());
-      return defaultVal.get();
-    }
+    return ctor.apply(fieldValue);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Removed try-catch block in ServerConfigUtil that was silently ignoring JSON parsing exceptions
- Invalid JSON in configuration will now properly throw exceptions instead of being ignored

## Test plan
- Existing tests should continue to pass
- Invalid JSON configurations will now fail fast with clear error messages