### PR TITLE
Fix Vert.x service termination on startup failure

### DIFF
--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
@@ -222,7 +222,11 @@ public class HttpServerVerticle extends AbstractVerticle {
                     .onFailure(err -> log.error("Failed to deploy REST bridge verticle", err));
               }
             })
-        .onFailure(err -> log.error("Failed to deploy GraphQL verticle", err));
+        .onFailure(
+            err -> {
+              log.error("Failed to deploy GraphQL verticle, shutting down application", err);
+              System.exit(1);
+            });
   }
 
   // ---------------------------------------------------------------------------

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/SubscriptionConfigurationImpl.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/SubscriptionConfigurationImpl.java
@@ -30,7 +30,6 @@ import com.datasqrl.graphql.server.RootGraphqlModel.SubscriptionCoords;
 import com.datasqrl.graphql.server.RootGraphqlModel.SubscriptionCoordsVisitor;
 import com.datasqrl.graphql.server.SubscriptionConfiguration;
 import graphql.schema.DataFetcher;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import java.util.HashMap;
@@ -53,7 +52,6 @@ public class SubscriptionConfigurationImpl implements SubscriptionConfiguration<
   RootGraphqlModel root;
   Vertx vertx;
   ServerConfig config;
-  Promise<Void> startPromise;
   VertxJdbcClient client;
 
   @Override
@@ -69,7 +67,8 @@ public class SubscriptionConfigurationImpl implements SubscriptionConfiguration<
             .onFailure(
                 err -> {
                   log.error("Failed to subscribe to topic: {}", coords.getTopic(), err);
-                  startPromise.fail(err);
+                  throw new RuntimeException(
+                      "Failed to subscribe to Kafka topic: " + coords.getTopic(), err);
                 });
         return KafkaDataFetcherFactory.create(new KafkaSinkConsumer<>(consumer), coords);
       }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
@@ -35,7 +35,6 @@ import com.datasqrl.graphql.server.RootGraphqlModel.StringSchema;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.pgclient.PgBuilder;
@@ -198,8 +197,7 @@ class WriteIT {
                 new GraphQLEngineBuilder.Builder()
                     .withMutationConfiguration(new MutationConfigurationImpl(model, vertx, config))
                     .withSubscriptionConfiguration(
-                        new SubscriptionConfigurationImpl(
-                            model, vertx, config, Promise.promise(), null))
+                        new SubscriptionConfigurationImpl(model, vertx, config, null))
                     .build(),
                 new VertxContext(new VertxJdbcClient(Map.of(DatabaseType.POSTGRES, client)), null))
             .build();


### PR DESCRIPTION
## Summary
- Fixed GraphQLServerVerticle to properly handle startup failures and fail promise correctly
- Removed Promise parameter from SubscriptionConfigurationImpl to prevent double failure completion
- Added proper exception handling to ensure JVM terminates when verticle deployment fails
- Updated HttpServerVerticle to call System.exit(1) when GraphQL verticle deployment fails

## Test plan
- [x] Verify compilation of modified modules
- [x] Run unit tests for sqrl-server-vertx-base module
- [x] Run WriteIT integration test to verify changes work correctly
- [x] Code formatted with pre-commit hooks

🤖 Generated with [Claude Code](https://claude.ai/code)