### PR TITLE
Rename `PackageJson#setPipeline` to `PackageJson#setEnabledEngines`

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -67,7 +67,7 @@ public abstract class AbstractCompileCmd extends AbstractCmd {
 
     var engines = getEngines();
     if (!engines.isEmpty()) {
-      sqrlConfig.setPipeline(engines);
+      sqrlConfig.setEnabledEngines(engines);
     }
 
     DirectoryManager.prepareTargetDirectory(getTargetDir());

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
@@ -30,7 +30,7 @@ public interface PackageJson {
 
   List<String> getEnabledEngines();
 
-  void setPipeline(List<String> pipeline);
+  void setEnabledEngines(List<String> enabledEngines);
 
   EnginesConfig getEngines();
 

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJsonImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJsonImpl.java
@@ -22,12 +22,11 @@ import lombok.Getter;
 public class PackageJsonImpl implements PackageJson {
 
   public static final String ENGINES_PROPERTY = "engines";
+  public static final String ENABLED_ENGINES_KEY = "enabled-engines";
   public static final String DISCOVERY_KEY = "discovery";
   public static final String DEPENDENCIES_KEY = "dependencies";
   public static final String SCRIPT_KEY = "script";
   public static final String COMPILER_KEY = "compiler";
-  public static final String PACKAGE_KEY = "package";
-  public static final String PIPELINE_KEY = "enabled-engines";
   public static final String CONNECTORS_KEY = "connectors";
   public static final String CONFIG_KEY = "config";
   public static final String TEST_RUNNER_KEY = "test-runner";
@@ -44,12 +43,12 @@ public class PackageJsonImpl implements PackageJson {
 
   @Override
   public List<String> getEnabledEngines() {
-    return sqrlConfig.asList(PIPELINE_KEY, String.class).get();
+    return sqrlConfig.asList(ENABLED_ENGINES_KEY, String.class).get();
   }
 
   @Override
-  public void setPipeline(List<String> pipeline) {
-    sqrlConfig.setProperty(PIPELINE_KEY, pipeline);
+  public void setEnabledEngines(List<String> enabledEngines) {
+    sqrlConfig.setProperty(ENABLED_ENGINES_KEY, enabledEngines);
   }
 
   @Override

--- a/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonImplTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonImplTest.java
@@ -53,13 +53,13 @@ class PackageJsonImplTest {
   }
 
   @Test
-  void givenPackageJson_whenSetPipeline_thenUpdatesEnabledEngines() {
+  void givenPackageJson_whenSetEnabledEngines_thenUpdatesEnabledEngines() {
     var packageJson = new PackageJsonImpl(config);
 
-    List<String> pipeline = List.of("stage1", "stage2", "stage3");
-    packageJson.setPipeline(pipeline);
+    var enabledEngines = List.of("stage1", "stage2", "stage3");
+    packageJson.setEnabledEngines(enabledEngines);
 
-    assertThat(packageJson.getEnabledEngines()).containsExactlyInAnyOrderElementsOf(pipeline);
+    assertThat(packageJson.getEnabledEngines()).containsExactlyInAnyOrderElementsOf(enabledEngines);
   }
 
   @Test


### PR DESCRIPTION
The getter is already called `getEnabledEngines`, this was just missed back then.