### PR TITLE
Add JWT authentication support for MCP endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
     <aws-sdk-bom.version>2.32.24</aws-sdk-bom.version>
     <openai-gpt3-java.version>0.18.2</openai-gpt3-java.version>
     <flink-client.version>1.1.4</flink-client.version>
+    <mcp-sdk.version>0.11.2</mcp-sdk.version>
 
     <!-- Plugin versions -->
     <maven-javadoc-plugin.version>3.11.3</maven-javadoc-plugin.version>
@@ -1129,6 +1130,10 @@
           <name>m2e.version</name>
         </property>
       </activation>
+
+      <properties>
+        <argLine></argLine>
+      </properties>
 
       <build>
         <directory>${project.basedir}/m2e-target</directory>

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/AbstractBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/AbstractBridgeVerticle.java
@@ -147,6 +147,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
             .query(operation.getApiQuery().query())
             .operationName(operation.getApiQuery().queryName())
             .variables(variables)
+            .graphQLContext(builder -> builder.put(RoutingContext.class, ctx))
             .build();
 
     // Kick off async execution (GraphQL Java spawns its own executor)

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/McpBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/McpBridgeVerticle.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.graphql;
 
+import com.datasqrl.graphql.auth.JwtFailureHandler;
 import com.datasqrl.graphql.config.ServerConfig;
 import com.datasqrl.graphql.server.RootGraphqlModel;
 import com.datasqrl.graphql.server.operation.ApiOperation;
@@ -33,6 +34,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.JWTAuthHandler;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -97,75 +99,91 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
     String mcpRoutePrefix = config.getServletConfig().getMcpEndpoint();
 
     // MCP SSE endpoint - handles POST for messages
-    router
-        .post(mcpRoutePrefix)
-        .handler(
-            ctx -> {
-              JsonNode payload = null;
-              try {
-                payload = objectMapper.readTree(ctx.body().buffer().getBytes());
-                processIncomingMessages(ctx, payload);
-              } catch (IOException e) { // TODO: improve error handling
-                throw new RuntimeException(e);
-              }
-            });
+    var postRoute = router.post(mcpRoutePrefix);
+
+    // Add JWT auth if configured
+    jwtAuth.ifPresent(
+        auth -> {
+          log.info("Applying JWT authentication to MCP endpoint: {}", mcpRoutePrefix);
+          postRoute.handler(JWTAuthHandler.create(auth));
+          postRoute.failureHandler(new JwtFailureHandler());
+        });
+
+    postRoute.handler(
+        ctx -> {
+          JsonNode payload = null;
+          try {
+            payload = objectMapper.readTree(ctx.body().buffer().getBytes());
+            processIncomingMessages(ctx, payload);
+          } catch (IOException e) { // TODO: improve error handling
+            throw new RuntimeException(e);
+          }
+        });
 
     // SSE endpoint for server-to-client streaming
-    router
-        .get(mcpRoutePrefix + "/sse")
-        .handler(
-            ctx -> {
-              if (!accepts(ctx, CT_SSE)) {
-                ctx.response().setStatusCode(406).end();
-                return;
-              }
-              HttpServerResponse response = ctx.response();
+    var sseRoute = router.get(mcpRoutePrefix + "/sse");
 
-              // Set up SSE headers
-              response
-                  .putHeader("Content-Type", "text/event-stream")
-                  .putHeader("Cache-Control", "no-cache")
-                  .putHeader("Connection", "keep-alive")
-                  .putHeader("Access-Control-Allow-Origin", "*")
-                  .setChunked(true);
+    // Add JWT auth to SSE endpoint if configured
+    jwtAuth.ifPresent(
+        auth -> {
+          log.info("Applying JWT authentication to MCP SSE endpoint: {}/sse", mcpRoutePrefix);
+          sseRoute.handler(JWTAuthHandler.create(auth));
+          sseRoute.failureHandler(new JwtFailureHandler());
+        });
 
-              String connectionId = UUID.randomUUID().toString();
-              SseConnection connection = new SseConnection(connectionId, response);
-              sseConnections.put(connectionId, connection);
+    sseRoute.handler(
+        ctx -> {
+          if (!accepts(ctx, CT_SSE)) {
+            ctx.response().setStatusCode(406).end();
+            return;
+          }
+          HttpServerResponse response = ctx.response();
 
-              // Send initial connection event
-              sendSseMessage(
-                  connection, "connected", new JsonObject().put("connectionId", connectionId));
+          // Set up SSE headers
+          response
+              .putHeader("Content-Type", "text/event-stream")
+              .putHeader("Cache-Control", "no-cache")
+              .putHeader("Connection", "keep-alive")
+              .putHeader("Access-Control-Allow-Origin", "*")
+              .setChunked(true);
 
-              // Send heartbeat every 30 seconds
-              long timerId =
-                  vertx.setPeriodic(
-                      30000,
-                      id -> {
-                        if (sseConnections.containsKey(connectionId)) {
-                          sendSseMessage(
-                              connection,
-                              "heartbeat",
-                              new JsonObject().put("timestamp", System.currentTimeMillis()));
-                        }
-                      });
+          String connectionId = UUID.randomUUID().toString();
+          SseConnection connection = new SseConnection(connectionId, response);
+          sseConnections.put(connectionId, connection);
 
-              // Handle connection close
-              response.closeHandler(
-                  v -> {
-                    vertx.cancelTimer(timerId);
-                    sseConnections.remove(connectionId);
-                    log.info("SSE connection closed: {}", connectionId);
+          // Send initial connection event
+          sendSseMessage(
+              connection, "connected", new JsonObject().put("connectionId", connectionId));
+
+          // Send heartbeat every 30 seconds
+          long timerId =
+              vertx.setPeriodic(
+                  30000,
+                  id -> {
+                    if (sseConnections.containsKey(connectionId)) {
+                      sendSseMessage(
+                          connection,
+                          "heartbeat",
+                          new JsonObject().put("timestamp", System.currentTimeMillis()));
+                    }
                   });
 
-              // Handle client disconnect
-              response.exceptionHandler(
-                  throwable -> {
-                    vertx.cancelTimer(timerId);
-                    sseConnections.remove(connectionId);
-                    log.warn("SSE connection error: {} - {}", connectionId, throwable.getMessage());
-                  });
-            });
+          // Handle connection close
+          response.closeHandler(
+              v -> {
+                vertx.cancelTimer(timerId);
+                sseConnections.remove(connectionId);
+                log.info("SSE connection closed: {}", connectionId);
+              });
+
+          // Handle client disconnect
+          response.exceptionHandler(
+              throwable -> {
+                vertx.cancelTimer(timerId);
+                sseConnections.remove(connectionId);
+                log.warn("SSE connection error: {} - {}", connectionId, throwable.getMessage());
+              });
+        });
     startPromise.complete();
   }
 
@@ -344,7 +362,9 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
                             err ->
                                 new JsonObject()
                                     .put("type", "text")
-                                    .put("text", "Tool Error:" + err.getPath()))
+                                    .put(
+                                        "text",
+                                        "Tool Error[" + err.getPath() + "]: " + err.getMessage()))
                         .toList());
                 json.put("isError", true);
               } else {
@@ -356,6 +376,7 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
                           new JsonObject()
                               .put("type", "text")
                               .put("text", objectMapper.writeValueAsString(result))));
+                  json.put("isError", false);
                 } catch (JsonProcessingException e) {
                   throw new RuntimeException(e);
                 }

--- a/sqrl-testing/sqrl-testing-container/pom.xml
+++ b/sqrl-testing/sqrl-testing-container/pom.xml
@@ -107,6 +107,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-core</artifactId>
+      <version>13.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-jackson</artifactId>
+      <version>13.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/sqrl-testing/sqrl-testing-container/pom.xml
+++ b/sqrl-testing/sqrl-testing-container/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>minio</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
@@ -92,6 +98,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp</artifactId>
+      <version>${mcp-sdk.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtContainerIT.java
@@ -17,21 +17,92 @@ package com.datasqrl.container.testing;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.jsonwebtoken.Jwts;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.nio.file.Path;
 import java.security.KeyPairGenerator;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
 
+@Slf4j
 public class JwtContainerIT extends SqrlContainerTestBase {
+
+  private PostgreSQLContainer<?> postgresql;
 
   @Override
   protected String getTestCaseName() {
     return "jwt-authorized";
+  }
+
+  private void startPostgreSQLContainer() {
+    if (postgresql == null) {
+      postgresql =
+          new PostgreSQLContainer<>("postgres:13-alpine")
+              .withDatabaseName("datasqrl")
+              .withUsername("datasqrl")
+              .withPassword("password")
+              .withNetwork(sharedNetwork)
+              .withNetworkAliases("postgresql");
+      postgresql.start();
+      log.info("PostgreSQL container started on port {}", postgresql.getMappedPort(5432));
+      createTestTables();
+    }
+  }
+
+  @SneakyThrows
+  private void createTestTables() {
+    // Create and populate tables as defined in jwt-authorized.sqrl
+    try (var connection = postgresql.createConnection("")) {
+      try (var stmt = connection.createStatement()) {
+        // Create MyTable and populate with values 1-10
+        stmt.execute("CREATE TABLE IF NOT EXISTS \"MyTable\" (val INTEGER)");
+        stmt.execute(
+            "INSERT INTO \"MyTable\" (val) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)");
+
+        // Create MyStringTable and populate with 'a', 'b', 'c', 'd'
+        stmt.execute("CREATE TABLE IF NOT EXISTS \"MyStringTable\" (val VARCHAR(1))");
+        stmt.execute("INSERT INTO \"MyStringTable\" (val) VALUES ('a'), ('b'), ('c'), ('d')");
+
+        log.info("Test tables created and populated successfully");
+      }
+    }
+  }
+
+  private void compileAndStartServerWithDatabase(String scriptName, Path testDir) {
+    startPostgreSQLContainer();
+    compileSqrlScript(scriptName, testDir);
+    startGraphQLServer(
+        testDir,
+        container -> {
+          container
+              .withEnv("POSTGRES_HOST", "postgresql")
+              .withEnv("POSTGRES_USERNAME", postgresql.getUsername())
+              .withEnv("POSTGRES_PASSWORD", postgresql.getPassword())
+              .withEnv("POSTGRES_DATABASE", postgresql.getDatabaseName())
+              .withEnv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092");
+        });
+  }
+
+  @Override
+  protected void commonTearDown() {
+    super.commonTearDown();
+    if (postgresql != null) {
+      postgresql.stop();
+      postgresql = null;
+    }
   }
 
   @Test
@@ -92,6 +163,83 @@ public class JwtContainerIT extends SqrlContainerTestBase {
     assertThat(responseBody).contains("\"IllegalArgumentException: Invalid format for JWT\"");
   }
 
+  @Test
+  @SneakyThrows
+  void givenJwtEnabledScript_whenMcpClientAccessesWithoutAuth_thenFails() {
+    compileAndStartServer("jwt-authorized.sqrl", testDir);
+
+    var mcpUrl =
+        String.format("http://localhost:%d/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+    log.info("Testing MCP endpoint without JWT: {}", mcpUrl);
+
+    // Create MCP client without authentication
+    var transport = HttpClientStreamableHttpTransport.builder(mcpUrl).build();
+    var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build();
+
+    // Should fail when trying to initialize due to lack of authentication
+    assertThatThrownBy(
+            () -> {
+              client.initialize();
+              client.listTools();
+            })
+        .hasMessageContaining("401");
+
+    client.close();
+  }
+
+  @Test
+  @SneakyThrows
+  void givenJwtEnabledScript_whenMcpClientAccessesWithValidJwt_thenSucceeds() {
+    compileAndStartServerWithDatabase("jwt-authorized.sqrl", testDir);
+
+    var mcpUrl =
+        String.format("http://localhost:%d/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+    var jwtToken = generateJwtToken();
+    log.info("Testing MCP endpoint with valid JWT: {}", mcpUrl);
+
+    // Create MCP client with JWT authentication
+    var transport =
+        HttpClientStreamableHttpTransport.builder(mcpUrl)
+            .customizeRequest(r -> r.header("Authorization", "Bearer " + jwtToken))
+            .build();
+
+    try (var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build(); ) {
+      // Should succeed with proper JWT
+      client.initialize();
+
+      var tools = client.listTools();
+
+      log.info("Successfully listed {} tools", tools.tools().size());
+      assertThat(tools).isNotNull();
+      assertThat(tools.tools()).isNotNull();
+      assertThat(tools.tools()).isNotEmpty();
+
+      // Test calling a tool that doesn't require auth metadata
+      var myTableTool =
+          tools.tools().stream()
+              .filter(tool -> "GetMyTable".equals(tool.name()))
+              .findFirst()
+              .orElseThrow(() -> new RuntimeException("GetMyTable tool not found"));
+      log.info("Testing tool call: {}", myTableTool.name());
+
+      var callRequest =
+          McpSchema.CallToolRequest.builder()
+              .name(myTableTool.name())
+              .arguments(Map.of("limit", 5))
+              .build();
+
+      var toolResult = client.callTool(callRequest);
+      log.info("Tool call result: {}", toolResult);
+      assertThat(toolResult).isNotNull();
+      assertThat(toolResult.isError()).isFalse();
+      assertThat(toolResult.content()).isNotNull();
+    } finally {
+      var logs = serverContainer.getLogs();
+      log.info("Detailed MCP Validation Results:");
+      System.out.println(logs);
+    }
+  }
+
   private String generateJwtToken() {
     var now = Instant.now();
     var expiration = now.plusSeconds(20);
@@ -103,6 +251,8 @@ public class JwtContainerIT extends SqrlContainerTestBase {
         .and()
         .issuedAt(Date.from(now))
         .expiration(Date.from(expiration))
+        .claim("val", 1)
+        .claim("values", List.of(1, 2, 3))
         .signWith(
             new SecretKeySpec(
                 "testSecretThatIsAtLeast256BitsLong32Chars".getBytes(UTF_8), "HmacSHA256"))


### PR DESCRIPTION
## Summary
This PR adds JWT authentication support for MCP endpoints to enhance security.

## Related PR
This is targeting `main` branch. See #1504 for the same changes targeting `0.7.x` branch.

## Changes
- Add JWT authentication support for MCP endpoints
- Use EnvVariableNames constants and PostgreSQL 17 as per review comments
- Add comprehensive REST endpoint authentication testing with Feign client

## Test plan
- Unit tests added for JWT authentication
- Integration tests with Feign client for REST endpoints
- Container tests updated to verify authentication flows