### PR TITLE
Use Jackson instead of Vert.x `JsonObject` in the server config

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -26,7 +26,6 @@ import com.datasqrl.flinkrunner.EnvVarResolver;
 import com.datasqrl.flinkrunner.SqrlRunner;
 import com.datasqrl.graphql.HttpServerVerticle;
 import com.datasqrl.graphql.SqrlObjectMapper;
-import com.datasqrl.graphql.config.ServerConfig;
 import com.datasqrl.graphql.config.ServerConfigUtil;
 import com.datasqrl.graphql.server.ModelContainer;
 import com.datasqrl.util.ConfigLoaderUtils;
@@ -35,7 +34,6 @@ import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
-import io.vertx.core.json.JsonObject;
 import io.vertx.micrometer.MicrometerMetricsFactory;
 import java.net.URI;
 import java.nio.file.Files;
@@ -288,7 +286,7 @@ public class DatasqrlRun {
     }
 
     Map<String, Object> json = mapper.readValue(vertxConfigJson, Map.class);
-    var baseServerConfig = new ServerConfig(new JsonObject(json));
+    var baseServerConfig = ServerConfigUtil.fromConfigMap(json);
 
     var serverConfig = ServerConfigUtil.mergeConfigs(baseServerConfig, vertxConfig());
     var serverVerticle = new HttpServerVerticle(serverConfig, rootGraphqlModel);

--- a/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
@@ -23,6 +23,8 @@ import com.datasqrl.config.ConnectorFactoryFactoryImpl;
 import com.datasqrl.config.ExecutionEnginesHolder;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.config.QueryEngineConfigConverter;
+import com.datasqrl.config.QueryEngineConfigConverterImpl;
 import com.datasqrl.config.SqrlCompilerConfiguration;
 import com.datasqrl.config.SqrlConfigPipeline;
 import com.datasqrl.config.SqrlConstants;
@@ -76,6 +78,7 @@ public class SqrlInjector extends AbstractModule {
     bind(ModuleLoader.class).to(ModuleLoaderImpl.class);
     bind(CompilerConfig.class).to(SqrlCompilerConfiguration.class);
     bind(ConnectorFactoryFactory.class).to(ConnectorFactoryFactoryImpl.class);
+    bind(QueryEngineConfigConverter.class).to(QueryEngineConfigConverterImpl.class);
 
     Multibinder<Preprocessor> binder = Multibinder.newSetBinder(binder(), Preprocessor.class);
     binder.addBinding().to(CopyStaticDataPreprocessor.class);

--- a/sqrl-cli/src/test/java/com/datasqrl/engine/server/GenericJavaServerEngineTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/engine/server/GenericJavaServerEngineTest.java
@@ -18,9 +18,11 @@ package com.datasqrl.engine.server;
 import static com.datasqrl.graphql.SqrlObjectMapper.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.datasqrl.config.PackageJsonImpl;
+import com.datasqrl.config.PackageJson.EmptyEngineConfig;
+import com.datasqrl.config.QueryEngineConfigConverter;
 import com.datasqrl.graphql.config.ServerConfigUtil;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
@@ -28,7 +30,8 @@ import org.junit.jupiter.api.Test;
 
 class GenericJavaServerEngineTest {
 
-  GenericJavaServerEngine underTest = new GenericJavaServerEngine("", new PackageJsonImpl()) {};
+  GenericJavaServerEngine underTest =
+      new GenericJavaServerEngine("", new EmptyEngineConfig(""), new DummyConverter()) {};
 
   @Test
   void test() {
@@ -110,5 +113,13 @@ class GenericJavaServerEngineTest {
     // Ensure buffer is not a complex object (would have been corrupted by old VertxModule usage)
     assertThat(bufferNode.isObject()).isFalse();
     assertThat(bufferNode.has("bytes")).isFalse();
+  }
+
+  private static class DummyConverter implements QueryEngineConfigConverter {
+
+    @Override
+    public List<ObjectNode> convertConfigsToJson() {
+      return List.of();
+    }
   }
 }

--- a/sqrl-cli/src/test/java/com/datasqrl/packager/config/ServerConfigTemplateTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/packager/config/ServerConfigTemplateTest.java
@@ -18,10 +18,9 @@ package com.datasqrl.packager.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datasqrl.graphql.SqrlObjectMapper;
-import com.datasqrl.graphql.config.ServerConfig;
+import com.datasqrl.graphql.config.ServerConfigUtil;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.json.JsonObject;
 import java.io.File;
 import java.util.Comparator;
 import java.util.Map;
@@ -39,7 +38,7 @@ class ServerConfigTemplateTest {
   @SneakyThrows
   void test() {
     var original = mapper.readValue(TEMPLATE, Map.class);
-    var afterParsing = new ServerConfig(new JsonObject(original));
+    var afterParsing = ServerConfigUtil.fromConfigMap(original);
     assertThat(mapper.convertValue(afterParsing, Map.class))
         .usingRecursiveComparison()
         .withComparatorForType(numberComparatorIgnoringType(), Number.class)
@@ -58,7 +57,7 @@ class ServerConfigTemplateTest {
   @SneakyThrows
   public static void main(String[] args) {
     var original = mapper.readValue(TEMPLATE, Map.class);
-    var afterParsing = new ServerConfig(new JsonObject(original));
+    var afterParsing = ServerConfigUtil.fromConfigMap(original);
 
     if (!Objects.equals(original, mapper.convertValue(afterParsing, Map.class))) {
       mapper

--- a/sqrl-planner/src/main/java/com/datasqrl/config/ExecutionEnginesHolder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/ExecutionEnginesHolder.java
@@ -30,6 +30,7 @@ import com.datasqrl.util.ServiceLoaderDiscovery;
 import com.datasqrl.util.StreamUtil;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
+import jakarta.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -66,6 +67,12 @@ public class ExecutionEnginesHolder {
   }
 
   public Map<String, ExecutionEngine> getEngines() {
+    return getEngines(null);
+  }
+
+  public Map<String, ExecutionEngine> getEngines(
+      @Nullable Class<? extends ExecutionEngine> filterClass) {
+
     if (engines == null) {
       synchronized (this) {
         if (engines == null) {
@@ -98,7 +105,15 @@ public class ExecutionEnginesHolder {
       }
     }
 
-    return engines;
+    if (filterClass == null) {
+      return engines;
+    }
+
+    var filteredEngines = new TreeMap<String, ExecutionEngine>();
+    StreamUtil.filterByClass(engines.values(), filterClass)
+        .forEach(e -> filteredEngines.put(e.getName(), e));
+
+    return Collections.unmodifiableMap(filteredEngines);
   }
 
   ExecutionEngine getEngineInstance(String engineName) {

--- a/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverter.java
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.graphql.config;
+package com.datasqrl.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class JdbcConfig {
+/** Converts query engine configurations to JSON format for server deployment. */
+public interface QueryEngineConfigConverter {
 
-  private String url;
+  /**
+   * Converts enabled query engine configurations to a list of JSON objects.
+   *
+   * @return a list of ObjectNode instances, each containing server configuration for an enabled
+   *     query engine
+   */
+  List<ObjectNode> convertConfigsToJson();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverterImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverterImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.config;
+
+import static com.datasqrl.graphql.SqrlObjectMapper.MAPPER;
+
+import com.datasqrl.engine.database.QueryEngine;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class QueryEngineConfigConverterImpl implements QueryEngineConfigConverter {
+
+  private final ExecutionEnginesHolder enginesHolder;
+  private final PackageJson packageJson;
+
+  public List<ObjectNode> convertConfigsToJson() {
+    var convertedConfigs = new ArrayList<ObjectNode>();
+    var enabledQueryEngines = enginesHolder.getEngines(QueryEngine.class).values();
+
+    for (var engine : enabledQueryEngines) {
+      var queryEngine = (QueryEngine) engine;
+      var engineConf = packageJson.getEngines().getEngineConfig(queryEngine.getName()).get();
+      var url = engineConf.getSetting("url", Optional.empty());
+
+      if (url != null) {
+        var rootNode = MAPPER.createObjectNode();
+        var configNode = rootNode.putObject(queryEngine.serverConfigName());
+        configNode.put("url", url);
+
+        convertedConfigs.add(rootNode);
+      }
+    }
+
+    return List.copyOf(convertedConfigs);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/QueryEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/QueryEngine.java
@@ -27,4 +27,6 @@ import com.datasqrl.planner.dag.plan.MaterializationStagePlan;
 public interface QueryEngine extends ExecutionEngine {
 
   EnginePhysicalPlan plan(MaterializationStagePlan stagePlan);
+
+  String serverConfigName();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDBEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDBEngine.java
@@ -33,6 +33,11 @@ public class DuckDBEngine extends AbstractJDBCQueryEngine {
   }
 
   @Override
+  public String serverConfigName() {
+    return "duckDbConfig";
+  }
+
+  @Override
   protected JdbcDialect getDialect() {
     return JdbcDialect.Postgres;
   }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeEngine.java
@@ -33,6 +33,11 @@ public class SnowflakeEngine extends AbstractJDBCQueryEngine {
   }
 
   @Override
+  public String serverConfigName() {
+    return "snowflakeConfig";
+  }
+
+  @Override
   protected JdbcDialect getDialect() {
     return JdbcDialect.Snowflake;
   }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/server/VertxEngineFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/server/VertxEngineFactory.java
@@ -17,15 +17,10 @@ package com.datasqrl.engine.server;
 
 import com.datasqrl.config.EngineFactory;
 import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.QueryEngineConfigConverter;
 import com.datasqrl.engine.IExecutionEngine;
-import com.datasqrl.engine.database.relational.DuckDBEngineFactory;
-import com.datasqrl.engine.database.relational.SnowflakeEngineFactory;
 import com.google.auto.service.AutoService;
 import com.google.inject.Inject;
-import io.vertx.core.json.JsonObject;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @AutoService(EngineFactory.class)
 public class VertxEngineFactory extends GenericJavaServerEngineFactory {
@@ -45,48 +40,11 @@ public class VertxEngineFactory extends GenericJavaServerEngineFactory {
   public static class VertxEngine extends GenericJavaServerEngine {
 
     @Inject
-    public VertxEngine(PackageJson packageJson) {
-      super(ENGINE_NAME, packageJson, getQueryEngineConfigs(packageJson));
-    }
-
-    // TODO ferenc: This is temporary until we get away from JsonObject,
-    //  after that this should be generalized
-    private static List<JsonObject> getQueryEngineConfigs(PackageJson packageJson) {
-      var configs = new ArrayList<JsonObject>();
-
-      getDuckDbConfig(packageJson).map(configs::add);
-      getSnowflakeConfig(packageJson).map(configs::add);
-
-      return List.copyOf(configs);
-    }
-
-    private static Optional<JsonObject> getDuckDbConfig(PackageJson packageJson) {
-      var url = getUrl(packageJson, DuckDBEngineFactory.ENGINE_NAME);
-      if (url == null) {
-        return Optional.empty();
-      }
-
-      return Optional.of(JsonObject.of("duckDbConfig", JsonObject.of("url", url)));
-    }
-
-    private static Optional<JsonObject> getSnowflakeConfig(PackageJson packageJson) {
-      var url = getUrl(packageJson, SnowflakeEngineFactory.ENGINE_NAME);
-      if (url == null) {
-        return Optional.empty();
-      }
-
-      return Optional.of(JsonObject.of("snowflakeConfig", JsonObject.of("url", url)));
-    }
-
-    private static String getUrl(PackageJson packageJson, String engineName) {
-      if (!packageJson.getEnabledEngines().contains(engineName)) {
-        return null;
-      }
-
-      return packageJson
-          .getEngines()
-          .getEngineConfigOrEmpty(engineName)
-          .getSetting("url", Optional.empty());
+    public VertxEngine(PackageJson packageJson, QueryEngineConfigConverter configConverter) {
+      super(
+          ENGINE_NAME,
+          packageJson.getEngines().getEngineConfigOrEmpty(ENGINE_NAME),
+          configConverter);
     }
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
@@ -17,6 +17,7 @@ package com.datasqrl.graphql;
 
 import com.datasqrl.graphql.config.CorsHandlerOptions;
 import com.datasqrl.graphql.config.ServerConfig;
+import com.datasqrl.graphql.config.ServerConfigUtil;
 import com.datasqrl.graphql.server.ModelContainer;
 import com.datasqrl.graphql.server.RootGraphqlModel;
 import com.datasqrl.graphql.server.operation.ApiOperation;
@@ -86,7 +87,7 @@ public class HttpServerVerticle extends AbstractVerticle {
           .onFailure(startPromise::fail)
           .onSuccess(
               raw -> {
-                this.config = new ServerConfig(raw);
+                this.config = ServerConfigUtil.fromConfigMap(raw.getMap());
                 try {
                   bootstrap(startPromise);
                 } catch (Exception e) {

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/CorsHandlerOptions.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/CorsHandlerOptions.java
@@ -15,12 +15,10 @@
  */
 package com.datasqrl.graphql.config;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,6 +26,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CorsHandlerOptions {
 
   private String allowedOrigin;
@@ -38,61 +37,4 @@ public class CorsHandlerOptions {
   private Set<String> allowedMethods = new LinkedHashSet<>();
   private Set<String> allowedHeaders = new LinkedHashSet<>();
   private Set<String> exposedHeaders = new LinkedHashSet<>();
-
-  public CorsHandlerOptions(JsonObject json) {
-    for (java.util.Map.Entry<String, Object> member : json) {
-      switch (member.getKey()) {
-        case "allowedOrigin":
-          if (member.getValue() instanceof String) {
-            this.allowedOrigin = (String) member.getValue();
-          }
-          break;
-        case "allowedOrigins":
-          if (member.getValue() instanceof Iterable c) {
-            this.allowedOrigins = toList(c);
-          }
-          break;
-        case "allowCredentials":
-          if (member.getValue() instanceof Boolean) {
-            this.allowCredentials = (Boolean) member.getValue();
-          }
-          break;
-        case "maxAgeSeconds":
-          if (member.getValue() instanceof Integer) {
-            this.maxAgeSeconds = (Integer) member.getValue();
-          }
-          break;
-        case "allowPrivateNetwork":
-          if (member.getValue() instanceof Boolean) {
-            this.allowPrivateNetwork = (Boolean) member.getValue();
-          }
-          break;
-        case "allowedMethods":
-          if (member.getValue() instanceof Iterable c) {
-            this.allowedMethods = toSet(c);
-          }
-          break;
-        case "allowedHeaders":
-          if (member.getValue() instanceof Iterable c) {
-            this.allowedHeaders = toSet(c);
-          }
-          break;
-        case "exposedHeaders":
-          if (member.getValue() instanceof Iterable c) {
-            this.exposedHeaders = toSet(c);
-          }
-          break;
-      }
-    }
-  }
-
-  private static List<String> toList(Iterable<?> c) {
-    return StreamSupport.stream(c.spliterator(), false).map(String.class::cast).toList();
-  }
-
-  private static Set<String> toSet(Iterable<?> c) {
-    return StreamSupport.stream(c.spliterator(), false)
-        .map(String.class::cast)
-        .collect(Collectors.toCollection(LinkedHashSet::new));
-  }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/KafkaConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/KafkaConfig.java
@@ -23,7 +23,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,15 +35,13 @@ import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class KafkaConfig {
 
   protected Map<String, String> config = new HashMap<>();
 
-  public KafkaConfig(JsonObject json) {
-    for (Map.Entry<String, Object> entry : json) {
-      config.put(entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
-    }
-
+  /** Validates that required configuration is present. Should be called after deserialization. */
+  public void validateConfig() {
     checkNotNull(
         config.get(BOOTSTRAP_SERVERS_CONFIG),
         "The '%s' config must be provided".formatted(BOOTSTRAP_SERVERS_CONFIG));
@@ -64,10 +62,6 @@ public abstract class KafkaConfig {
   @NoArgsConstructor
   public static class KafkaSubscriptionConfig extends KafkaConfig {
 
-    public KafkaSubscriptionConfig(JsonObject json) {
-      super(json);
-    }
-
     public KafkaSubscriptionConfig(Map<String, String> config) {
       super(config);
     }
@@ -84,10 +78,6 @@ public abstract class KafkaConfig {
   @Setter
   @NoArgsConstructor
   public static class KafkaMutationConfig extends KafkaConfig {
-
-    public KafkaMutationConfig(JsonObject json) {
-      super(json);
-    }
 
     public KafkaMutationConfig(Map<String, String> config) {
       super(config);

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.graphql.config;
 
+import static com.datasqrl.graphql.SqrlObjectMapper.MAPPER;
+
 import com.datasqrl.env.EnvVariableNames;
 import com.datasqrl.env.GlobalEnvironmentStore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -44,8 +46,9 @@ public class ServerConfig {
   private PgConnectOptions pgConnectOptions = new PgConnectOptions();
   private PoolOptions poolOptions = new PoolOptions();
   private CorsHandlerOptions corsHandlerOptions = new CorsHandlerOptions();
-  private JWTAuthOptions jwtAuth;
   private SwaggerConfig swaggerConfig = new SwaggerConfig();
+  private JWTAuthOptions jwtAuth;
+
   private KafkaConfig.KafkaMutationConfig kafkaMutationConfig;
   private KafkaConfig.KafkaSubscriptionConfig kafkaSubscriptionConfig;
   private JdbcConfig duckDbConfig;
@@ -79,35 +82,66 @@ public class ServerConfig {
     return this;
   }
 
+  ////////////////////////////////////////////////////////////////////////////////
   // Custom JSON setters for Jackson deserialization of Vert.x classes
+  ////////////////////////////////////////////////////////////////////////////////
+
   @JsonSetter("graphQLHandlerOptions")
   public void setGraphQLHandlerOptionsFromJson(Map<String, Object> options) {
-    this.graphQLHandlerOptions = new GraphQLHandlerOptions(new JsonObject(options));
+    this.graphQLHandlerOptions = new GraphQLHandlerOptions(getJsonObjectOrEmpty(options));
+  }
+
+  @JsonSetter("httpServerOptions")
+  public void setHttpServerOptionsFromJson(Map<String, Object> options) {
+    this.httpServerOptions = new HttpServerOptions(getJsonObjectOrEmpty(options));
+  }
+
+  @JsonSetter("pgConnectOptions")
+  public void setPgConnectOptionsFromJson(Map<String, Object> options) {
+    this.pgConnectOptions = new PgConnectOptions(getJsonObjectOrEmpty(options));
+  }
+
+  @JsonSetter("poolOptions")
+  public void setPoolOptionsFromJson(Map<String, Object> options) {
+    this.poolOptions = new PoolOptions(getJsonObjectOrEmpty(options));
   }
 
   @JsonSetter("graphiQLHandlerOptions")
   public void setGraphiQLHandlerOptionsFromJson(Map<String, Object> options) {
     this.graphiQLHandlerOptions =
-        options != null ? new GraphiQLHandlerOptions(new JsonObject(options)) : null;
-  }
-
-  @JsonSetter("httpServerOptions")
-  public void setHttpServerOptionsFromJson(Map<String, Object> options) {
-    this.httpServerOptions = new HttpServerOptions(new JsonObject(options));
-  }
-
-  @JsonSetter("pgConnectOptions")
-  public void setPgConnectOptionsFromJson(Map<String, Object> options) {
-    this.pgConnectOptions = new PgConnectOptions(new JsonObject(options));
-  }
-
-  @JsonSetter("poolOptions")
-  public void setPoolOptionsFromJson(Map<String, Object> options) {
-    this.poolOptions = new PoolOptions(new JsonObject(options));
+        options == null ? null : new GraphiQLHandlerOptions(new JsonObject(options));
   }
 
   @JsonSetter("jwtAuth")
   public void setJwtAuthFromJson(Map<String, Object> options) {
-    this.jwtAuth = options != null ? new JWTAuthOptions(new JsonObject(options)) : null;
+    this.jwtAuth = options == null ? null : new JWTAuthOptions(new JsonObject(options));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Custom JSON setters for Jackson deserialization of our own POJO classes
+  ////////////////////////////////////////////////////////////////////////////////
+
+  @JsonSetter("servletConfig")
+  public void setServletConfigFromJson(Map<String, Object> options) {
+    this.servletConfig =
+        options == null ? new ServletConfig() : MAPPER.convertValue(options, ServletConfig.class);
+  }
+
+  @JsonSetter("corsHandlerOptions")
+  public void setCorsHandlerOptionsFromJson(Map<String, Object> options) {
+    this.corsHandlerOptions =
+        options == null
+            ? new CorsHandlerOptions()
+            : MAPPER.convertValue(options, CorsHandlerOptions.class);
+  }
+
+  @JsonSetter("swaggerConfig")
+  public void setSwaggerConfigFromJson(Map<String, Object> options) {
+    this.swaggerConfig =
+        options == null ? new SwaggerConfig() : MAPPER.convertValue(options, SwaggerConfig.class);
+  }
+
+  private JsonObject getJsonObjectOrEmpty(Map<String, Object> options) {
+    return options == null ? new JsonObject() : new JsonObject(options);
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServletConfig.java
@@ -15,7 +15,7 @@
  */
 package com.datasqrl.graphql.config;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,6 +23,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServletConfig implements Versioned {
 
   private String graphiQLEndpoint = "/graphiql*";
@@ -30,38 +31,6 @@ public class ServletConfig implements Versioned {
   private String restEndpoint = "/rest";
   private String mcpEndpoint = "/mcp";
   private boolean usePgPool = true;
-
-  public ServletConfig(JsonObject json) {
-    for (java.util.Map.Entry<String, Object> member : json) {
-      switch (member.getKey()) {
-        case "graphiQLEndpoint":
-          if (member.getValue() instanceof String) {
-            this.graphiQLEndpoint = (String) member.getValue();
-          }
-          break;
-        case "graphQLEndpoint":
-          if (member.getValue() instanceof String) {
-            this.graphQLEndpoint = (String) member.getValue();
-          }
-          break;
-        case "restEndpoint":
-          if (member.getValue() instanceof String) {
-            this.restEndpoint = (String) member.getValue();
-          }
-          break;
-        case "mcpEndpoint":
-          if (member.getValue() instanceof String) {
-            this.mcpEndpoint = (String) member.getValue();
-          }
-          break;
-        case "usePgPool":
-          if (member.getValue() instanceof Boolean) {
-            this.usePgPool = (Boolean) member.getValue();
-          }
-          break;
-      }
-    }
-  }
 
   public String getGraphiQLEndpoint(String version) {
     return getVersionedEndpoint(version, graphiQLEndpoint);

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/SwaggerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/SwaggerConfig.java
@@ -15,77 +15,28 @@
  */
 package com.datasqrl.graphql.config;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SwaggerConfig implements Versioned {
 
-  private boolean enabled;
-  private String endpoint;
-  private String uiEndpoint;
-  private String title;
-  private String description;
-  private String version;
-  private String contact;
-  private String contactUrl;
-  private String contactEmail;
-  private String license;
-  private String licenseUrl;
-
-  public SwaggerConfig() {
-    this.enabled = true;
-    this.endpoint = "/swagger";
-    this.uiEndpoint = "/swagger-ui";
-    this.title = "DataSQRL REST API";
-    this.description = "Auto-generated REST API documentation for DataSQRL endpoints";
-    this.version = "1.0.0";
-    this.contact = "DataSQRL";
-    this.contactUrl = "https://datasqrl.com";
-    this.contactEmail = "contact@datasqrl.com";
-    this.license = "Apache License 2.0";
-    this.licenseUrl = "https://www.apache.org/licenses/LICENSE-2.0";
-  }
-
-  public SwaggerConfig(JsonObject json) {
-    this(); // Initialize with defaults
-
-    if (json.getValue("enabled") instanceof Boolean) {
-      this.enabled = (Boolean) json.getValue("enabled");
-    }
-    if (json.getValue("endpoint") instanceof String) {
-      this.endpoint = (String) json.getValue("endpoint");
-    }
-    if (json.getValue("uiEndpoint") instanceof String) {
-      this.uiEndpoint = (String) json.getValue("uiEndpoint");
-    }
-    if (json.getValue("title") instanceof String) {
-      this.title = (String) json.getValue("title");
-    }
-    if (json.getValue("description") instanceof String) {
-      this.description = (String) json.getValue("description");
-    }
-    if (json.getValue("version") instanceof String) {
-      this.version = (String) json.getValue("version");
-    }
-    if (json.getValue("contact") instanceof String) {
-      this.contact = (String) json.getValue("contact");
-    }
-    if (json.getValue("contactUrl") instanceof String) {
-      this.contactUrl = (String) json.getValue("contactUrl");
-    }
-    if (json.getValue("contactEmail") instanceof String) {
-      this.contactEmail = (String) json.getValue("contactEmail");
-    }
-    if (json.getValue("license") instanceof String) {
-      this.license = (String) json.getValue("license");
-    }
-    if (json.getValue("licenseUrl") instanceof String) {
-      this.licenseUrl = (String) json.getValue("licenseUrl");
-    }
-  }
+  private boolean enabled = true;
+  private String endpoint = "/swagger";
+  private String uiEndpoint = "/swagger-ui";
+  private String title = "DataSQRL REST API";
+  private String description = "Auto-generated REST API documentation for DataSQRL endpoints";
+  private String version = "1.0.0";
+  private String contact = "DataSQRL";
+  private String contactUrl = "https://datasqrl.com";
+  private String contactEmail = "contact@datasqrl.com";
+  private String license = "Apache License 2.0";
+  private String licenseUrl = "https://www.apache.org/licenses/LICENSE-2.0";
 
   public String getEndpoint(String version) {
     return getVersionedEndpoint(version, endpoint);

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/config/ServerConfigTest.java
@@ -15,18 +15,19 @@
  */
 package com.datasqrl.graphql.config;
 
+import static com.datasqrl.graphql.SqrlObjectMapper.MAPPER;
 import static org.assertj.core.api.Assertions.*;
 
-import io.vertx.core.json.JsonObject;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ServerConfigTest {
 
   @Test
   void given_emptyJson_when_constructorCalled_then_createsConfigWithDefaults() {
-    var json = new JsonObject();
+    var json = MAPPER.createObjectNode();
 
-    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
+    var serverConfig = ServerConfigUtil.fromConfigMap(MAPPER.convertValue(json, Map.class));
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();
@@ -43,30 +44,30 @@ class ServerConfigTest {
 
   @Test
   void given_jsonWithAllFields_when_constructorCalled_then_createsConfigWithAllValues() {
-    var json =
-        new JsonObject()
-            .put("servletConfig", new JsonObject().put("graphQLEndpoint", "/custom-graphql"))
-            .put("graphQLHandlerOptions", new JsonObject())
-            .put("graphiQLHandlerOptions", new JsonObject())
-            .put("httpServerOptions", new JsonObject().put("port", 9999))
-            .put(
-                "pgConnectOptions", new JsonObject().put("host", "custom-host").put("port", "1234"))
-            .put("poolOptions", new JsonObject().put("maxSize", 20))
-            .put("corsHandlerOptions", new JsonObject().put("allowCredentials", true))
-            .put("jwtAuth", new JsonObject().put("algorithm", "HS256"))
-            .put("swaggerConfig", new JsonObject().put("enabled", true))
-            .put(
-                "kafkaMutationConfig",
-                new JsonObject()
-                    .put("bootstrap.servers", "localhost:9092")
-                    .put("topic", "mutations"))
-            .put(
-                "kafkaSubscriptionConfig",
-                new JsonObject()
-                    .put("bootstrap.servers", "localhost:9092")
-                    .put("groupId", "test-group"));
+    var json = MAPPER.createObjectNode();
+    json.set("servletConfig", MAPPER.createObjectNode().put("graphQLEndpoint", "/custom-graphql"));
+    json.set("graphQLHandlerOptions", MAPPER.createObjectNode());
+    json.set("graphiQLHandlerOptions", MAPPER.createObjectNode());
+    json.set("httpServerOptions", MAPPER.createObjectNode().put("port", 9999));
+    json.set(
+        "pgConnectOptions",
+        MAPPER.createObjectNode().put("host", "custom-host").put("port", "1234"));
+    json.set("poolOptions", MAPPER.createObjectNode().put("maxSize", 20));
+    json.set("corsHandlerOptions", MAPPER.createObjectNode().put("allowCredentials", true));
+    json.set("jwtAuth", MAPPER.createObjectNode().put("algorithm", "HS256"));
+    json.set("swaggerConfig", MAPPER.createObjectNode().put("enabled", true));
 
-    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
+    var kafkaMutationConfig = MAPPER.createObjectNode();
+    kafkaMutationConfig.put("bootstrap.servers", "localhost:9092");
+    kafkaMutationConfig.put("topic", "mutations");
+    json.set("kafkaMutationConfig", kafkaMutationConfig);
+
+    var kafkaSubscriptionConfig = MAPPER.createObjectNode();
+    kafkaSubscriptionConfig.put("bootstrap.servers", "localhost:9092");
+    kafkaSubscriptionConfig.put("groupId", "test-group");
+    json.set("kafkaSubscriptionConfig", kafkaSubscriptionConfig);
+
+    var serverConfig = ServerConfigUtil.fromConfigMap(MAPPER.convertValue(json, Map.class));
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();
@@ -83,20 +84,19 @@ class ServerConfigTest {
 
   @Test
   void given_jsonWithNullFields_when_constructorCalled_then_handlesNullsCorrectly() {
-    var json =
-        new JsonObject()
-            .putNull("servletConfig")
-            .putNull("graphQLHandlerOptions")
-            .putNull("httpServerOptions")
-            .putNull("pgConnectOptions")
-            .putNull("poolOptions")
-            .putNull("corsHandlerOptions")
-            .putNull("jwtAuth")
-            .putNull("swaggerConfig")
-            .putNull("kafkaMutationConfig")
-            .putNull("kafkaSubscriptionConfig");
+    var json = MAPPER.createObjectNode();
+    json.putNull("servletConfig");
+    json.putNull("graphQLHandlerOptions");
+    json.putNull("httpServerOptions");
+    json.putNull("pgConnectOptions");
+    json.putNull("poolOptions");
+    json.putNull("corsHandlerOptions");
+    json.putNull("jwtAuth");
+    json.putNull("swaggerConfig");
+    json.putNull("kafkaMutationConfig");
+    json.putNull("kafkaSubscriptionConfig");
 
-    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
+    var serverConfig = ServerConfigUtil.fromConfigMap(MAPPER.convertValue(json, Map.class));
 
     // Fields with empty defaults should still be created
     assertThat(serverConfig.getServletConfig()).isNotNull();
@@ -117,10 +117,10 @@ class ServerConfigTest {
 
   @Test
   void given_constructorWithJson_when_created_then_configurationIsApplied() {
-    var json =
-        new JsonObject().put("servletConfig", new JsonObject().put("graphQLEndpoint", "/test"));
+    var json = MAPPER.createObjectNode();
+    json.set("servletConfig", MAPPER.createObjectNode().put("graphQLEndpoint", "/test"));
 
-    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
+    var serverConfig = ServerConfigUtil.fromConfigMap(MAPPER.convertValue(json, Map.class));
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/config/ServerConfigTest.java
@@ -26,7 +26,7 @@ class ServerConfigTest {
   void given_emptyJson_when_constructorCalled_then_createsConfigWithDefaults() {
     var json = new JsonObject();
 
-    var serverConfig = new ServerConfig(json);
+    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();
@@ -66,7 +66,7 @@ class ServerConfigTest {
                     .put("bootstrap.servers", "localhost:9092")
                     .put("groupId", "test-group"));
 
-    var serverConfig = new ServerConfig(json);
+    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();
@@ -96,7 +96,7 @@ class ServerConfigTest {
             .putNull("kafkaMutationConfig")
             .putNull("kafkaSubscriptionConfig");
 
-    var serverConfig = new ServerConfig(json);
+    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
 
     // Fields with empty defaults should still be created
     assertThat(serverConfig.getServletConfig()).isNotNull();
@@ -120,7 +120,7 @@ class ServerConfigTest {
     var json =
         new JsonObject().put("servletConfig", new JsonObject().put("graphQLEndpoint", "/test"));
 
-    var serverConfig = new ServerConfig(json);
+    var serverConfig = ServerConfigUtil.fromConfigMap(json.getMap());
 
     assertThat(serverConfig.getServletConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLHandlerOptions()).isNotNull();


### PR DESCRIPTION
## Main changes

- Remove the `JsonObject` boilerplate from our custom `ServerConfig` classes and use Jackson to ser/deser instead
- Add `QueryEngineConfigConverter` to generalize query engine config conversion between `package.json` and the `server-config.json` format

Fixes #1483
Fixes #1484 