### PR TITLE
chore: switch kafka base image from bitnami to bitnamilegacy

### DIFF
--- a/sqrl-cli/src/test/resources/profiles/profile1/docker-compose.yml
+++ b/sqrl-cli/src/test/resources/profiles/profile1/docker-compose.yml
@@ -34,7 +34,7 @@ services:
         taskmanager.numberOfTaskSlots: 1
 
   kafka:
-    image: docker.io/bitnami/kafka:3.4.0-debian-11-r38
+    image: docker.io/bitnamilegacy/kafka:3.4.0-debian-11-r38
     ports:
       - "9092:9092"
       - "9094:9094"
@@ -45,7 +45,7 @@ services:
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
   kafka-setup:
-    image: docker.io/bitnami/kafka:3.4.0-debian-11-r38
+    image: docker.io/bitnamilegacy/kafka:3.4.0-debian-11-r38
     volumes:
       - './create-topics.sh:/create-topics.sh'
     command: ['/bin/bash', '/create-topics.sh']


### PR DESCRIPTION
The traditional Bitnami images will no longer be available in their current form. 

They are being archived in the legacy repository so that teams have time to migrate either to their own maintained images or to the new secure catalog

ref: 
- https://github.com/bitnami/containers/issues/83267