### PR TITLE
Remove Flink `FileSystem.initialize` call from `DatasqrlRun`

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -64,7 +64,6 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.table.api.TableResult;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -198,8 +197,7 @@ public class DatasqrlRun {
               flinkConfig.set(SavepointConfigOptions.SAVEPOINT_PATH, sp);
             });
 
-    FileSystem.initialize(flinkConfig, null);
-    SqrlRunner runner = new SqrlRunner(execMode, flinkConfig, resolver, sqlFile, planFile, udfPath);
+    var runner = new SqrlRunner(execMode, flinkConfig, resolver, sqlFile, planFile, udfPath);
 
     return runner.run();
   }


### PR DESCRIPTION
This is now done by the Flink SQL runner, so it is redundant to call it here too.