### PR TITLE
Fix iceberg database property name in `DuckDbStatementFactory`

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConstants.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConstants.java
@@ -26,6 +26,7 @@ public class SqrlConstants {
   public static final String PACKAGE_JSON = "package.json";
   public static final Path DEFAULT_PACKAGE = Path.of(PACKAGE_JSON);
   public static final String FLINK_ASSETS_DIR = "flink";
+  public static final String FLINK_DEFAULT_DATABASE = "default_database";
   public static final String LIB_DIR = "lib";
   public static final String DATA_DIR = "data";
   public static final String SQRL_EXTENSION = "sqrl";


### PR DESCRIPTION
Now, if the table sits in the non-default DB, all of our DuckDB queries will fail.