### PR TITLE
Support for Passthrough queries

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/JdbcStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/JdbcStatementFactory.java
@@ -20,7 +20,6 @@ import com.datasqrl.plan.global.IndexDefinition;
 import com.datasqrl.planner.dag.plan.MaterializationStagePlan.Query;
 import java.util.List;
 import java.util.Map;
-import lombok.Value;
 
 public interface JdbcStatementFactory {
 
@@ -39,11 +38,11 @@ public interface JdbcStatementFactory {
   QueryResult createQuery(
       Query query, boolean withView, Map<String, JdbcEngineCreateTable> tableIdMap);
 
+  QueryResult createPassthroughQuery(Query query, boolean withView);
+
   JdbcStatement addIndex(IndexDefinition indexDefinition);
 
-  @Value
-  class QueryResult {
-    ExecutableJdbcReadQuery.ExecutableJdbcReadQueryBuilder execQueryBuilder;
-    JdbcStatement view;
-  }
+  record QueryResult(
+      ExecutableJdbcReadQuery.ExecutableJdbcReadQueryBuilder execQueryBuilder,
+      JdbcStatement view) {}
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/statements/GenericCreateViewDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/statements/GenericCreateViewDdlFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational.ddl.statements;
+
+import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifier;
+
+import com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GenericCreateViewDdlFactory {
+
+  public String createView(String viewName, List<String> columns, String select) {
+    var colStr =
+        columns.stream()
+            .map(AbstractJdbcStatementFactory::quoteIdentifier)
+            .collect(Collectors.joining(", "));
+
+    return "CREATE OR REPLACE VIEW %s (%s) AS %s"
+        .formatted(quoteIdentifier(viewName), colStr, select);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
@@ -278,6 +278,10 @@ public class KafkaLogEngine extends ExecutionEngine.Base implements LogEngine {
           "The Kafka engine currently only supports"
               + "simple filter queries without any transformations, but got: %s",
           relNode.explain());
+      errors.checkFatal(
+          !query.getFunction().isPassthrough(),
+          "Kafka does not support passthrough queries: %s",
+          query.getFunction());
       RelOptTable table = relNode.getTable();
       var tableName = table.getQualifiedName().get(2);
       var topicName = table2TopicMap.get(tableName);

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
@@ -84,7 +84,7 @@ public class GraphqlModelGenerator extends GraphqlSchemaWalker {
   protected void visitSubscription(
       FieldDefinition atField, SqrlTableFunction tableFunction, TypeDefinitionRegistry registry) {
     Preconditions.checkArgument(
-        tableFunction.getVisibility().getAccess() == AccessModifier.SUBSCRIPTION);
+        tableFunction.getVisibility().access() == AccessModifier.SUBSCRIPTION);
     final var executableQuery = tableFunction.getExecutableQuery();
 
     var fieldName = atField.getName();

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlSchemaFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlSchemaFactory.java
@@ -125,7 +125,7 @@ public class GraphqlSchemaFactory {
 
     final List<SqrlTableFunction> tableFunctions =
         serverPlan.getFunctions().stream()
-            .filter(function -> function.getVisibility().getAccess() == tableFunctionsType)
+            .filter(function -> function.getVisibility().access() == tableFunctionsType)
             .toList();
 
     // group table functions by their parent path
@@ -370,7 +370,7 @@ public class GraphqlSchemaFactory {
                         .build())
             .collect(Collectors.toList());
     List<GraphQLArgument> limitAndOffsetArguments = List.of();
-    if (tableFunction.getVisibility().getAccess() != AccessModifier.SUBSCRIPTION
+    if (tableFunction.getVisibility().access() != AccessModifier.SUBSCRIPTION
         && tableFunction.getMultiplicity() == Multiplicity.MANY) {
       limitAndOffsetArguments = generateLimitAndOffsetArguments();
     }

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlSchemaWalker.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlSchemaWalker.java
@@ -138,7 +138,7 @@ public abstract class GraphqlSchemaWalker {
         typeDefinition.getSourceLocation(),
         "Could not infer non-object type on graphql schema: %s",
         typeDefinition.getName());
-    if (tableFunction.getVisibility().getAccess()
+    if (tableFunction.getVisibility().access()
         == AccessModifier.QUERY) { // walking a query table function
       visitQuery(parentType, atField, tableFunction, registry);
     } else { // walking a subscription table function

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
@@ -356,13 +356,18 @@ public class DAGPlanner {
                 }
                 if (function != null) {
                   var originalRelnode = function.getFunctionAnalysis().getRelNode();
-                  var plannedRelNode =
-                      originalRelnode.accept(
-                          new QueryExpansionRelShuttle(
-                              id -> streamTableMapping.get(new InputTableKey(dataStoreStage, id)),
-                              sqrlEnv,
-                              dbEngine.getTypeMapping(),
-                              true));
+                  RelNode plannedRelNode;
+                  if (function.isPassthrough()) {
+                    plannedRelNode = originalRelnode;
+                  } else {
+                    plannedRelNode =
+                        originalRelnode.accept(
+                            new QueryExpansionRelShuttle(
+                                id -> streamTableMapping.get(new InputTableKey(dataStoreStage, id)),
+                                sqrlEnv,
+                                dbEngine.getTypeMapping(),
+                                true));
+                  }
                   dbPlan.query(
                       new Query(
                           function, plannedRelNode, function.getFunctionAnalysis().getErrors()));

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlPassthroughTableFunctionStatement.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlPassthroughTableFunctionStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.parser;
+
+import com.datasqrl.canonicalizer.NamePath;
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * A table function that passes the SQL directly through to the database engine for execution
+ * (without parsing/validating). Requires a return type so we know what types of records it returns
+ * (since we don't analyze it).
+ */
+@Getter
+public class SqrlPassthroughTableFunctionStatement extends SqrlTableFunctionStatement {
+
+  private final ParsedObject<String> returnType;
+
+  public SqrlPassthroughTableFunctionStatement(
+      ParsedObject<NamePath> tableName,
+      ParsedObject<String> definitionBody,
+      AccessModifier access,
+      SqrlComments comments,
+      ParsedObject<String> signature,
+      List<ParsedArgument> argumentsByIndex,
+      ParsedObject<String> returnType) {
+    super(tableName, definitionBody, access, comments, signature, argumentsByIndex);
+    this.returnType = returnType;
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/tables/AccessVisibility.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/tables/AccessVisibility.java
@@ -16,35 +16,24 @@
 package com.datasqrl.planner.tables;
 
 import com.datasqrl.planner.parser.AccessModifier;
-import lombok.Value;
 
-/** Defines the visibility of a {@link com.datasqrl.planner.tables.SqrlTableFunction} */
-@Value
-public class AccessVisibility {
+/**
+ * Defines the visibility of a {@link SqrlTableFunction}
+ *
+ * @param access The type of access: Query or Subscription; if access type is NONE it means the
+ *     function cannot be queried and is only used for planning.
+ * @param isTest If the table has been annotated as a test in the SQRL file
+ * @param isAccessOnly Access only table functions are only queryable and not added to the
+ *     planner/catalog, i.e. they cannot be referenced in subsequent definitions in a SQRL script
+ *     Access only functions represent relationships or functions generated for queryable tables.
+ * @param isHidden Whether this table (function) is visible to external consumers (i.e. as an API
+ *     call or view)
+ */
+public record AccessVisibility(
+    AccessModifier access, boolean isTest, boolean isAccessOnly, boolean isHidden) {
 
   public static final AccessVisibility NONE =
       new AccessVisibility(AccessModifier.NONE, false, false, true);
-
-  /**
-   * The type of access: Query or Subscription; if access type is NONE it means the function cannot
-   * be queried and is only used for planning.
-   */
-  AccessModifier access;
-
-  /** If the table has been annotated as a test in the SQRL file */
-  boolean isTest;
-
-  /**
-   * Access only table functions are only queryable and not added to the planner/catalog, i.e. they
-   * cannot be referenced in subsequent definitions in a SQRL script Access only functions represent
-   * relationships or functions generated for queryable tables.
-   */
-  boolean isAccessOnly;
-
-  /**
-   * Whether this table (function) is visible to external consumers (i.e. as an API call or view)
-   */
-  boolean isHidden;
 
   public boolean isEndpoint() {
     return (access == AccessModifier.QUERY || access == AccessModifier.SUBSCRIPTION);

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/tables/SqrlTableFunction.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/tables/SqrlTableFunction.java
@@ -89,6 +89,12 @@ public class SqrlTableFunction implements TableFunction, TableOrFunctionAnalysis
 
   @Default private Duration cacheDuration = Duration.ZERO;
 
+  /**
+   * Whether this is a passthrough function where the SQL gets executed directly against the engine
+   * without analysis/translation
+   */
+  @Default private boolean passthrough = false;
+
   @Override
   public RelDataType getRowType(
       RelDataTypeFactory relDataTypeFactory, List<? extends Object> list) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqlTableNameExtractor.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqlTableNameExtractor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SqlTableNameExtractor {
+
+  /** Regex that captures a single identifier in any quoting style. */
+  private static final String IDENTIFIER =
+      "(?:`([^`]+)`|\"([^\"]+)\"|\\[([^\\]]+)\\]|([a-zA-Z_][a-zA-Z0-9_$]*))";
+
+  /** FROM / JOIN pattern (same as before, minus compile in loop). */
+  private static final Pattern TABLE_PATTERN =
+      Pattern.compile(
+          "\\b(?:from|join)\\s+"
+              + "(?!\\(\\s*select)"
+              + // negative lookahead to skip subqueries
+              IDENTIFIER,
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  /** CTE definition pattern: WITH [RECURSIVE] <ident> AS ( … ) [, <ident> AS ( … )]* */
+  private static final Pattern CTE_PATTERN =
+      Pattern.compile(
+          "\\bwith\\s+(?:recursive\\s+)?"
+              + IDENTIFIER
+              + "\\s+as\\s*\\("
+              + "(?:[^()]*+|\\((?:[^()]*+|\\([^()]*+\\))*+\\))*+"
+              + "\\)"
+              + "(?:\\s*,\\s*"
+              + IDENTIFIER
+              + "\\s+as\\s*\\("
+              + "(?:[^()]*+|\\((?:[^()]*+|\\([^()]*+\\))*+\\))*+\\))*",
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  /**
+   * Extracts all the table names from a given SQL string (but excluding CTEs defined in the
+   * string).
+   *
+   * <p>Assumptions
+   *
+   * <ul>
+   *   <li>Each table is referenced by a single identifier (no db.schema.table).
+   *   <li>Identifiers may be bare (<code>orders</code>) or quoted with back-ticks (<code>`Orders`
+   *       </code>), double-quotes (<code>"Orders"</code>), or square brackets (<code>[Orders]
+   *       </code>).
+   *   <li>SQL comments (<code>-- …</code> &amp; /* ..) and string literals are ignored to prevent
+   *       false positives.
+   * </ul>
+   *
+   * @param sql Arbitrary SQL statement (may contain multiple sub-queries)
+   * @return Set of distinct table names as they appear in the query (quotes removed)
+   */
+  public static Set<String> findTableNames(String sql) {
+    Objects.requireNonNull(sql, "sql");
+
+    String sanitized = stripLiteralsAndComments(sql).replaceAll("\\s+", " ");
+
+    // 1. Collect names defined in the WITH-clause (CTEs)
+    Set<String> cteNames = extractCteNames(sanitized);
+
+    // 2. Collect everything that sits after FROM / JOIN
+    Set<String> all = extractFromJoinIdentifiers(sanitized);
+
+    // 3. Remove the CTE names – what is left are the base tables
+    all.removeAll(cteNames);
+    return all;
+  }
+
+  private static Set<String> extractFromJoinIdentifiers(String sql) {
+    Set<String> tables = new LinkedHashSet<>();
+
+    // First, extract table names from subqueries by recursively processing them
+    Pattern subqueryPattern =
+        Pattern.compile(
+            "\\b(?:from|join)\\s+\\(\\s*(select.*?)\\)\\s*(?:as\\s+)?\\w*\\s*",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    Matcher subqueryMatcher = subqueryPattern.matcher(sql);
+    while (subqueryMatcher.find()) {
+      String subquery = subqueryMatcher.group(1);
+      tables.addAll(extractFromJoinIdentifiers(subquery)); // Recursive call
+    }
+
+    // Then extract direct table references (excluding subqueries)
+    Matcher m = TABLE_PATTERN.matcher(sql);
+    while (m.find()) {
+      addFirstNonNullGroup(tables, m, 4);
+    }
+    return tables;
+  }
+
+  private static Set<String> extractCteNames(String sql) {
+    Set<String> ctes = new HashSet<>();
+    Matcher m = CTE_PATTERN.matcher(sql);
+    while (m.find()) {
+      // The pattern captures one or more identifiers; step through all captures
+      for (int g = 1; g <= 4; g++) addFirstNonNullGroup(ctes, m, g);
+      // For additional CTEs in the same WITH, groups repeat after the big match.
+      for (int g = 5; g <= m.groupCount(); g += 4) {
+        for (int sub = g; sub < g + 4; sub++) {
+          String id = m.group(sub);
+          if (id != null) {
+            ctes.add(stripQuotes(id));
+            break;
+          }
+        }
+      }
+    }
+    return ctes;
+  }
+
+  /* --------------------- utility helpers ----------------------------- */
+
+  private static void addFirstNonNullGroup(Set<String> out, Matcher m, int maxGroup) {
+    for (int g = 1; g <= maxGroup; g++) {
+      String id = m.group(g);
+      if (id != null) {
+        out.add(stripQuotes(id));
+        break;
+      }
+    }
+  }
+
+  private static String stripQuotes(String s) {
+    // Caller guarantees no mixed quoting, so trim leading/trailing quote char.
+    if (s.length() > 1 && ("`\"[".indexOf(s.charAt(0)) >= 0)) {
+      return s.substring(1, s.length() - 1);
+    }
+    return s;
+  }
+
+  private static String stripLiteralsAndComments(String s) {
+    // Remove single‑line comments
+    s = s.replaceAll("(?m)--.*?$", " ");
+    // Remove multi‑line comments
+    s = s.replaceAll("/\\*.*?\\*/", " ");
+    // Remove single‑quoted string literals
+    s = s.replaceAll("'(?:''|[^'])*'", " ");
+    // Remove PostgreSQL dollar‑quoted literals
+    s = s.replaceAll("(?s)\\$\\$.*?\\$\\$", " ");
+    return s;
+  }
+}

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/util/SqlTableNameExtractorTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/util/SqlTableNameExtractorTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SqlTableNameExtractorTest {
+
+  @Test
+  void givenSimpleQuery_whenFindTableNames_thenReturnsTableName() {
+    String sql = "SELECT * FROM orders";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactly("orders");
+  }
+
+  @Test
+  void givenQueryWithJoin_whenFindTableNames_thenReturnsBothTables() {
+    String sql = "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("orders", "customers");
+  }
+
+  @Test
+  void givenQueryWithCTE_whenFindTableNames_thenExcludesCTEFromResults() {
+    String sql =
+        """
+      WITH recent_orders AS (
+          SELECT * FROM orders WHERE order_date >= CURRENT_DATE - 1
+      ),
+      enriched AS (
+          SELECT r.*, c.name FROM recent_orders r
+          JOIN customers c ON c.id = r.customer_id
+      )
+      SELECT * FROM enriched JOIN audit_log al ON al.order_id = enriched.id
+      """;
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("orders", "customers", "audit_log");
+  }
+
+  @Test
+  void givenQueryWithQuotedIdentifiers_whenFindTableNames_thenHandlesAllQuoteTypes() {
+    String sql = "SELECT * FROM `Orders` JOIN \"Customers\" c ON c.id = [Orders].customer_id";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("Orders", "Customers");
+  }
+
+  @Test
+  void givenQueryWithComments_whenFindTableNames_thenIgnoresComments() {
+    String sql =
+        """
+      -- This is a comment with table_name_in_comment
+      SELECT * FROM orders /* another comment with products */
+      JOIN customers c ON c.id = o.customer_id
+      """;
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("orders", "customers");
+  }
+
+  @Test
+  void givenRecursiveCTEQuery_whenFindTableNames_thenExtractsTablesExcludingCTE() {
+    String sql =
+        """
+      WITH RECURSIVE employee_hierarchy AS (
+        -- Base case: direct reports
+        SELECT r.employeeid, r.managerid, 1 as level
+        FROM Reporting r
+        WHERE r.managerid = this.employeeid
+
+        UNION ALL
+
+        -- Recursive case: reports of reports
+        SELECT r.employeeid, r.managerid, eh.level + 1 as level
+        FROM Reporting r
+        INNER JOIN employee_hierarchy eh ON r.managerid = eh.employeeid
+      )
+      SELECT e.employeeid, e.name, eh.level
+      FROM employee_hierarchy eh
+      JOIN Employees e ON eh.employeeid = e.employeeid
+      ORDER BY eh.level, e.employeeid
+      """;
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("Reporting", "Employees");
+  }
+
+  @Test
+  void givenQueryWithStringLiterals_whenFindTableNames_thenIgnoresLiterals() {
+    String sql = "SELECT * FROM orders WHERE description = 'FROM customers table'";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactly("orders");
+  }
+
+  @Test
+  void givenQueryWithSubquery_whenFindTableNames_thenHandlesSubqueries() {
+    String sql = "SELECT * FROM (SELECT * FROM orders) o JOIN customers c ON o.customer_id = c.id";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("orders", "customers");
+  }
+
+  @Test
+  void givenQueryWithMultipleJoinTypes_whenFindTableNames_thenHandlesAllJoinTypes() {
+    String sql =
+        """
+      SELECT * FROM orders o
+      LEFT JOIN customers c ON o.customer_id = c.id
+      RIGHT JOIN products p ON o.product_id = p.id
+      INNER JOIN categories cat ON p.category_id = cat.id
+      """;
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("orders", "customers", "products", "categories");
+  }
+
+  @Test
+  void givenQueryWithDollarQuotedLiterals_whenFindTableNames_thenIgnoresDollarQuotes() {
+    String sql = "SELECT * FROM orders WHERE description = $$FROM customers table$$";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactly("orders");
+  }
+
+  @Test
+  void givenComplexNestedCTE_whenFindTableNames_thenHandlesNestedStructures() {
+    String sql =
+        """
+      WITH recursive_cte AS (
+        SELECT * FROM base_table
+        UNION ALL
+        SELECT * FROM recursive_cte r JOIN child_table c ON r.id = c.parent_id
+      ),
+      final_cte AS (
+        SELECT * FROM recursive_cte JOIN lookup_table l ON recursive_cte.type = l.type
+      )
+      SELECT * FROM final_cte JOIN results r ON final_cte.id = r.id
+      """;
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder("base_table", "child_table", "lookup_table", "results");
+  }
+
+  @Test
+  void givenEmptyString_whenFindTableNames_thenReturnsEmptySet() {
+    String sql = "";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void
+      givenQueryWithIdentifiersContainingDollarsAndUnderscores_whenFindTableNames_thenHandlesSpecialCharacters() {
+    String sql =
+        "SELECT * FROM order_items_$temp JOIN customer_data_2024 c ON c.id = order_items_$temp.customer_id";
+
+    Set<String> result = SqlTableNameExtractor.findTableNames(sql);
+
+    assertThat(result).containsExactlyInAnyOrder("order_items_$temp", "customer_data_2024");
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
@@ -60,7 +60,7 @@ public class FullUseCaseIT extends AbstractFullUseCaseTest {
   @Disabled("Intended for manual usage")
   @Test
   void specificUseCase() {
-    var pkg = USE_CASES.resolve("analytics-only").resolve("package.json");
+    var pkg = USE_CASES.resolve("passthrough").resolve("package.json");
 
     var param = new UseCaseParam(pkg);
     fullUseCaseTest(param);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/passthroughTest.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/passthroughTest.sqrl
@@ -1,0 +1,9 @@
+IMPORT ecommerceTs.Orders;
+
+FilteredOrders := SELECT * FROM Orders WHERE id>0;
+
+PassThroughTable RETURNS (id BIGINT NOT NULL, updateTime TIMESTAMP_LTZ(3) NOT NULL):=
+                 SELECT id, time AS updateTime FROM "FilteredOrders";
+
+PassThroughFunction(customerid BIGINT NOT NULL) RETURNS (id BIGINT NOT NULL) :=
+                   SELECT id FROM "FilteredOrders" WHERE customerid = :customerid;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
@@ -1,0 +1,510 @@
+>>>pipeline_explain.txt
+=== FilteredOrders
+ID:     default_catalog.default_database.FilteredOrders
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.Orders
+Annotations:
+ - stream-root: Orders
+Primary Key: id, time
+Timestamp  : time
+Schema:
+ - id: BIGINT NOT NULL
+ - customerid: BIGINT NOT NULL
+ - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+ - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
+Plan:
+LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3])
+  LogicalFilter(condition=[>($0, 0)])
+    LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+SQL: CREATE VIEW FilteredOrders AS  SELECT * FROM Orders WHERE id>0;
+
+=== Orders
+ID:     default_catalog.default_database.Orders
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database.Orders__base
+Annotations:
+ - features: DENORMALIZE (feature)
+ - stream-root: Orders
+Primary Key: id, time
+Timestamp  : time
+Schema:
+ - id: BIGINT NOT NULL
+ - customerid: BIGINT NOT NULL
+ - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+ - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
+Plan:
+LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
+  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+SQL: CREATE VIEW `Orders__view`
+AS
+SELECT `Orders`.`id`, `Orders`.`customerid`, `Orders`.`time`, `Orders`.`entries`
+FROM `default_catalog`.`default_database`.`Orders` AS `Orders`
+=== PassThroughFunction
+ID:     default_catalog.default_database.PassThroughFunction
+Type:   query
+Stage:  postgres
+Inputs: default_catalog.default_database.FilteredOrders
+Annotations:
+ - parameters: customerid
+ - base-table: PassThroughFunction
+Plan:
+LogicalValues(tuples=[[]])
+SQL: SELECT id FROM "FilteredOrders" WHERE customerid = $?$0
+=== PassThroughTable
+ID:     default_catalog.default_database.PassThroughTable
+Type:   query
+Stage:  postgres
+Inputs: default_catalog.default_database.FilteredOrders
+Annotations:
+ - base-table: PassThroughTable
+Plan:
+LogicalValues(tuples=[[]])
+SQL: SELECT id, time AS updateTime FROM "FilteredOrders"
+>>>flink-sql-no-functions.sql
+CREATE TEMPORARY TABLE `Orders__schema` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
+) WITH (
+  'connector' = 'datagen'
+);
+CREATE TABLE `Orders` (
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
+  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
+) WITH (
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec',
+  'connector' = 'filesystem'
+)
+LIKE `Orders__schema`;
+CREATE VIEW `FilteredOrders`
+AS
+SELECT *
+FROM `Orders`
+WHERE `id` > 0;
+CREATE TABLE `FilteredOrders_1` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `entries` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'FilteredOrders_1',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Orders_2` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `entries` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'Orders_2',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_1`
+(SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
+ FROM `default_catalog`.`default_database`.`FilteredOrders`)
+;
+INSERT INTO `default_catalog`.`default_database`.`Orders_2`
+ (SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
+  FROM `default_catalog`.`default_database`.`Orders`)
+ ;
+ END
+>>>kafka.json
+{
+  "topics" : [ ],
+  "testRunnerTopics" : [ ]
+}
+>>>postgres.json
+{
+  "statements" : [
+    {
+      "name" : "FilteredOrders_1",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"FilteredOrders_1\" (\"id\" BIGINT NOT NULL, \"customerid\" BIGINT NOT NULL, \"time\" TIMESTAMP WITH TIME ZONE NOT NULL, \"entries\" JSONB, PRIMARY KEY (\"id\",\"time\"))",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "id",
+        "time"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "Orders_2",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"Orders_2\" (\"id\" BIGINT NOT NULL, \"customerid\" BIGINT NOT NULL, \"time\" TIMESTAMP WITH TIME ZONE NOT NULL, \"entries\" JSONB, PRIMARY KEY (\"id\",\"time\"))",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "id",
+        "time"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "FilteredOrders",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"FilteredOrders\"(\"id\", \"customerid\", \"time\", \"entries\") AS SELECT *\nFROM \"FilteredOrders_1\"",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "Orders",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"Orders\"(\"id\", \"customerid\", \"time\", \"entries\") AS SELECT *\nFROM \"Orders_2\"",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "PassThroughTable",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"PassThroughTable\" (\"id\", \"updateTime\") AS SELECT id, time AS updateTime FROM \"FilteredOrders\"",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "updateTime",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ]
+    }
+  ]
+}
+>>>vertx.json
+{
+  "model" : {
+    "queries" : [
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "FilteredOrders",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT *\nFROM \"FilteredOrders_1\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Orders",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT *\nFROM \"Orders_2\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "PassThroughFunction",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "customerid"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT id FROM \"FilteredOrders\" WHERE customerid = $1",
+            "parameters" : [
+              {
+                "type" : "arg",
+                "path" : "customerid"
+              }
+            ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "PassThroughTable",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT id, time AS updateTime FROM \"FilteredOrders\"",
+            "parameters" : [ ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      }
+    ],
+    "mutations" : [ ],
+    "subscriptions" : [ ],
+    "operations" : [
+      {
+        "function" : {
+          "name" : "GetFilteredOrders",
+          "parameters" : {
+            "type" : "object",
+            "properties" : {
+              "offset" : {
+                "type" : "integer"
+              },
+              "limit" : {
+                "type" : "integer"
+              }
+            },
+            "required" : [ ]
+          }
+        },
+        "format" : "JSON",
+        "apiQuery" : {
+          "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+          "queryName" : "FilteredOrders",
+          "operationType" : "QUERY"
+        },
+        "mcpMethod" : "TOOL",
+        "restMethod" : "GET",
+        "uriTemplate" : "queries/FilteredOrders{?offset,limit}"
+      },
+      {
+        "function" : {
+          "name" : "GetOrders",
+          "parameters" : {
+            "type" : "object",
+            "properties" : {
+              "offset" : {
+                "type" : "integer"
+              },
+              "limit" : {
+                "type" : "integer"
+              }
+            },
+            "required" : [ ]
+          }
+        },
+        "format" : "JSON",
+        "apiQuery" : {
+          "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+          "queryName" : "Orders",
+          "operationType" : "QUERY"
+        },
+        "mcpMethod" : "TOOL",
+        "restMethod" : "GET",
+        "uriTemplate" : "queries/Orders{?offset,limit}"
+      },
+      {
+        "function" : {
+          "name" : "GetPassThroughFunction",
+          "parameters" : {
+            "type" : "object",
+            "properties" : {
+              "offset" : {
+                "type" : "integer"
+              },
+              "customerid" : {
+                "type" : "integer"
+              },
+              "limit" : {
+                "type" : "integer"
+              }
+            },
+            "required" : [
+              "customerid"
+            ]
+          }
+        },
+        "format" : "JSON",
+        "apiQuery" : {
+          "query" : "query PassThroughFunction($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nPassThroughFunction(customerid: $customerid, limit: $limit, offset: $offset) {\nid\n}\n\n}",
+          "queryName" : "PassThroughFunction",
+          "operationType" : "QUERY"
+        },
+        "mcpMethod" : "TOOL",
+        "restMethod" : "GET",
+        "uriTemplate" : "queries/PassThroughFunction{?offset,customerid,limit}"
+      },
+      {
+        "function" : {
+          "name" : "GetPassThroughTable",
+          "parameters" : {
+            "type" : "object",
+            "properties" : {
+              "offset" : {
+                "type" : "integer"
+              },
+              "limit" : {
+                "type" : "integer"
+              }
+            },
+            "required" : [ ]
+          }
+        },
+        "format" : "JSON",
+        "apiQuery" : {
+          "query" : "query PassThroughTable($limit: Int = 10, $offset: Int = 0) {\nPassThroughTable(limit: $limit, offset: $offset) {\nid\nupdateTime\n}\n\n}",
+          "queryName" : "PassThroughTable",
+          "operationType" : "QUERY"
+        },
+        "mcpMethod" : "TOOL",
+        "restMethod" : "GET",
+        "uriTemplate" : "queries/PassThroughTable{?offset,limit}"
+      }
+    ],
+    "schema" : {
+      "type" : "string",
+      "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Orders {\n  id: Long!\n  customerid: Long!\n  time: DateTime!\n  entries: [Orders_entriesOutput]!\n}\n\ntype Orders_entriesOutput {\n  productid: Long!\n  quantity: Long!\n  unit_price: Float!\n  discount: Float\n}\n\ntype PassThroughFunction {\n  id: Long!\n}\n\ntype PassThroughTable {\n  id: Long!\n  updateTime: DateTime!\n}\n\ntype Query {\n  FilteredOrders(limit: Int = 10, offset: Int = 0): [Orders!]\n  Orders(limit: Int = 10, offset: Int = 0): [Orders!]\n  PassThroughFunction(customerid: Long!, limit: Int = 10, offset: Int = 0): [PassThroughFunction!]\n  PassThroughTable(limit: Int = 10, offset: Int = 0): [PassThroughTable!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/hierarchy--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/hierarchy--package.txt
@@ -1,0 +1,327 @@
+>>>pipeline_explain.txt
+=== Employees
+ID:     default_catalog.default_database.Employees
+Type:   state
+Stage:  flink
+Inputs: default_catalog.default_database._employees
+Annotations:
+ - mostRecentDistinct: true
+Primary Key: employeeid
+Timestamp  : updatedDate
+Schema:
+ - employeeid: BIGINT NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Plan:
+LogicalProject(employeeid=[$0], name=[$1], email=[$2], updatedDate=[$3])
+  LogicalFilter(condition=[=($4, 1)])
+    LogicalProject(employeeid=[$0], name=[$1], email=[$2], updatedDate=[$3], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
+      LogicalTableScan(table=[[default_catalog, default_database, _employees]])
+SQL: CREATE VIEW `Employees`
+AS
+SELECT `employeeid`, `name`, `email`, `updatedDate`
+FROM (SELECT `employeeid`, `name`, `email`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
+  FROM `default_catalog`.`default_database`.`_employees`) AS `t`
+WHERE `__sqrlinternal_rownum` = 1
+=== Reporting
+ID:     default_catalog.default_database.Reporting
+Type:   state
+Stage:  flink
+Inputs: default_catalog.default_database._reporting
+Annotations:
+ - mostRecentDistinct: true
+Primary Key: employeeid, managerid
+Timestamp  : updatedDate
+Schema:
+ - employeeid: BIGINT NOT NULL
+ - managerid: BIGINT NOT NULL
+ - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Plan:
+LogicalProject(employeeid=[$0], managerid=[$1], updatedDate=[$2])
+  LogicalFilter(condition=[=($3, 1)])
+    LogicalProject(employeeid=[$0], managerid=[$1], updatedDate=[$2], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $1 ORDER BY $2 DESC NULLS LAST)])
+      LogicalTableScan(table=[[default_catalog, default_database, _reporting]])
+SQL: CREATE VIEW `Reporting`
+AS
+SELECT `employeeid`, `managerid`, `updatedDate`
+FROM (SELECT `employeeid`, `managerid`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid`, `managerid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
+  FROM `default_catalog`.`default_database`.`_reporting`) AS `t`
+WHERE `__sqrlinternal_rownum` = 1
+=== _employees
+ID:     default_catalog.default_database._employees
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database._employees__base
+Primary Key: -
+Timestamp  : updatedDate
+Schema:
+ - employeeid: BIGINT NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Plan:
+LogicalWatermarkAssigner(rowtime=[updatedDate], watermark=[-($3, 1:INTERVAL SECOND)])
+  LogicalTableScan(table=[[default_catalog, default_database, _employees]])
+SQL: CREATE VIEW `_employees__view`
+AS
+SELECT `_employees`.`employeeid`, `_employees`.`name`, `_employees`.`email`, `_employees`.`updatedDate`
+FROM `default_catalog`.`default_database`.`_employees` AS `_employees`
+=== _reporting
+ID:     default_catalog.default_database._reporting
+Type:   stream
+Stage:  flink
+Inputs: default_catalog.default_database._reporting__base
+Primary Key: -
+Timestamp  : updatedDate
+Schema:
+ - employeeid: BIGINT NOT NULL
+ - managerid: BIGINT NOT NULL
+ - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Plan:
+LogicalWatermarkAssigner(rowtime=[updatedDate], watermark=[-($2, 1:INTERVAL SECOND)])
+  LogicalTableScan(table=[[default_catalog, default_database, _reporting]])
+SQL: CREATE VIEW `_reporting__view`
+AS
+SELECT `_reporting`.`employeeid`, `_reporting`.`managerid`, `_reporting`.`updatedDate`
+FROM `default_catalog`.`default_database`.`_reporting` AS `_reporting`
+>>>flink-sql-no-functions.sql
+CREATE TABLE `_employees` (
+  `employeeid` BIGINT NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
+) WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = '${DATA_PATH}/employees.jsonl',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE TABLE `_reporting` (
+  `employeeid` BIGINT NOT NULL,
+  `managerid` BIGINT NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
+) WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = '${DATA_PATH}/reporting.jsonl',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE VIEW `Employees`
+AS
+SELECT `employeeid`, `name`, `email`, `updatedDate`
+FROM (SELECT `employeeid`, `name`, `email`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
+  FROM `default_catalog`.`default_database`.`_employees`) AS `t`
+WHERE `__sqrlinternal_rownum` = 1;
+CREATE VIEW `Reporting`
+AS
+SELECT `employeeid`, `managerid`, `updatedDate`
+FROM (SELECT `employeeid`, `managerid`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid`, `managerid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
+  FROM `default_catalog`.`default_database`.`_reporting`) AS `t`
+WHERE `__sqrlinternal_rownum` = 1;
+CREATE VIEW `EmployeeCountTest`
+AS
+SELECT COUNT(*) AS `num_employees`
+FROM `Employees`;
+CREATE TABLE `Employees_1` (
+  `employeeid` BIGINT NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`employeeid`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'Employees',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Reporting_2` (
+  `employeeid` BIGINT NOT NULL,
+  `managerid` BIGINT NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`employeeid`, `managerid`) NOT ENFORCED
+) WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'Reporting',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`Employees_1`
+(SELECT *
+ FROM `default_catalog`.`default_database`.`_employees`)
+;
+INSERT INTO `default_catalog`.`default_database`.`Reporting_2`
+ (SELECT *
+  FROM `default_catalog`.`default_database`.`_reporting`)
+ ;
+ END
+>>>postgres-schema.sql
+CREATE TABLE IF NOT EXISTS "Employees" ("employeeid" BIGINT NOT NULL, "name" TEXT NOT NULL, "email" TEXT NOT NULL, "updatedDate" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("employeeid"));
+CREATE TABLE IF NOT EXISTS "Reporting" ("employeeid" BIGINT NOT NULL, "managerid" BIGINT NOT NULL, "updatedDate" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("employeeid","managerid"));
+
+CREATE INDEX IF NOT EXISTS "Employees_hash_c1" ON "Employees" USING hash ("name");
+CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("managerid")
+>>>postgres-views.sql
+
+>>>vertx.json
+{
+  "model" : {
+    "queries" : [
+      {
+        "type" : "args",
+        "parentType" : "Query",
+        "fieldName" : "Employees",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "employeeid"
+            },
+            {
+              "type" : "variable",
+              "path" : "name"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT *\nFROM \"Employees\"\nWHERE (\"employeeid\" = $1 OR $1 IS NULL) AND (\"name\" = $2 OR $2 IS NULL)",
+            "parameters" : [
+              {
+                "type" : "arg",
+                "path" : "employeeid"
+              },
+              {
+                "type" : "arg",
+                "path" : "name"
+              }
+            ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Employees",
+        "fieldName" : "allReports",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "WITH RECURSIVE employee_hierarchy AS (\n    SELECT r.employeeid, r.managerid, 1 as level\n    FROM \"Reporting\" r\n    WHERE r.managerid = $1\n    UNION ALL\n    SELECT r.employeeid, r.managerid, eh.level + 1 as level\n    FROM \"Reporting\" r\n    INNER JOIN employee_hierarchy eh ON r.managerid = eh.employeeid\n  )\n  SELECT e.employeeid, e.name, eh.level\n  FROM employee_hierarchy eh\n  JOIN \"Employees\" e ON eh.employeeid = e.employeeid\n  ORDER BY eh.level, e.employeeid",
+            "parameters" : [
+              {
+                "type" : "source",
+                "key" : "employeeid"
+              }
+            ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      },
+      {
+        "type" : "args",
+        "parentType" : "Employees",
+        "fieldName" : "directReports",
+        "exec" : {
+          "arguments" : [
+            {
+              "type" : "variable",
+              "path" : "offset"
+            },
+            {
+              "type" : "variable",
+              "path" : "limit"
+            }
+          ],
+          "query" : {
+            "type" : "SqlQuery",
+            "sql" : "SELECT \"Employees\".\"employeeid\", \"Employees\".\"name\", \"Employees\".\"email\", \"Employees\".\"updatedDate\"\nFROM \"Reporting\"\n INNER JOIN \"Employees\" ON \"Reporting\".\"employeeid\" = \"Employees\".\"employeeid\"\nWHERE \"Reporting\".\"managerid\" = $1\nORDER BY \"Employees\".\"employeeid\" NULLS FIRST",
+            "parameters" : [
+              {
+                "type" : "source",
+                "key" : "employeeid"
+              }
+            ],
+            "pagination" : "LIMIT_AND_OFFSET",
+            "cacheDurationMs" : 0,
+            "database" : "POSTGRES"
+          }
+        }
+      }
+    ],
+    "mutations" : [ ],
+    "subscriptions" : [ ],
+    "operations" : [
+      {
+        "function" : {
+          "name" : "GetEmployees",
+          "parameters" : {
+            "type" : "object",
+            "properties" : {
+              "allReports_limit" : {
+                "type" : "integer"
+              },
+              "offset" : {
+                "type" : "integer"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "limit" : {
+                "type" : "integer"
+              },
+              "employeeid" : {
+                "type" : "integer"
+              },
+              "allReports_offset" : {
+                "type" : "integer"
+              }
+            },
+            "required" : [ ]
+          }
+        },
+        "format" : "JSON",
+        "apiQuery" : {
+          "query" : "query Employees($employeeid: Long, $name: String, $limit: Int = 10, $offset: Int = 0$allReports_limit: Int = 10, $allReports_offset: Int = 0) {\nEmployees(employeeid: $employeeid, name: $name, limit: $limit, offset: $offset) {\nemployeeid\nname\nemail\nupdatedDate\nallReports(limit: $allReports_limit, offset: $allReports_offset) {\nemployeeid\nname\nlevel\n}\n}\n\n}",
+          "queryName" : "Employees",
+          "operationType" : "QUERY"
+        },
+        "mcpMethod" : "TOOL",
+        "restMethod" : "GET",
+        "uriTemplate" : "queries/Employees{?allReports_limit,offset,name,limit,employeeid,allReports_offset}"
+      }
+    ],
+    "schema" : {
+      "type" : "string",
+      "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype Employees {\n  employeeid: Long!\n  name: String!\n  email: String!\n  updatedDate: DateTime!\n  allReports(limit: Int = 10, offset: Int = 0): [Employees_allReports!]\n  directReports(limit: Int = 10, offset: Int = 0): [Employees!]\n}\n\ntype Employees_allReports {\n  employeeid: Long!\n  name: String!\n  level: Int!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  Employees(employeeid: Long, name: String, limit: Int = 10, offset: Int = 0): [Employees!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hierarchy.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hierarchy.sqrl
@@ -1,0 +1,32 @@
+IMPORT hr-data.* AS _;
+
+/*+ query_by_any(employeeid, name) */
+Employees := DISTINCT _employees ON employeeid ORDER BY updatedDate DESC;
+/*+ no_query */
+Reporting := DISTINCT _reporting ON employeeid, managerid ORDER BY updatedDate DESC;
+
+Employees.directReports := SELECT e.* FROM Reporting r JOIN Employees e ON r.employeeid = e.employeeid
+                           WHERE r.managerid = this.employeeid ORDER BY e.employeeid;
+
+Employees.allReports RETURNS (employeeid BIGINT NOT NULL, name STRING NOT NULL, level INT NOT NULL) :=
+  WITH RECURSIVE employee_hierarchy AS (
+    -- Base case: direct reports
+    SELECT r.employeeid, r.managerid, 1 as level
+    FROM "Reporting" r
+    WHERE r.managerid = this.employeeid
+    
+    UNION ALL
+    
+    -- Recursive case: reports of reports
+    SELECT r.employeeid, r.managerid, eh.level + 1 as level
+    FROM "Reporting" r
+    INNER JOIN employee_hierarchy eh ON r.managerid = eh.employeeid
+  )
+  SELECT e.employeeid, e.name, eh.level
+  FROM employee_hierarchy eh
+  JOIN "Employees" e ON eh.employeeid = e.employeeid
+  ORDER BY eh.level, e.employeeid;
+
+
+/*+test */
+EmployeeCountTest := SELECT count(*) AS num_employees FROM Employees;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/employees.jsonl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/employees.jsonl
@@ -1,0 +1,10 @@
+{"employeeid": 1, "name": "Sarah Johnson", "email": "sarah.johnson@company.com", "updatedDate": "2024-01-01T08:00:00Z"}
+{"employeeid": 2, "name": "Mike Chen", "email": "mike.chen@company.com", "updatedDate": "2024-01-01T08:15:00Z"}
+{"employeeid": 3, "name": "Emily Rodriguez", "email": "emily.rodriguez@company.com", "updatedDate": "2024-01-01T08:30:00Z"}
+{"employeeid": 4, "name": "David Wilson", "email": "david.wilson@company.com", "updatedDate": "2024-01-01T08:45:00Z"}
+{"employeeid": 5, "name": "Lisa Thompson", "email": "lisa.thompson@company.com", "updatedDate": "2024-01-01T09:00:00Z"}
+{"employeeid": 6, "name": "James Park", "email": "james.park@company.com", "updatedDate": "2024-01-01T09:15:00Z"}
+{"employeeid": 7, "name": "Anna Kowalski", "email": "anna.kowalski@company.com", "updatedDate": "2024-01-01T09:30:00Z"}
+{"employeeid": 8, "name": "Robert Brown", "email": "robert.brown@company.com", "updatedDate": "2024-01-01T09:45:00Z"}
+{"employeeid": 9, "name": "Michelle Davis", "email": "michelle.davis@company.com", "updatedDate": "2024-01-01T10:00:00Z"}
+{"employeeid": 10, "name": "Alex Martinez", "email": "alex.martinez@company.com", "updatedDate": "2024-01-01T10:15:00Z"}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/employees.table.sql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/employees.table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `employees` (
+  `employeeid` BIGINT NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
+) WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = '${DATA_PATH}/employees.jsonl',
+  'source.monitor-interval' = '10 sec'
+);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/reporting.jsonl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/reporting.jsonl
@@ -1,0 +1,9 @@
+{"employeeid": 2, "managerid": 1, "updatedDate": "2024-01-01T08:20:00Z"}
+{"employeeid": 3, "managerid": 1, "updatedDate": "2024-01-01T08:35:00Z"}
+{"employeeid": 4, "managerid": 2, "updatedDate": "2024-01-01T08:50:00Z"}
+{"employeeid": 5, "managerid": 2, "updatedDate": "2024-01-01T09:05:00Z"}
+{"employeeid": 6, "managerid": 3, "updatedDate": "2024-01-01T09:20:00Z"}
+{"employeeid": 7, "managerid": 3, "updatedDate": "2024-01-01T09:35:00Z"}
+{"employeeid": 8, "managerid": 4, "updatedDate": "2024-01-01T09:50:00Z"}
+{"employeeid": 9, "managerid": 5, "updatedDate": "2024-01-01T10:05:00Z"}
+{"employeeid": 10, "managerid": 5, "updatedDate": "2024-01-01T10:20:00Z"}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/reporting.table.sql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/hr-data/reporting.table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `reporting` (
+  `employeeid` BIGINT NOT NULL,
+  `managerid` BIGINT NOT NULL,
+  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
+) WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = '${DATA_PATH}/reporting.jsonl',
+  'source.monitor-interval' = '10 sec'
+);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "enabled-engines": ["postgres","flink", "vertx"],
+  "script": {
+    "main": "hierarchy.sqrl"
+  },
+  "test-runner": {
+    "delay-sec": -1
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/snapshots/EmployeeCountTest.snapshot
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/snapshots/EmployeeCountTest.snapshot
@@ -1,0 +1,7 @@
+{
+  "data" : {
+    "EmployeeCountTest" : [ {
+      "num_employees" : 10
+    } ]
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/snapshots/employee_query.snapshot
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/snapshots/employee_query.snapshot
@@ -1,0 +1,40 @@
+{
+  "data" : {
+    "Employees" : [ {
+      "name" : "Sarah Johnson",
+      "directReports" : [ {
+        "employeeid" : 2
+      }, {
+        "employeeid" : 3
+      } ],
+      "allReports" : [ {
+        "employeeid" : 2,
+        "level" : 1
+      }, {
+        "employeeid" : 3,
+        "level" : 1
+      }, {
+        "employeeid" : 4,
+        "level" : 2
+      }, {
+        "employeeid" : 5,
+        "level" : 2
+      }, {
+        "employeeid" : 6,
+        "level" : 2
+      }, {
+        "employeeid" : 7,
+        "level" : 2
+      }, {
+        "employeeid" : 8,
+        "level" : 3
+      }, {
+        "employeeid" : 9,
+        "level" : 3
+      }, {
+        "employeeid" : 10,
+        "level" : 3
+      } ]
+    } ]
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/tests/employee_query.graphql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/passthrough/tests/employee_query.graphql
@@ -1,0 +1,12 @@
+query Employee {
+    Employees(employeeid: 1) {
+        name
+        directReports(limit: 10) {
+            employeeid
+        }
+        allReports(limit: 100) {
+            employeeid
+            level
+        }
+    }
+}


### PR DESCRIPTION
Sqrl uses the Flink parser to parse SQL. This means we will not support all the features of all the database dialects. To make those accessible to users, this PR adds a "pass-through" function definition that passes the sql string through to the database engine with argument replacement.

This enables advanced features like recursive CTEs (see test case)