### PR TITLE
Relax package.json schema to allow pipeline sizing

### DIFF
--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -165,6 +165,24 @@
             "config": {
               "type": "object",
               "minProperties": 1
+            },
+            "deployment": {
+              "type": "object",
+              "properties": {
+                "jobmanager-size": {
+                  "type": "string",
+                  "enum": ["dev", "small", "medium", "large"]
+                },
+                "taskmanager-size": {
+                  "type": "string",
+                  "enum": ["dev", "small", "small.mem", "small.cpu", "medium", "medium.mem", "medium.cpu", "large", "large.mem", "large.cpu"]
+                },
+                "taskmanager-count": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -195,6 +213,44 @@
             "config": {
               "type": "object",
               "minProperties": 1
+            },
+            "deployment": {
+              "type": "object",
+              "properties": {
+                "instance-size": {
+                  "type": "string",
+                  "enum": ["dev", "small", "small.disk", "medium", "medium.disk", "large", "large.disk"]
+                },
+                "instance-count": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "postgres": {
+          "type": "object",
+          "properties": {
+            "config": {
+              "type": "object",
+              "minProperties": 1
+            },
+            "deployment": {
+              "type": "object",
+              "properties": {
+                "instance-size": {
+                  "type": "string",
+                  "enum": ["dev", "small", "medium", "large", "xlarge"]
+                },
+                "replica-count": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
@@ -39,7 +39,11 @@ class PackageJsonSchemaTest {
         "missingProfilesField.json",
         "validPackageWithUrls.json",
         "onlyVersionFieldExists.json",
-        "scriptApiVersion.json"
+        "scriptApiVersion.json",
+        "validFlinkDeployment.json",
+        "validPostgresDeployment.json",
+        "validVertxDeployment.json",
+        "validFullDeployment.json"
       })
   void validConfigFile(String configFileName) {
     var errors = ErrorCollector.root();
@@ -60,7 +64,11 @@ class PackageJsonSchemaTest {
         "emptyPropertiesInPackage.json",
         "invalidEnumString.json",
         "invalidScriptFields.json",
-        "invalidScriptApiFields.json"
+        "invalidScriptApiFields.json",
+        "invalidFlinkDeploymentSize.json",
+        "invalidDeploymentCount.json",
+        "invalidPostgresReplicaCount.json",
+        "invalidBadModifier.json"
       })
   void invalidConfigFile(String configFileName) {
     testForErrors(

--- a/sqrl-planner/src/test/resources/config/package/invalidBadModifier.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidBadModifier.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "flink": {
+      "deployment": {
+        "taskmanager-size": "medium.disk",
+        "taskmanager-count": 2
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/invalidDeploymentCount.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidDeploymentCount.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "vertx": {
+      "deployment": {
+        "instance-size": "small",
+        "instance-count": 0
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/invalidFlinkDeploymentSize.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidFlinkDeploymentSize.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "flink": {
+      "deployment": {
+        "jobmanager-size": "invalid-size",
+        "taskmanager-count": 2
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/invalidPostgresReplicaCount.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidPostgresReplicaCount.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "postgres": {
+      "deployment": {
+        "instance-size": "medium",
+        "replica-count": -1
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/validFlinkDeployment.json
+++ b/sqrl-planner/src/test/resources/config/package/validFlinkDeployment.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "engines": {
+    "flink": {
+      "deployment": {
+        "jobmanager-size": "medium",
+        "taskmanager-size": "large.mem",
+        "taskmanager-count": 4
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/validFullDeployment.json
+++ b/sqrl-planner/src/test/resources/config/package/validFullDeployment.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "enabled-engines": ["flink", "postgres", "vertx"],
+  "engines": {
+    "flink": {
+      "deployment": {
+        "jobmanager-size": "dev",
+        "taskmanager-size": "small",
+        "taskmanager-count": 1
+      }
+    },
+    "postgres": {
+      "deployment": {
+        "instance-size": "small",
+        "replica-count": 0
+      }
+    },
+    "vertx": {
+      "deployment": {
+        "instance-size": "dev",
+        "instance-count": 1
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/validPostgresDeployment.json
+++ b/sqrl-planner/src/test/resources/config/package/validPostgresDeployment.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "postgres": {
+      "deployment": {
+        "instance-size": "xlarge",
+        "replica-count": 2
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/config/package/validVertxDeployment.json
+++ b/sqrl-planner/src/test/resources/config/package/validVertxDeployment.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "engines": {
+    "vertx": {
+      "deployment": {
+        "instance-size": "medium.disk",
+        "instance-count": 3
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added deployment configuration support to package.json schema for Flink, Postgres, and Vertx engines
- Schema now validates instance sizes (dev, small, medium, large, xlarge) and counts
- Added comprehensive test coverage for valid and invalid deployment configurations

## Changes
- Updated `packageSchema.json` to include deployment sections for each engine:
  - **Flink**: jobmanager-size, taskmanager-size (with .mem/.cpu modifiers), taskmanager-count
  - **Postgres**: instance-size, replica-count 
  - **Vertx**: instance-size (with .disk modifier), instance-count
- Added validation rules: instance counts must be positive (except postgres replicas can be 0)
- Created test files to verify schema accepts valid configurations and rejects invalid ones

## Test Plan
- [x] Added valid deployment configuration test files
- [x] Added invalid deployment configuration test files
- [x] Updated PackageJsonSchemaTest with new test cases
- [x] All tests passing

Closes #1604