### PR TITLE
Disable JBang runner in case of internal test execution

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -71,7 +71,8 @@ public abstract class AbstractCompileCmd extends AbstractCmd {
 
     var injector =
         Guice.createInjector(
-            new SqrlInjector(errors, cli.rootDir, getTargetDir(), sqrlConfig, getGoal()));
+            new SqrlInjector(
+                errors, cli.rootDir, getTargetDir(), sqrlConfig, getGoal(), cli.internalTestExec));
 
     var engineHolder = injector.getInstance(ExecutionEnginesHolder.class);
     engineHolder.initEnabledEngines();

--- a/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
@@ -43,6 +43,7 @@ import com.datasqrl.plan.validate.ExecutionGoal;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import java.nio.file.Path;
@@ -56,19 +57,22 @@ public class SqrlInjector extends AbstractModule {
   private final Path targetDir;
   private final PackageJson sqrlConfig;
   private final ExecutionGoal goal;
+  private final boolean internalTestExec;
 
   public SqrlInjector(
       ErrorCollector errors,
       Path rootDir,
       Path targetDir,
       PackageJson sqrlConfig,
-      ExecutionGoal goal) {
+      ExecutionGoal goal,
+      boolean internalTestExec) {
     this.errors = errors;
     this.rootDir = rootDir;
     this.buildDir = rootDir.resolve(SqrlConstants.BUILD_DIR_NAME);
     this.targetDir = targetDir;
     this.sqrlConfig = sqrlConfig;
     this.goal = goal;
+    this.internalTestExec = internalTestExec;
   }
 
   @Override
@@ -116,8 +120,9 @@ public class SqrlInjector extends AbstractModule {
   }
 
   @Provides
+  @Singleton
   public JBangRunner provideJBangRunner() {
-    return new JBangRunner();
+    return internalTestExec ? JBangRunner.disabled() : JBangRunner.create();
   }
 
   @Provides


### PR DESCRIPTION
If we run an SQRL command programmatically by one of our integration test classes (e.g. `DAGPlannerTest`) `JBangRunner` will be init by Guice and its ctor checks for binary availability, which in my case slowed the internal test exec that uses preprocessors a lot.

## Changes
- Modified JBang availability check to not run at class instantiation, but the first `isJBangAvailable()` call, so `JBangRunner` will not trigger native `Process` exec right away when Guice sets things up
- Added an internal `DisabledRunner` so internal tests that actually use preprocessors, but will not require JBang at all will not spend significant time figuring out if it exists on the system or not, just to not use it afterwards.