### PR TITLE
Validate query engine presence when table format engine is configured

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -62,7 +62,7 @@ public class CompilationProcess {
     var environment =
         new Sqrl2FlinkSQLTranslator(
             buildPath,
-            (FlinkStreamEngine) planner.getStreamStage().getEngine(),
+            (FlinkStreamEngine) planner.getStreamStage().engine(),
             config.getCompilerConfig());
     planner.planMain(mainScript, environment);
     var dagBuilder = planner.getDagBuilder();

--- a/sqrl-cli/src/main/java/com/datasqrl/packager/Packager.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/packager/Packager.java
@@ -291,7 +291,7 @@ public class Packager {
     // We'll write a single asset for each folder in the physical plan stage, plus any deployment
     // artifacts that the plan has
     for (PhysicalStagePlan stagePlan : plan.getStagePlans()) {
-      writePlan(stagePlan.getStage().getName(), stagePlan.getPlan(), planDir);
+      writePlan(stagePlan.getStage().name(), stagePlan.getPlan(), planDir);
     }
 
     if (testPlan != null) {

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/EngineStage.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/EngineStage.java
@@ -17,22 +17,11 @@ package com.datasqrl.engine.pipeline;
 
 import com.datasqrl.engine.EngineFeature;
 import com.datasqrl.engine.ExecutionEngine;
-import lombok.Value;
 
-@Value
-public class EngineStage implements ExecutionStage {
-
-  String name;
-  ExecutionEngine engine;
+public record EngineStage(String name, ExecutionEngine engine) implements ExecutionStage {
 
   @Override
   public boolean supportsFeature(EngineFeature capability) {
     return engine.supports(capability);
   }
-
-  //  @Override
-  //  public boolean supportsFunction(FunctionDefinition function) {
-  //    return engine.supports(function);
-  //  }
-
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/ExecutionPipeline.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/ExecutionPipeline.java
@@ -26,10 +26,10 @@ import java.util.stream.Collectors;
 
 public interface ExecutionPipeline {
 
-  List<ExecutionStage> getStages();
+  List<ExecutionStage> stages();
 
   default List<ExecutionStage> getReadStages() {
-    return getStages().stream().filter(ExecutionStage::isRead).collect(Collectors.toList());
+    return stages().stream().filter(ExecutionStage::isRead).collect(Collectors.toList());
   }
 
   /**
@@ -40,12 +40,12 @@ public interface ExecutionPipeline {
   default Optional<ServerEngine> getServerEngine() {
     return StreamUtil.getOnlyElement(
         getStagesByType(EngineType.SERVER).stream()
-            .map(stage -> (ServerEngine) stage.getEngine())
+            .map(stage -> (ServerEngine) stage.engine())
             .distinct());
   }
 
   default boolean hasReadStages() {
-    return getStages().stream().anyMatch(ExecutionStage::isRead);
+    return stages().stream().anyMatch(ExecutionStage::isRead);
   }
 
   Set<ExecutionStage> getUpStreamFrom(ExecutionStage stage);
@@ -54,18 +54,18 @@ public interface ExecutionPipeline {
 
   default Optional<ExecutionStage> getStage(String name) {
     return StreamUtil.getOnlyElement(
-        getStages().stream().filter(s -> s.getName().equalsIgnoreCase(name)));
+        stages().stream().filter(s -> s.name().equalsIgnoreCase(name)));
   }
 
   default Optional<ExecutionStage> getMutationStage() {
     return StreamUtil.getOnlyElement(
         getStagesByType(EngineType.LOG).stream()
-            .filter(stage -> stage.getEngine().supports(EngineFeature.MUTATIONS)));
+            .filter(stage -> stage.engine().supports(EngineFeature.MUTATIONS)));
   }
 
   default Optional<ExecutionStage> getStageByType(EngineType type) {
     return StreamUtil.getOnlyElement(
-        getStages().stream().filter(s -> s.getEngine().getType().equals(type)));
+        stages().stream().filter(s -> s.engine().getType().equals(type)));
   }
 
   /**
@@ -77,8 +77,8 @@ public interface ExecutionPipeline {
    * @return the stage for a given {@link EngineType}.
    */
   default List<ExecutionStage> getStagesByType(EngineType type) {
-    return getStages().stream()
-        .filter(s -> s.getEngine().getType().equals(type))
+    return stages().stream()
+        .filter(s -> s.engine().getType().equals(type))
         .collect(Collectors.toList());
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/ExecutionStage.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/pipeline/ExecutionStage.java
@@ -23,33 +23,31 @@ import org.apache.calcite.sql.SqlOperator;
 
 public interface ExecutionStage {
 
-  String getName();
+  String name();
 
   default boolean supportsAllFeatures(Collection<EngineFeature> capabilities) {
     return capabilities.stream().allMatch(this::supportsFeature);
   }
 
   default EngineType getType() {
-    return getEngine().getType();
+    return engine().getType();
   }
 
   boolean supportsFeature(EngineFeature capability);
 
-  //  boolean supportsFunction(FunctionDefinition function);
-
   default boolean isRead() {
-    return getEngine().getType().isRead();
+    return engine().getType().isRead();
   }
 
   default boolean isWrite() {
-    return getEngine().getType().isWrite();
+    return engine().getType().isWrite();
   }
 
   default boolean isCompute() {
-    return getEngine().getType().isCompute();
+    return engine().getType().isCompute();
   }
 
-  ExecutionEngine getEngine();
+  ExecutionEngine engine();
 
   default boolean supportsFunction(SqlOperator operator) {
     return true;

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/JdbcIndexOptimization.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/JdbcIndexOptimization.java
@@ -33,13 +33,13 @@ public class JdbcIndexOptimization implements PhysicalPlanRewriter {
   @Override
   public boolean appliesTo(EnginePhysicalPlan plan) {
     return plan instanceof JdbcPhysicalPlan jpp
-        && jpp.stage().getEngine() instanceof AbstractJDBCDatabaseEngine;
+        && jpp.stage().engine() instanceof AbstractJDBCDatabaseEngine;
   }
 
   @Override
   public JdbcPhysicalPlan rewrite(EnginePhysicalPlan plan, Sqrl2FlinkSQLTranslator sqrlEnv) {
     var jdbcPlan = (JdbcPhysicalPlan) plan;
-    var engine = (AbstractJDBCDatabaseEngine) jdbcPlan.stage().getEngine();
+    var engine = (AbstractJDBCDatabaseEngine) jdbcPlan.stage().engine();
     var indexSelectorConfig = engine.getIndexSelectorConfig();
     var indexSelector = new IndexSelector(sqrlEnv, indexSelectorConfig, jdbcPlan.tableIdMap());
 

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
@@ -71,7 +71,7 @@ public class PipelineDAGExporter {
               .map(PipelineNode::getId)
               .sorted()
               .collect(Collectors.toUnmodifiableList());
-      var stage = node.getChosenStage().getEngine().getName().toLowerCase();
+      var stage = node.getChosenStage().engine().getName().toLowerCase();
       if (node instanceof TableNode tableNode) {
         var table = tableNode.getTableAnalysis();
         if (table.getSourceSinkTable().isPresent()) {

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/StageAnalysis.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/StageAnalysis.java
@@ -37,7 +37,7 @@ public abstract class StageAnalysis {
   }
 
   public String getName() {
-    return stage.getName();
+    return stage.name();
   }
 
   @Value

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/rules/IdealExecutionStage.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/rules/IdealExecutionStage.java
@@ -27,7 +27,7 @@ public final class IdealExecutionStage implements ExecutionStage {
   public static final String NAME = "IDEAL";
 
   @Override
-  public String getName() {
+  public String name() {
     return NAME;
   }
 
@@ -37,7 +37,7 @@ public final class IdealExecutionStage implements ExecutionStage {
   }
 
   @Override
-  public ExecutionEngine getEngine() {
+  public ExecutionEngine engine() {
     throw new UnsupportedOperationException();
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -168,17 +168,17 @@ public class SqlScriptPlanner {
     and server_subscribe to tables and subscription stages.
      */
     this.tableStages =
-        pipeline.getStages().stream()
+        pipeline.stages().stream()
             .filter(
                 stage ->
                     stage.getType() == EngineType.DATABASE || stage.getType() == EngineType.STREAMS)
             .collect(Collectors.toList());
     this.queryStages =
-        pipeline.getStages().stream()
+        pipeline.stages().stream()
             .filter(stage -> stage.getType() == EngineType.DATABASE)
             .collect(Collectors.toList());
     this.subscriptionStages =
-        pipeline.getStages().stream()
+        pipeline.stages().stream()
             .filter(stage -> stage.getType() == EngineType.LOG)
             .collect(Collectors.toList());
   }
@@ -566,8 +566,8 @@ public class SqlScriptPlanner {
                       execHint.getStageNames().stream()
                           .anyMatch(
                               name ->
-                                  stage.getName().equalsIgnoreCase(name)
-                                      || stage.getEngine().getType().name().equalsIgnoreCase(name)))
+                                  stage.name().equalsIgnoreCase(name)
+                                      || stage.engine().getType().name().equalsIgnoreCase(name)))
               .collect(Collectors.toList());
       if (availableStages.isEmpty()) {
         throw new StatementParserException(
@@ -815,7 +815,7 @@ public class SqlScriptPlanner {
             "CREATE TABLE requires that a log engine is configured that supports mutations");
       };
     }
-    var engine = (LogEngine) logStage.get().getEngine();
+    var engine = (LogEngine) logStage.get().engine();
     return (tableBuilder, datatype) -> {
       var originalTableName = tableBuilder.getTableName();
       var mutationBuilder = MutationQuery.builder();

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/cost/SimpleCostAnalysisModel.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/cost/SimpleCostAnalysisModel.java
@@ -37,14 +37,14 @@ public record SimpleCostAnalysisModel(@NonNull Type type) implements CostModel {
 
   public Simple getCost(ExecutionStage executionStage, TableAnalysis tableAnalysis) {
     var cost = 1.0;
-    switch (executionStage.getEngine().getType()) {
+    switch (executionStage.engine().getType()) {
       case DATABASE:
         // Currently we make the simplifying assumption that database execution is the baseline and
         // we compare
         // other engines against it
         // However, if the database is a table format, we apply a penalty because query engines are
         // less efficient.
-        if (executionStage.getEngine() instanceof AnalyticDatabaseEngine) {
+        if (executionStage.engine() instanceof AnalyticDatabaseEngine) {
           cost = cost * 1.3;
         }
         break;
@@ -74,7 +74,7 @@ public record SimpleCostAnalysisModel(@NonNull Type type) implements CostModel {
         break;
       default:
         throw new UnsupportedOperationException(
-            "Unsupported engine type: " + executionStage.getEngine().getType());
+            "Unsupported engine type: " + executionStage.engine().getType());
     }
     return new Simple(cost);
   }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
@@ -173,14 +173,12 @@ public class DAGPlanner {
     var serverEngine = pipeline.getServerEngine();
     var serverPlan = ServerStagePlan.builder();
     List<ExecutionStage> dataStoreStages =
-        pipeline.getStages().stream()
-            .filter(stage -> stage.getEngine().getType().isDataStore())
-            .collect(Collectors.toList());
+        pipeline.stages().stream().filter(stage -> stage.engine().getType().isDataStore()).toList();
 
     var engineUtils = new MaterializationStagePlan.Utils(sqrlEnv.getRexUtil());
     Map<ExecutionStage, MaterializationStagePlanBuilder> exportPlans =
-        pipeline.getStages().stream()
-            .filter(stage -> stage.getEngine().getType().supportsExport())
+        pipeline.stages().stream()
+            .filter(stage -> stage.engine().getType().supportsExport())
             .collect(
                 Collectors.toMap(
                     Function.identity(),
@@ -245,11 +243,11 @@ public class DAGPlanner {
                   }
                   assert exportStage != null;
                   Preconditions.checkArgument(
-                      exportStage.getEngine().getType().supportsExport(),
+                      exportStage.engine().getType().supportsExport(),
                       "Execution stage [%s] does not support exporting [%s]",
                       exportStage,
                       node);
-                  var exportEngine = (ExportEngine) exportStage.getEngine();
+                  var exportEngine = (ExportEngine) exportStage.engine();
                   TableAnalysis originalNodeTable = node.getTableAnalysis(),
                       sinkNodeTable = originalNodeTable;
                   if (exportEngine.supports(EngineFeature.MATERIALIZE_ON_KEY)
@@ -325,7 +323,7 @@ public class DAGPlanner {
     // SqrlTableFunction
     Map<ObjectIdentifier, SqrlTableFunction> databaseTableMapping = new HashMap<>();
     for (ExecutionStage dataStoreStage : dataStoreStages) {
-      var dbEngine = (DatabaseEngine) dataStoreStage.getEngine();
+      var dbEngine = (DatabaseEngine) dataStoreStage.engine();
       var dbPlan = exportPlans.get(dataStoreStage);
       dag.allNodesByClassAndStage(PlannedNode.class, dataStoreStage)
           .forEach(

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/nodes/PipelineNode.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/nodes/PipelineNode.java
@@ -96,7 +96,7 @@ public abstract class PipelineNode implements AbstractDAG.Node, Comparable<Pipel
       return "no stages found";
     }
     return stageAnalysis.values().stream()
-        .map(stage -> stage.getStage().getName() + ": " + stage.getMessage())
+        .map(stage -> stage.getStage().name() + ": " + stage.getMessage())
         .collect(Collectors.joining("\n"));
   }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/EngineValidationTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/EngineValidationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datasqrl.util.SnapshotTest.Snapshot;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class EngineValidationTest extends AbstractAssetSnapshotTest {
+
+  public static final Path SCRIPT_DIR = getResourcesDirectory("engine-validation");
+
+  protected EngineValidationTest() {
+    super(SCRIPT_DIR.resolve("plan-output"));
+  }
+
+  @Test
+  void testInvalidEngine() {
+    var script = SCRIPT_DIR.resolve("invalidPackage-fail.sqrl");
+
+    assertThat(Files.exists(script)).isTrue();
+    var testModifier = TestNameModifier.of(script);
+    var expectFailure = testModifier == TestNameModifier.fail;
+    var printMessages =
+        testModifier == TestNameModifier.fail || testModifier == TestNameModifier.warn;
+    this.snapshot = Snapshot.of(getDisplayName(script), getClass());
+    var hook =
+        execute(
+            SCRIPT_DIR,
+            "compile",
+            script.getFileName().toString(),
+            "-t",
+            outputDir.getFileName().toString());
+    assertThat(hook.isFailed()).as(hook.getMessages()).isEqualTo(expectFailure);
+    if (printMessages) {
+      createMessageSnapshot(hook.getMessages());
+    } else {
+      createSnapshot();
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/invalidPackage-fail.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/invalidPackage-fail.sqrl
@@ -1,0 +1,2 @@
+Numbers := SELECT * FROM (VALUES (1), (2), (3), (4), (5)) AS T(id);
+Numbers2 := SELECT * FROM (VALUES (1), (2), (3), (4), (4)) AS T(id);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "iceberg", "vertx"],
+  "connectors" : {
+    "iceberg" : {
+      "warehouse":"warehouse",
+      "catalog-type":"hadoop",
+      "catalog-name": "mydatabase"
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/invalidPackage-fail.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/invalidPackage-fail.txt
@@ -1,0 +1,2 @@
+[FATAL] Engine 'iceberg' requires a query engine, but none are listed under 'enabled-engines'. Available options: [duckdb, snowflake]
+


### PR DESCRIPTION
## Main changes

- Validate query engine presence when table format engine is configured in `SimplePipeline`
- `SimplePipeline` is part of the Guice inject flow, so added some extra handling logic in `AbstractCmd` to properly present the validation error there
- Added `EngineValidationTest`
- Some general refactor, removing dead code, updating lombok value class to `record`