### PR TITLE
Make `PipelineDAGExporter` honor its include SQL setting

### DIFF
--- a/documentation/docs/configuration-default.md
+++ b/documentation/docs/configuration-default.md
@@ -12,12 +12,10 @@ The following is the [default configuration file](https://raw.githubusercontent.
     "compile-flink-plan": true,
     "cost-model": "DEFAULT",
     "explain": {
-      "text": true,
       "sql": false,
-      "logical": true,
+      "logical": false,
       "physical": false,
-      "sorted": true,
-      "visual": true
+      "sorted": true
     },
     "api": {
       "protocols": ["GRAPHQL", "REST", "MCP"],

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -120,12 +120,10 @@ Configuration options that control the compiler, such as where logging output is
     "cost-model": "DEFAULT",       // cost model to use for DAG optimization ("DEFAULT" | "READ" | "WRITE")
 
     "explain": {                   // controls what and how the compiler writes pipeline plans to build/pipeline_*
-      "text":     true,           // create text version of the plan
       "sql":      false,          // include SQL code in the plan
-      "logical":  true,           // include the logical plan for each table
+      "logical":  false,           // include the logical plan for each table
       "physical": false,          // include the physical plan for each table
-      "sorted":   true,           // ensure deterministic ordering (mostly for tests)
-      "visual":   true            // create a visual version of the plan
+      "sorted":   true           // ensure deterministic ordering (mostly for tests)
     },
 
     "api": {

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/DagWriter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/DagWriter.java
@@ -56,41 +56,40 @@ public class DagWriter {
   @SneakyThrows
   private void writeExplain(PipelineDAG dag) {
     ExplainConfig explainConfig = compilerConfig.getExplain();
-    if (explainConfig.isText()) {
-      PipelineDAGExporter exporter =
-          PipelineDAGExporter.builder()
-              .includeQueries(false)
-              .includeImports(false)
-              .withHints(true)
-              .includeLogicalPlan(explainConfig.isLogical())
-              .includeSQL(explainConfig.isSql())
-              .includePhysicalPlan(explainConfig.isPhysical())
-              .build();
-      List<PipelineDAGExporter.Node> nodes = exporter.export(dag);
-      if (explainConfig.isSorted()) Collections.sort(nodes); // make order deterministic
-      writeFile(
-          buildDir.buildDir().resolve(EXPLAIN_TEXT_FILENAME),
-          nodes.stream().map(PipelineDAGExporter.Node::toString).collect(Collectors.joining("\n")));
-    }
-    if (explainConfig.isVisual()) {
-      PipelineDAGExporter exporter =
-          PipelineDAGExporter.builder()
-              .includeQueries(true)
-              .includeImports(true)
-              .withHints(true)
-              .includeLogicalPlan(true)
-              .includeSQL(true)
-              .includePhysicalPlan(true)
-              .build();
-      List<PipelineDAGExporter.Node> nodes = exporter.export(dag);
-      if (explainConfig.isSorted()) Collections.sort(nodes); // make order deterministic
-      String jsonContent = Deserializer.INSTANCE.toJson(nodes);
-      String htmlFile =
-          Resources.toString(Resources.getResource(VISUAL_HTML_FILENAME), StandardCharsets.UTF_8);
-      htmlFile = htmlFile.replace(DAG_PLACEHOLDER, jsonContent);
-      writeFile(buildDir.buildDir().resolve(EXPLAIN_VISUAL_FILENAME), htmlFile);
-      writeFile(buildDir.buildDir().resolve(EXPLAIN_JSON_FILENAME), jsonContent);
-    }
+    // Write Pipeline plan as text
+    PipelineDAGExporter exporter =
+        PipelineDAGExporter.builder()
+            .includeQueries(false)
+            .includeImports(false)
+            .withHints(true)
+            .includeLogicalPlan(explainConfig.isLogical())
+            .includeSQL(explainConfig.isSql())
+            .includePhysicalPlan(explainConfig.isPhysical())
+            .build();
+    List<PipelineDAGExporter.Node> nodes = exporter.export(dag);
+    if (explainConfig.isSorted()) Collections.sort(nodes); // make order deterministic
+    writeFile(
+        buildDir.buildDir().resolve(EXPLAIN_TEXT_FILENAME),
+        nodes.stream().map(PipelineDAGExporter.Node::toString).collect(Collectors.joining("\n")));
+
+    // Write pipeline plan as visual representation
+    exporter =
+        PipelineDAGExporter.builder()
+            .includeQueries(true)
+            .includeImports(true)
+            .withHints(true)
+            .includeLogicalPlan(true)
+            .includeSQL(true)
+            .includePhysicalPlan(true)
+            .build();
+    nodes = exporter.export(dag);
+    if (explainConfig.isSorted()) Collections.sort(nodes); // make order deterministic
+    String jsonContent = Deserializer.INSTANCE.toJson(nodes);
+    String htmlFile =
+        Resources.toString(Resources.getResource(VISUAL_HTML_FILENAME), StandardCharsets.UTF_8);
+    htmlFile = htmlFile.replace(DAG_PLACEHOLDER, jsonContent);
+    writeFile(buildDir.buildDir().resolve(EXPLAIN_VISUAL_FILENAME), htmlFile);
+    writeFile(buildDir.buildDir().resolve(EXPLAIN_JSON_FILENAME), jsonContent);
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/main/java/com/datasqrl/config/ExplainConfigImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/ExplainConfigImpl.java
@@ -23,11 +23,6 @@ public class ExplainConfigImpl implements PackageJson.ExplainConfig {
   private final SqrlConfig sqrlConfig;
 
   @Override
-  public boolean isText() {
-    return sqrlConfig.asBool("text").get();
-  }
-
-  @Override
   public boolean isSql() {
     return sqrlConfig.asBool("sql").get();
   }
@@ -45,10 +40,5 @@ public class ExplainConfigImpl implements PackageJson.ExplainConfig {
   @Override
   public boolean isSorted() {
     return sqrlConfig.asBool("sorted").get();
-  }
-
-  @Override
-  public boolean isVisual() {
-    return sqrlConfig.asBool("visual").get();
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
@@ -82,8 +82,6 @@ public interface PackageJson {
 
   interface ExplainConfig {
 
-    boolean isText();
-
     boolean isSql();
 
     boolean isLogical();
@@ -91,8 +89,6 @@ public interface PackageJson {
     boolean isPhysical();
 
     boolean isSorted();
-
-    boolean isVisual();
   }
 
   interface ScriptConfig {

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
@@ -98,7 +98,7 @@ public class PipelineDAGExporter {
                   .stage(stage)
                   .inputs(inputs)
                   .plan(explain(table.getCollapsedRelnode()))
-                  .sql(table.getOriginalSql())
+                  .sql(getSql(table))
                   .primary_key(
                       table.getPrimaryKey().isUndefined()
                           ? null
@@ -140,7 +140,7 @@ public class PipelineDAGExporter {
                 .type(NodeType.QUERY.getName())
                 .stage(stage)
                 .plan(explain(fct.getFunctionAnalysis().getCollapsedRelnode()))
-                .sql(fct.getFunctionAnalysis().getOriginalSql())
+                .sql(getSql(fct.getFunctionAnalysis()))
                 .annotations(getAnnotations(fct))
                 .inputs(inputs)
                 .build());
@@ -149,6 +149,13 @@ public class PipelineDAGExporter {
       }
     }
     return result;
+  }
+
+  private String getSql(TableAnalysis tableAnalysis) {
+    if (!includeSQL) {
+      return null;
+    }
+    return tableAnalysis.getOriginalSql();
   }
 
   private String explain(RelNode relNode) {

--- a/sqrl-planner/src/main/resources/default-package.json
+++ b/sqrl-planner/src/main/resources/default-package.json
@@ -7,12 +7,10 @@
     "compile-flink-plan": true,
     "cost-model": "DEFAULT",
     "explain": {
-      "text": true,
       "sql": false,
-      "logical": true,
+      "logical": false,
       "physical": false,
-      "sorted": true,
-      "visual": true
+      "sorted": true
     },
     "api": {
       "protocols": ["GRAPHQL", "REST", "MCP"],

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/package.json
@@ -1,5 +1,12 @@
 {
   "version": "1",
+  "compiler": {
+    "explain": {
+      "sql": true,
+      "logical": true,
+      "physical": false
+    }
+  },
   "connectors": {
     "kafka": {
       "topic" : "kafka-${sqrl:table-name}"

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-.txt
@@ -12,11 +12,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$3])
-  LogicalFilter(condition=[>($0, 100)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE VIEW `AnotherCustomer` AS  SELECT customerid, email, lastUpdated FROM _Customer WHERE customerid > 100;
 
 === Customer
 ID:     default_catalog.default_database.Customer
@@ -33,29 +28,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE TEMPORARY TABLE `Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `Customer__schema`
+
 === CustomerById
 ID:     default_catalog.default_database.CustomerById
 Type:   query
@@ -65,11 +38,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerById` AS  SELECT * FROM Customer WHERE customerid > ?     ;
 
 === CustomerByMultipleTime
 ID:     default_catalog.default_database.CustomerByMultipleTime
@@ -87,17 +55,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $1 ORDER BY $4 DESC NULLS LAST, $3 NULLS FIRST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByMultipleTime`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid`, `email` ORDER BY `timestamp` DESC NULLS LAST, `lastUpdated` NULLS FIRST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerByTime2
 ID:     default_catalog.default_database.CustomerByTime2
 Type:   state
@@ -114,17 +72,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByTime2`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerFilteredDistinct
 ID:     default_catalog.default_database.CustomerFilteredDistinct
 Type:   state
@@ -140,27 +88,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalFilter(condition=[OR(AND(IS NULL($5), IS NULL($6)), <>($1, $5), <>($2, $6))])
-          LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[LAG($1, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)], $f6=[LAG($2, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-            LogicalFilter(condition=[>=($3, $5)])
-              LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[MAX($3) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-                LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerFilteredDistinct`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `$f5`
-  FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-    FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, LAG(`email`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f5`, LAG(`name`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f6`
-      FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, MAX(`lastUpdated`) OVER (PARTITION BY `customerid` ORDER BY `timestamp` RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `$f5`
-        FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-      WHERE `lastUpdated` >= `$f5`) AS `t1`
-    WHERE `$f5` IS NULL AND `$f6` IS NULL OR `email` <> `$f5` OR `name` <> `$f6`) AS `t3`) AS `t4`
-WHERE `$f5` = 1
+
 === CustomerQuery
 ID:     default_catalog.default_database.CustomerQuery
 Type:   query
@@ -170,11 +98,6 @@ Annotations:
  - stream-root: _Customer
  - parameters: id
  - base-table: AnotherCustomer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$2])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, AnotherCustomer]])
-SQL: CREATE VIEW `CustomerQuery` AS  SELECT * FROM AnotherCustomer WHERE customerid = ?  ;
 
 === CustomerSubscription
 ID:     default_catalog.default_database.CustomerSubscription
@@ -191,10 +114,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscription` AS  SELECT * FROM Customer;
 
 === CustomerSubscriptionById
 ID:     default_catalog.default_database.CustomerSubscriptionById
@@ -205,11 +124,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscriptionById` AS  SELECT * FROM Customer WHERE customerid = ?     ;
 
 === CustomerTimeWindow
 ID:     default_catalog.default_database.CustomerTimeWindow
@@ -224,20 +138,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], unique_email_count=[COUNT(DISTINCT $2)])
-  LogicalProject(window_start=[$5], window_end=[$6], email=[$1])
-    LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('timestamp'), 60000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalTableScan(table=[[default_catalog, default_database, SelectCustomers]])
-SQL: CREATE VIEW `CustomerTimeWindow` AS  SELECT
-                          window_start, window_end,
-                          COUNT(DISTINCT email) AS unique_email_count
-                      FROM TABLE(
-                              TUMBLE(TABLE SelectCustomers, DESCRIPTOR(`timestamp`), INTERVAL '1' MINUTE)
-                           )
-                      GROUP BY
-                          window_start, window_end;
 
 === CustomerTimeWindowTest
 ID:     default_catalog.default_database.CustomerTimeWindowTest
@@ -252,10 +152,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalProject(window_start=[$0], window_end=[$1], unique_email_count=[$2])
-  LogicalTableScan(table=[[default_catalog, default_database, CustomerTimeWindow]])
-SQL: CREATE VIEW `CustomerTimeWindowTest` AS  SELECT * FROM CustomerTimeWindow ORDER BY window_end DESC;
 
 === ExplicitDistinct
 ID:     default_catalog.default_database.ExplicitDistinct
@@ -270,12 +166,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `ExplicitDistinct` AS  SELECT customerid, `timestamp`, name FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === ExternalOrders
 ID:     default_catalog.default_database.ExternalOrders
@@ -292,27 +182,7 @@ Schema:
  - customerid: BIGINT NOT NULL
  - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-SQL: CREATE TEMPORARY TABLE `ExternalOrders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `ExternalOrders` (
-  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
-  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `ExternalOrders__schema`
+
 === InvalidDistinct
 ID:     default_catalog.default_database.InvalidDistinct
 Type:   state
@@ -326,12 +196,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - namee: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], namee=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `InvalidDistinct` AS  SELECT customerid, `timestamp`, name AS namee FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === MissedTemporalJoin
 ID:     default_catalog.default_database.MissedTemporalJoin
@@ -348,12 +212,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalJoin(condition=[=($1, $4)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `MissedTemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct c ON o.customerid = c.customerid;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -365,23 +223,7 @@ Timestamp  : -
 Schema:
  - orderid: INTEGER NOT NULL
  - amount: FLOAT
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TABLE `Orders` (
-  `orderid` INTEGER NOT NULL,
-  `amount` FLOAT,
-  PRIMARY KEY (`orderid`) NOT ENFORCED
-) WITH (
-  'connector' = 'upsert-kafka',
-  'key.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'key.format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'Orders',
-  'value.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'value.format' = 'flexible-json'
-)
+
 === SelectCustomers
 ID:     default_catalog.default_database.SelectCustomers
 Type:   stream
@@ -398,11 +240,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, 0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `SelectCustomers` AS  SELECT * From Customer WHERE customerid > 0 ORDER BY `timestamp` DESC LIMIT 10;
 
 === TableFunctionCallsTblFct
 ID:     default_catalog.default_database.TableFunctionCallsTblFct
@@ -414,11 +251,6 @@ Annotations:
  - stream-root: Customer
  - parameters: arg1, arg2
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableFunctionScan(invocation=[CustomerById(?1)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp)], elementType=[class [Ljava.lang.Object;])
-SQL: CREATE VIEW `TableFunctionCallsTblFct` AS  SELECT * FROM Table(CustomerById(?    )) WHERE customerid > ?    ;
 
 === TemporalJoin
 ID:     default_catalog.default_database.TemporalJoin
@@ -437,14 +269,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 2}])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalFilter(condition=[=($cor1.customerid, $0)])
-      LogicalSnapshot(period=[$cor1.time])
-        LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `TemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct FOR SYSTEM_TIME AS OF `time` c ON o.customerid = c.customerid;
 
 === UnnestOrders
 ID:     default_catalog.default_database.UnnestOrders
@@ -463,16 +287,7 @@ Schema:
  - quantity: BIGINT NOT NULL
  - discount: DOUBLE
  - newId: BIGINT NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], discount=[$5], newId=[+($0, $3)])
-  LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$4], quantity=[$5], discount=[$7])
-    LogicalCorrelate(correlation=[$cor5], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-      Uncollect
-        LogicalProject(entries=[$cor5.entries])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: ALTER VIEW `UnnestOrders` AS SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`,  id + productid AS `newId` FROM 
-(  SELECT o.id, o.customerid, o.`time`, e.productid, e.quantity, e.discount FROM ExternalOrders o CROSS JOIN UNNEST(entries) e );
+
 === _Customer
 ID:     default_catalog.default_database._Customer
 Type:   stream
@@ -488,29 +303,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE TEMPORARY TABLE `_Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_Customer__schema`
+
 === customersink
 ID:     mysink.customersink
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-limit-offset-combinations-.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-limit-offset-combinations-.txt
@@ -12,11 +12,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$3])
-  LogicalFilter(condition=[>($0, 100)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE VIEW `AnotherCustomer` AS  SELECT customerid, email, lastUpdated FROM _Customer WHERE customerid > 100;
 
 === Customer
 ID:     default_catalog.default_database.Customer
@@ -33,29 +28,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE TEMPORARY TABLE `Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `Customer__schema`
+
 === CustomerById
 ID:     default_catalog.default_database.CustomerById
 Type:   query
@@ -65,11 +38,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerById` AS  SELECT * FROM Customer WHERE customerid > ?     ;
 
 === CustomerByMultipleTime
 ID:     default_catalog.default_database.CustomerByMultipleTime
@@ -87,17 +55,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $1 ORDER BY $4 DESC NULLS LAST, $3 NULLS FIRST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByMultipleTime`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid`, `email` ORDER BY `timestamp` DESC NULLS LAST, `lastUpdated` NULLS FIRST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerByTime2
 ID:     default_catalog.default_database.CustomerByTime2
 Type:   state
@@ -114,17 +72,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByTime2`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerFilteredDistinct
 ID:     default_catalog.default_database.CustomerFilteredDistinct
 Type:   state
@@ -140,27 +88,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalFilter(condition=[OR(AND(IS NULL($5), IS NULL($6)), <>($1, $5), <>($2, $6))])
-          LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[LAG($1, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)], $f6=[LAG($2, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-            LogicalFilter(condition=[>=($3, $5)])
-              LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[MAX($3) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-                LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerFilteredDistinct`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `$f5`
-  FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-    FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, LAG(`email`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f5`, LAG(`name`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f6`
-      FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, MAX(`lastUpdated`) OVER (PARTITION BY `customerid` ORDER BY `timestamp` RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `$f5`
-        FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-      WHERE `lastUpdated` >= `$f5`) AS `t1`
-    WHERE `$f5` IS NULL AND `$f6` IS NULL OR `email` <> `$f5` OR `name` <> `$f6`) AS `t3`) AS `t4`
-WHERE `$f5` = 1
+
 === CustomerQuery
 ID:     default_catalog.default_database.CustomerQuery
 Type:   query
@@ -170,11 +98,6 @@ Annotations:
  - stream-root: _Customer
  - parameters: id
  - base-table: AnotherCustomer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$2])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, AnotherCustomer]])
-SQL: CREATE VIEW `CustomerQuery` AS  SELECT * FROM AnotherCustomer WHERE customerid = ?  ;
 
 === CustomerSubscription
 ID:     default_catalog.default_database.CustomerSubscription
@@ -191,10 +114,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscription` AS  SELECT * FROM Customer;
 
 === CustomerSubscriptionById
 ID:     default_catalog.default_database.CustomerSubscriptionById
@@ -205,11 +124,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscriptionById` AS  SELECT * FROM Customer WHERE customerid = ?     ;
 
 === CustomerTimeWindow
 ID:     default_catalog.default_database.CustomerTimeWindow
@@ -224,20 +138,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], unique_email_count=[COUNT(DISTINCT $2)])
-  LogicalProject(window_start=[$5], window_end=[$6], email=[$1])
-    LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('timestamp'), 60000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalTableScan(table=[[default_catalog, default_database, SelectCustomers]])
-SQL: CREATE VIEW `CustomerTimeWindow` AS  SELECT
-                          window_start, window_end,
-                          COUNT(DISTINCT email) AS unique_email_count
-                      FROM TABLE(
-                              TUMBLE(TABLE SelectCustomers, DESCRIPTOR(`timestamp`), INTERVAL '1' MINUTE)
-                           )
-                      GROUP BY
-                          window_start, window_end;
 
 === CustomerTimeWindowTest
 ID:     default_catalog.default_database.CustomerTimeWindowTest
@@ -252,10 +152,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalProject(window_start=[$0], window_end=[$1], unique_email_count=[$2])
-  LogicalTableScan(table=[[default_catalog, default_database, CustomerTimeWindow]])
-SQL: CREATE VIEW `CustomerTimeWindowTest` AS  SELECT * FROM CustomerTimeWindow ORDER BY window_end DESC;
 
 === ExplicitDistinct
 ID:     default_catalog.default_database.ExplicitDistinct
@@ -270,12 +166,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `ExplicitDistinct` AS  SELECT customerid, `timestamp`, name FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === ExternalOrders
 ID:     default_catalog.default_database.ExternalOrders
@@ -292,27 +182,7 @@ Schema:
  - customerid: BIGINT NOT NULL
  - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-SQL: CREATE TEMPORARY TABLE `ExternalOrders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `ExternalOrders` (
-  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
-  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `ExternalOrders__schema`
+
 === InvalidDistinct
 ID:     default_catalog.default_database.InvalidDistinct
 Type:   state
@@ -326,12 +196,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - namee: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], namee=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `InvalidDistinct` AS  SELECT customerid, `timestamp`, name AS namee FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === MissedTemporalJoin
 ID:     default_catalog.default_database.MissedTemporalJoin
@@ -348,12 +212,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalJoin(condition=[=($1, $4)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `MissedTemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct c ON o.customerid = c.customerid;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -365,23 +223,7 @@ Timestamp  : -
 Schema:
  - orderid: INTEGER NOT NULL
  - amount: FLOAT
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TABLE `Orders` (
-  `orderid` INTEGER NOT NULL,
-  `amount` FLOAT,
-  PRIMARY KEY (`orderid`) NOT ENFORCED
-) WITH (
-  'connector' = 'upsert-kafka',
-  'key.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'key.format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'Orders',
-  'value.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'value.format' = 'flexible-json'
-)
+
 === SelectCustomers
 ID:     default_catalog.default_database.SelectCustomers
 Type:   stream
@@ -398,11 +240,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, 0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `SelectCustomers` AS  SELECT * From Customer WHERE customerid > 0 ORDER BY `timestamp` DESC LIMIT 10;
 
 === TableFunctionCallsTblFct
 ID:     default_catalog.default_database.TableFunctionCallsTblFct
@@ -414,11 +251,6 @@ Annotations:
  - stream-root: Customer
  - parameters: arg1, arg2
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableFunctionScan(invocation=[CustomerById(?1)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp)], elementType=[class [Ljava.lang.Object;])
-SQL: CREATE VIEW `TableFunctionCallsTblFct` AS  SELECT * FROM Table(CustomerById(?    )) WHERE customerid > ?    ;
 
 === TemporalJoin
 ID:     default_catalog.default_database.TemporalJoin
@@ -437,14 +269,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 2}])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalFilter(condition=[=($cor1.customerid, $0)])
-      LogicalSnapshot(period=[$cor1.time])
-        LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `TemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct FOR SYSTEM_TIME AS OF `time` c ON o.customerid = c.customerid;
 
 === UnnestOrders
 ID:     default_catalog.default_database.UnnestOrders
@@ -463,16 +287,7 @@ Schema:
  - quantity: BIGINT NOT NULL
  - discount: DOUBLE
  - newId: BIGINT NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], discount=[$5], newId=[+($0, $3)])
-  LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$4], quantity=[$5], discount=[$7])
-    LogicalCorrelate(correlation=[$cor5], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-      Uncollect
-        LogicalProject(entries=[$cor5.entries])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: ALTER VIEW `UnnestOrders` AS SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`,  id + productid AS `newId` FROM 
-(  SELECT o.id, o.customerid, o.`time`, e.productid, e.quantity, e.discount FROM ExternalOrders o CROSS JOIN UNNEST(entries) e );
+
 === _Customer
 ID:     default_catalog.default_database._Customer
 Type:   stream
@@ -488,29 +303,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE TEMPORARY TABLE `_Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_Customer__schema`
+
 === customersink
 ID:     mysink.customersink
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-parameters-order-.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-comprehensiveTest-parameters-order-.txt
@@ -12,11 +12,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$3])
-  LogicalFilter(condition=[>($0, 100)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE VIEW `AnotherCustomer` AS  SELECT customerid, email, lastUpdated FROM _Customer WHERE customerid > 100;
 
 === Customer
 ID:     default_catalog.default_database.Customer
@@ -33,29 +28,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE TEMPORARY TABLE `Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `Customer__schema`
+
 === CustomerById
 ID:     default_catalog.default_database.CustomerById
 Type:   query
@@ -65,11 +38,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerById` AS  SELECT * FROM Customer WHERE customerid > ?     ;
 
 === CustomerByMultipleTime
 ID:     default_catalog.default_database.CustomerByMultipleTime
@@ -87,17 +55,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $1 ORDER BY $4 DESC NULLS LAST, $3 NULLS FIRST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByMultipleTime`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid`, `email` ORDER BY `timestamp` DESC NULLS LAST, `lastUpdated` NULLS FIRST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerByTime2
 ID:     default_catalog.default_database.CustomerByTime2
 Type:   state
@@ -114,17 +72,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerByTime2`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerFilteredDistinct
 ID:     default_catalog.default_database.CustomerFilteredDistinct
 Type:   state
@@ -140,27 +88,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalFilter(condition=[OR(AND(IS NULL($5), IS NULL($6)), <>($1, $5), <>($2, $6))])
-          LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[LAG($1, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)], $f6=[LAG($2, 1) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-            LogicalFilter(condition=[>=($3, $5)])
-              LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], $f5=[MAX($3) OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST)])
-                LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerFilteredDistinct`
-AS
-SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `customerid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `$f5`
-  FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`
-    FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, LAG(`email`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f5`, LAG(`name`, 1) OVER (PARTITION BY `customerid` ORDER BY `timestamp`) AS `$f6`
-      FROM (SELECT `customerid`, `email`, `name`, `lastUpdated`, `timestamp`, MAX(`lastUpdated`) OVER (PARTITION BY `customerid` ORDER BY `timestamp` RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `$f5`
-        FROM `default_catalog`.`default_database`.`Customer`) AS `t`
-      WHERE `lastUpdated` >= `$f5`) AS `t1`
-    WHERE `$f5` IS NULL AND `$f6` IS NULL OR `email` <> `$f5` OR `name` <> `$f6`) AS `t3`) AS `t4`
-WHERE `$f5` = 1
+
 === CustomerQuery
 ID:     default_catalog.default_database.CustomerQuery
 Type:   query
@@ -170,11 +98,6 @@ Annotations:
  - stream-root: _Customer
  - parameters: id
  - base-table: AnotherCustomer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], lastUpdated=[$2])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, AnotherCustomer]])
-SQL: CREATE VIEW `CustomerQuery` AS  SELECT * FROM AnotherCustomer WHERE customerid = ?  ;
 
 === CustomerSubscription
 ID:     default_catalog.default_database.CustomerSubscription
@@ -191,10 +114,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscription` AS  SELECT * FROM Customer;
 
 === CustomerSubscriptionById
 ID:     default_catalog.default_database.CustomerSubscriptionById
@@ -205,11 +124,6 @@ Annotations:
  - stream-root: Customer
  - parameters: minId
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `CustomerSubscriptionById` AS  SELECT * FROM Customer WHERE customerid = ?     ;
 
 === CustomerTimeWindow
 ID:     default_catalog.default_database.CustomerTimeWindow
@@ -224,20 +138,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], unique_email_count=[COUNT(DISTINCT $2)])
-  LogicalProject(window_start=[$5], window_end=[$6], email=[$1])
-    LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('timestamp'), 60000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-      LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-        LogicalTableScan(table=[[default_catalog, default_database, SelectCustomers]])
-SQL: CREATE VIEW `CustomerTimeWindow` AS  SELECT
-                          window_start, window_end,
-                          COUNT(DISTINCT email) AS unique_email_count
-                      FROM TABLE(
-                              TUMBLE(TABLE SelectCustomers, DESCRIPTOR(`timestamp`), INTERVAL '1' MINUTE)
-                           )
-                      GROUP BY
-                          window_start, window_end;
 
 === CustomerTimeWindowTest
 ID:     default_catalog.default_database.CustomerTimeWindowTest
@@ -252,10 +152,6 @@ Schema:
  - window_start: TIMESTAMP(3) NOT NULL
  - window_end: TIMESTAMP(3) NOT NULL
  - unique_email_count: BIGINT NOT NULL
-Plan:
-LogicalProject(window_start=[$0], window_end=[$1], unique_email_count=[$2])
-  LogicalTableScan(table=[[default_catalog, default_database, CustomerTimeWindow]])
-SQL: CREATE VIEW `CustomerTimeWindowTest` AS  SELECT * FROM CustomerTimeWindow ORDER BY window_end DESC;
 
 === ExplicitDistinct
 ID:     default_catalog.default_database.ExplicitDistinct
@@ -270,12 +166,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], name=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `ExplicitDistinct` AS  SELECT customerid, `timestamp`, name FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === ExternalOrders
 ID:     default_catalog.default_database.ExternalOrders
@@ -292,27 +182,7 @@ Schema:
  - customerid: BIGINT NOT NULL
  - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-SQL: CREATE TEMPORARY TABLE `ExternalOrders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `ExternalOrders` (
-  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
-  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `ExternalOrders__schema`
+
 === InvalidDistinct
 ID:     default_catalog.default_database.InvalidDistinct
 Type:   state
@@ -326,12 +196,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - namee: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(customerid=[$0], timestamp=[$4], namee=[$2])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4], _rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `InvalidDistinct` AS  SELECT customerid, `timestamp`, name AS namee FROM (SELECT *, (ROW_NUMBER() OVER (PARTITION BY customerid ORDER BY `timestamp` DESC)) AS _rownum FROM Customer) WHERE (_rownum = 1);
 
 === MissedTemporalJoin
 ID:     default_catalog.default_database.MissedTemporalJoin
@@ -348,12 +212,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalJoin(condition=[=($1, $4)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `MissedTemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct c ON o.customerid = c.customerid;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -365,23 +223,7 @@ Timestamp  : -
 Schema:
  - orderid: INTEGER NOT NULL
  - amount: FLOAT
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TABLE `Orders` (
-  `orderid` INTEGER NOT NULL,
-  `amount` FLOAT,
-  PRIMARY KEY (`orderid`) NOT ENFORCED
-) WITH (
-  'connector' = 'upsert-kafka',
-  'key.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'key.format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'Orders',
-  'value.flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'value.format' = 'flexible-json'
-)
+
 === SelectCustomers
 ID:     default_catalog.default_database.SelectCustomers
 Type:   stream
@@ -398,11 +240,6 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, 0)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
-SQL: CREATE VIEW `SelectCustomers` AS  SELECT * From Customer WHERE customerid > 0 ORDER BY `timestamp` DESC LIMIT 10;
 
 === TableFunctionCallsTblFct
 ID:     default_catalog.default_database.TableFunctionCallsTblFct
@@ -414,11 +251,6 @@ Annotations:
  - stream-root: Customer
  - parameters: arg1, arg2
  - base-table: Customer
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[>($0, ?0)])
-    LogicalTableFunctionScan(invocation=[CustomerById(?1)], rowType=[RecordType(BIGINT customerid, VARCHAR(2147483647) email, VARCHAR(2147483647) name, BIGINT lastUpdated, TIMESTAMP_LTZ(3) *ROWTIME* timestamp)], elementType=[class [Ljava.lang.Object;])
-SQL: CREATE VIEW `TableFunctionCallsTblFct` AS  SELECT * FROM Table(CustomerById(?    )) WHERE customerid > ?    ;
 
 === TemporalJoin
 ID:     default_catalog.default_database.TemporalJoin
@@ -437,14 +269,6 @@ Schema:
  - customerid0: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], entries=[$3], customerid0=[$4], timestamp=[$5], name=[$6])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 2}])
-    LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-    LogicalFilter(condition=[=($cor1.customerid, $0)])
-      LogicalSnapshot(period=[$cor1.time])
-        LogicalTableScan(table=[[default_catalog, default_database, ExplicitDistinct]])
-SQL: CREATE VIEW `TemporalJoin` AS  SELECT * FROM ExternalOrders o JOIN ExplicitDistinct FOR SYSTEM_TIME AS OF `time` c ON o.customerid = c.customerid;
 
 === UnnestOrders
 ID:     default_catalog.default_database.UnnestOrders
@@ -463,16 +287,7 @@ Schema:
  - quantity: BIGINT NOT NULL
  - discount: DOUBLE
  - newId: BIGINT NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], discount=[$5], newId=[+($0, $3)])
-  LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$4], quantity=[$5], discount=[$7])
-    LogicalCorrelate(correlation=[$cor5], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, ExternalOrders]])
-      Uncollect
-        LogicalProject(entries=[$cor5.entries])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: ALTER VIEW `UnnestOrders` AS SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`,  id + productid AS `newId` FROM 
-(  SELECT o.id, o.customerid, o.`time`, e.productid, e.quantity, e.discount FROM ExternalOrders o CROSS JOIN UNNEST(entries) e );
+
 === _Customer
 ID:     default_catalog.default_database._Customer
 Type:   stream
@@ -488,29 +303,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, _Customer]])
-SQL: CREATE TEMPORARY TABLE `_Customer__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Customer` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = 'file:/mock',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_Customer__schema`
+
 === customersink
 ID:     mysink.customersink
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only--package-snowflake.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only--package-snowflake.txt
@@ -24,16 +24,6 @@ Schema:
  - min_duration: BIGINT NOT NULL
  - updated_at0: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - id2: BIGINT
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], id0=[$7], name=[$8], description=[$9], interest_rate=[$10], max_amount=[$11], min_amount=[$12], max_duration=[$13], min_duration=[$14], updated_at0=[$15], id2=[$16])
-  LogicalJoin(condition=[=($16, $1)], joinType=[left])
-    LogicalJoin(condition=[=($7, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-      LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-    LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-SQL: CREATE VIEW `ApplicationInfo` AS  SELECT a.*, t.*, t2.id AS id2 FROM _Applications a
-    JOIN _LoanTypes t ON t.id = a.loan_type_id
-    LEFT JOIN _LoanTypes t2 ON t2.id = a.customer_id;
 
 === ApplicationStatus
 ID:     default_catalog.default_database.ApplicationStatus
@@ -55,21 +45,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - max_amount: DOUBLE NOT NULL
  - min_amount: DOUBLE NOT NULL
-Plan:
-LogicalProject(status=[$1], message=[$2], event_time=[$3], id=[$4], customer_id=[$5], loan_type_id=[$6], amount=[$7], duration=[$8], max_amount=[$15], min_amount=[$16])
-  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{3, 6}])
-    LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0, 3}])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-      LogicalFilter(condition=[=($0, $cor2.loan_application_id)])
-        LogicalSnapshot(period=[$cor2.event_time])
-          LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-    LogicalFilter(condition=[=($0, $cor3.loan_type_id)])
-      LogicalSnapshot(period=[$cor3.event_time])
-        LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-SQL: CREATE VIEW `ApplicationStatus` AS  SELECT u.status, u.message, u.event_time, a.id, a.customer_id, a.loan_type_id,
-                            a.amount, a.duration, t.max_amount, t.min_amount
-                     FROM _ApplicationUpdates u JOIN _Applications FOR SYSTEM_TIME AS OF u.`event_time` a ON a.id = u.loan_application_id
-                                               JOIN _LoanTypes FOR SYSTEM_TIME AS OF u.`event_time` t ON t.id = a.loan_type_id;
 
 === _ApplicationUpdates
 ID:     default_catalog.default_database._ApplicationUpdates
@@ -85,26 +60,7 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[$3])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationUpdates__schema` (
-  `loan_application_id` BIGINT NOT NULL,
-  `status` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `message` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationUpdates` (
-  PRIMARY KEY (`loan_application_id`, `event_time`) NOT ENFORCED,
-  WATERMARK FOR `event_time` AS `event_time`
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/application_updates.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationUpdates__schema`
+
 === _Applications
 ID:     default_catalog.default_database._Applications
 Type:   state
@@ -123,17 +79,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[=($7, 1)])
-    LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $6 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE VIEW `_Applications`
-AS
-SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`
-FROM (SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ApplicationsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _ApplicationsStream
 ID:     default_catalog.default_database._ApplicationsStream
 Type:   stream
@@ -151,30 +97,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationsStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationsStream__schema`
+
 === _LoanTypes
 ID:     default_catalog.default_database._LoanTypes
 Type:   state
@@ -195,17 +118,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8])
-  LogicalFilter(condition=[=($9, 1)])
-    LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $8 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE VIEW `_LoanTypes`
-AS
-SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`
-FROM (SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_LoanTypesStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _LoanTypesStream
 ID:     default_catalog.default_database._LoanTypesStream
 Type:   stream
@@ -225,32 +138,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($8, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE TEMPORARY TABLE `_LoanTypesStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `description` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `interest_rate` DOUBLE NOT NULL,
-  `max_amount` DOUBLE NOT NULL,
-  `min_amount` DOUBLE NOT NULL,
-  `max_duration` BIGINT NOT NULL,
-  `min_duration` BIGINT NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_LoanTypesStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/loan_types.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_LoanTypesStream__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only--package.txt
@@ -24,16 +24,6 @@ Schema:
  - min_duration: BIGINT NOT NULL
  - updated_at0: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - id2: BIGINT
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], id0=[$7], name=[$8], description=[$9], interest_rate=[$10], max_amount=[$11], min_amount=[$12], max_duration=[$13], min_duration=[$14], updated_at0=[$15], id2=[$16])
-  LogicalJoin(condition=[=($16, $1)], joinType=[left])
-    LogicalJoin(condition=[=($7, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-      LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-    LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-SQL: CREATE VIEW `ApplicationInfo` AS  SELECT a.*, t.*, t2.id AS id2 FROM _Applications a
-    JOIN _LoanTypes t ON t.id = a.loan_type_id
-    LEFT JOIN _LoanTypes t2 ON t2.id = a.customer_id;
 
 === ApplicationStatus
 ID:     default_catalog.default_database.ApplicationStatus
@@ -55,21 +45,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - max_amount: DOUBLE NOT NULL
  - min_amount: DOUBLE NOT NULL
-Plan:
-LogicalProject(status=[$1], message=[$2], event_time=[$3], id=[$4], customer_id=[$5], loan_type_id=[$6], amount=[$7], duration=[$8], max_amount=[$15], min_amount=[$16])
-  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{3, 6}])
-    LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0, 3}])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-      LogicalFilter(condition=[=($0, $cor2.loan_application_id)])
-        LogicalSnapshot(period=[$cor2.event_time])
-          LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-    LogicalFilter(condition=[=($0, $cor3.loan_type_id)])
-      LogicalSnapshot(period=[$cor3.event_time])
-        LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-SQL: CREATE VIEW `ApplicationStatus` AS  SELECT u.status, u.message, u.event_time, a.id, a.customer_id, a.loan_type_id,
-                            a.amount, a.duration, t.max_amount, t.min_amount
-                     FROM _ApplicationUpdates u JOIN _Applications FOR SYSTEM_TIME AS OF u.`event_time` a ON a.id = u.loan_application_id
-                                               JOIN _LoanTypes FOR SYSTEM_TIME AS OF u.`event_time` t ON t.id = a.loan_type_id;
 
 === _ApplicationUpdates
 ID:     default_catalog.default_database._ApplicationUpdates
@@ -85,26 +60,7 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[$3])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationUpdates__schema` (
-  `loan_application_id` BIGINT NOT NULL,
-  `status` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `message` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationUpdates` (
-  PRIMARY KEY (`loan_application_id`, `event_time`) NOT ENFORCED,
-  WATERMARK FOR `event_time` AS `event_time`
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/application_updates.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationUpdates__schema`
+
 === _Applications
 ID:     default_catalog.default_database._Applications
 Type:   state
@@ -123,17 +79,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[=($7, 1)])
-    LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $6 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE VIEW `_Applications`
-AS
-SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`
-FROM (SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ApplicationsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _ApplicationsStream
 ID:     default_catalog.default_database._ApplicationsStream
 Type:   stream
@@ -151,30 +97,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationsStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationsStream__schema`
+
 === _LoanTypes
 ID:     default_catalog.default_database._LoanTypes
 Type:   state
@@ -195,17 +118,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8])
-  LogicalFilter(condition=[=($9, 1)])
-    LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $8 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE VIEW `_LoanTypes`
-AS
-SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`
-FROM (SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_LoanTypesStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _LoanTypesStream
 ID:     default_catalog.default_database._LoanTypesStream
 Type:   stream
@@ -225,32 +138,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($8, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE TEMPORARY TABLE `_LoanTypesStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `description` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `interest_rate` DOUBLE NOT NULL,
-  `max_amount` DOUBLE NOT NULL,
-  `min_amount` DOUBLE NOT NULL,
-  `max_duration` BIGINT NOT NULL,
-  `min_duration` BIGINT NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_LoanTypesStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/loan_types.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_LoanTypesStream__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema--package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema--package-no-snapshots.txt
@@ -45,10 +45,6 @@ Schema:
  - decimalField: DECIMAL(10, 2) NOT NULL
  - mapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP NOT NULL
  - nullableMapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP
-Plan:
-LogicalProject(uuidField=[$0], timestampMillisField=[$1], nullableTimestampMillisField=[$2], timestampMicrosField=[$3], nullableTimestampMicrosField=[$4], dateField=[$5], nullableDateField=[$6], timeMillisField=[$7], nullableTimeMillisField=[$8], timeMicrosField=[$9], nullableTimeMicrosField=[$10], complexArrayField=[$11], nullableComplexArrayField=[$12], multiNestedRecord=[$13], stringField=[$14], nullableStringField=[$15], intField=[$16], nullableIntField=[$17], longField=[$18], nullableLongField=[$19], floatField=[$20], nullableFloatField=[$21], doubleField=[$22], nullableDoubleField=[$23], booleanField=[$24], nullableBooleanField=[$25], enumField=[$26], nullableEnumField=[$27], arrayField=[$28], nullableArrayField=[$29], nestedRecord=[$30], nullableNestedRecord=[$31], decimalField=[$32], mapField=[$33], nullableMapField=[$34])
-  LogicalTableScan(table=[[default_catalog, default_database, _Schema]])
-SQL: CREATE VIEW `Schema` AS  SELECT * FROM _Schema ORDER BY uuidField DESC;
 
 === _Schema
 ID:     default_catalog.default_database._Schema
@@ -96,58 +92,7 @@ Schema:
  - decimalField: DECIMAL(10, 2) NOT NULL
  - mapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP NOT NULL
  - nullableMapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestampMillisField], watermark=[$1])
-  LogicalTableScan(table=[[default_catalog, default_database, _Schema]])
-SQL: CREATE TEMPORARY TABLE `_Schema__schema` (
-  `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `timestampMillisField` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `nullableTimestampMillisField` TIMESTAMP(3) WITH LOCAL TIME ZONE,
-  `timestampMicrosField` TIMESTAMP(6) WITH LOCAL TIME ZONE NOT NULL,
-  `nullableTimestampMicrosField` TIMESTAMP(6) WITH LOCAL TIME ZONE,
-  `dateField` DATE NOT NULL,
-  `nullableDateField` DATE,
-  `timeMillisField` TIME(0) NOT NULL,
-  `nullableTimeMillisField` TIME(0),
-  `timeMicrosField` TIME(0) NOT NULL,
-  `nullableTimeMicrosField` TIME(0),
-  `complexArrayField` ROW(`itemFieldOne` INTEGER NOT NULL, `itemFieldTwo` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL) NOT NULL ARRAY NOT NULL,
-  `nullableComplexArrayField` ROW(`nullableItemFieldOne` DOUBLE, `nullableItemFieldTwo` BOOLEAN) ARRAY,
-  `multiNestedRecord` ROW(`nestedLevelOne` ROW(`levelOneField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `nestedLevelTwo` ROW(`levelTwoField` INTEGER NOT NULL) NOT NULL) NOT NULL) NOT NULL,
-  `stringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `nullableStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `intField` INTEGER NOT NULL,
-  `nullableIntField` INTEGER,
-  `longField` BIGINT NOT NULL,
-  `nullableLongField` BIGINT,
-  `floatField` FLOAT NOT NULL,
-  `nullableFloatField` FLOAT,
-  `doubleField` DOUBLE NOT NULL,
-  `nullableDoubleField` DOUBLE,
-  `booleanField` BOOLEAN NOT NULL,
-  `nullableBooleanField` BOOLEAN,
-  `enumField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `nullableEnumField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `arrayField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL ARRAY NOT NULL,
-  `nullableArrayField` INTEGER ARRAY,
-  `nestedRecord` ROW(`nestedStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `nestedIntField` INTEGER NOT NULL, `nestedArrayField` FLOAT NOT NULL ARRAY NOT NULL, `nestedMapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` > NOT NULL) NOT NULL,
-  `nullableNestedRecord` ROW(`nullableNestedStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `nullableNestedLongField` BIGINT),
-  `decimalField` DECIMAL(10, 2) NOT NULL,
-  `mapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` > NOT NULL,
-  `nullableMapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` >
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Schema` (
-  PRIMARY KEY (`uuidField`, `timestampMillisField`) NOT ENFORCED,
-  WATERMARK FOR `timestampMillisField` AS `timestampMillisField`
-) WITH (
-  'format' = 'json',
-  'json.timestamp-format.standard' = 'ISO-8601',
-  'path' = '${DATA_PATH}/schema.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_Schema__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_Schema__schema` (
   `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema--package.txt
@@ -45,10 +45,6 @@ Schema:
  - decimalField: DECIMAL(10, 2) NOT NULL
  - mapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP NOT NULL
  - nullableMapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP
-Plan:
-LogicalProject(uuidField=[$0], timestampMillisField=[$1], nullableTimestampMillisField=[$2], timestampMicrosField=[$3], nullableTimestampMicrosField=[$4], dateField=[$5], nullableDateField=[$6], timeMillisField=[$7], nullableTimeMillisField=[$8], timeMicrosField=[$9], nullableTimeMicrosField=[$10], complexArrayField=[$11], nullableComplexArrayField=[$12], multiNestedRecord=[$13], stringField=[$14], nullableStringField=[$15], intField=[$16], nullableIntField=[$17], longField=[$18], nullableLongField=[$19], floatField=[$20], nullableFloatField=[$21], doubleField=[$22], nullableDoubleField=[$23], booleanField=[$24], nullableBooleanField=[$25], enumField=[$26], nullableEnumField=[$27], arrayField=[$28], nullableArrayField=[$29], nestedRecord=[$30], nullableNestedRecord=[$31], decimalField=[$32], mapField=[$33], nullableMapField=[$34])
-  LogicalTableScan(table=[[default_catalog, default_database, _Schema]])
-SQL: CREATE VIEW `Schema` AS  SELECT * FROM _Schema ORDER BY uuidField DESC;
 
 === _Schema
 ID:     default_catalog.default_database._Schema
@@ -96,58 +92,7 @@ Schema:
  - decimalField: DECIMAL(10, 2) NOT NULL
  - mapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP NOT NULL
  - nullableMapField: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL) MAP
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestampMillisField], watermark=[$1])
-  LogicalTableScan(table=[[default_catalog, default_database, _Schema]])
-SQL: CREATE TEMPORARY TABLE `_Schema__schema` (
-  `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `timestampMillisField` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `nullableTimestampMillisField` TIMESTAMP(3) WITH LOCAL TIME ZONE,
-  `timestampMicrosField` TIMESTAMP(6) WITH LOCAL TIME ZONE NOT NULL,
-  `nullableTimestampMicrosField` TIMESTAMP(6) WITH LOCAL TIME ZONE,
-  `dateField` DATE NOT NULL,
-  `nullableDateField` DATE,
-  `timeMillisField` TIME(0) NOT NULL,
-  `nullableTimeMillisField` TIME(0),
-  `timeMicrosField` TIME(0) NOT NULL,
-  `nullableTimeMicrosField` TIME(0),
-  `complexArrayField` ROW(`itemFieldOne` INTEGER NOT NULL, `itemFieldTwo` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL) NOT NULL ARRAY NOT NULL,
-  `nullableComplexArrayField` ROW(`nullableItemFieldOne` DOUBLE, `nullableItemFieldTwo` BOOLEAN) ARRAY,
-  `multiNestedRecord` ROW(`nestedLevelOne` ROW(`levelOneField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `nestedLevelTwo` ROW(`levelTwoField` INTEGER NOT NULL) NOT NULL) NOT NULL) NOT NULL,
-  `stringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `nullableStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `intField` INTEGER NOT NULL,
-  `nullableIntField` INTEGER,
-  `longField` BIGINT NOT NULL,
-  `nullableLongField` BIGINT,
-  `floatField` FLOAT NOT NULL,
-  `nullableFloatField` FLOAT,
-  `doubleField` DOUBLE NOT NULL,
-  `nullableDoubleField` DOUBLE,
-  `booleanField` BOOLEAN NOT NULL,
-  `nullableBooleanField` BOOLEAN,
-  `enumField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `nullableEnumField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `arrayField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL ARRAY NOT NULL,
-  `nullableArrayField` INTEGER ARRAY,
-  `nestedRecord` ROW(`nestedStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `nestedIntField` INTEGER NOT NULL, `nestedArrayField` FLOAT NOT NULL ARRAY NOT NULL, `nestedMapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` > NOT NULL) NOT NULL,
-  `nullableNestedRecord` ROW(`nullableNestedStringField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `nullableNestedLongField` BIGINT),
-  `decimalField` DECIMAL(10, 2) NOT NULL,
-  `mapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` > NOT NULL,
-  `nullableMapField` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, VARCHAR(2147483647) CHARACTER SET `UTF-16LE` >
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Schema` (
-  PRIMARY KEY (`uuidField`, `timestampMillisField`) NOT ENFORCED,
-  WATERMARK FOR `timestampMillisField` AS `timestampMillisField`
-) WITH (
-  'format' = 'json',
-  'json.timestamp-format.standard' = 'ISO-8601',
-  'path' = '${DATA_PATH}/schema.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_Schema__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_Schema__schema` (
   `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts--package.txt
@@ -13,10 +13,6 @@ Schema:
  - uuidField: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - timestampMillisField: TIMESTAMP(3) *ROWTIME* NOT NULL
  - nullableTimestampMillisField: TIMESTAMP(3)
-Plan:
-LogicalProject(uuidField=[$0], timestampMillisField=[$1], nullableTimestampMillisField=[$2])
-  LogicalTableScan(table=[[default_catalog, default_database, _MySchema]])
-SQL: CREATE VIEW `Res` AS  SELECT * FROM _MySchema ORDER BY uuidField DESC;
 
 === _MySchema
 ID:     default_catalog.default_database._MySchema
@@ -31,26 +27,7 @@ Schema:
  - uuidField: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - timestampMillisField: TIMESTAMP(3) *ROWTIME* NOT NULL
  - nullableTimestampMillisField: TIMESTAMP(3)
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestampMillisField], watermark=[$1])
-  LogicalTableScan(table=[[default_catalog, default_database, _MySchema]])
-SQL: CREATE TEMPORARY TABLE `_MySchema__schema` (
-  `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `timestampMillisField` TIMESTAMP(3) NOT NULL,
-  `nullableTimestampMillisField` TIMESTAMP(3)
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_MySchema` (
-  PRIMARY KEY (`uuidField`, `timestampMillisField`) NOT ENFORCED,
-  WATERMARK FOR `timestampMillisField` AS `timestampMillisField`
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'avro',
-  'path' = '${DATA_PATH}/data.avro',
-  'avro.timestamp_mapping.legacy' = 'true'
-)
-LIKE `_MySchema__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_MySchema__schema` (
   `uuidField` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch--package.txt
@@ -13,24 +13,7 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, ApplicationUpdates]])
-SQL: CREATE TEMPORARY TABLE `ApplicationUpdates__schema` (
-  `loan_application_id` BIGINT NOT NULL,
-  `status` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `message` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `ApplicationUpdates` (
-  PRIMARY KEY (`loan_application_id`, `event_time`) NOT ENFORCED
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/application_updates.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `ApplicationUpdates__schema`
+
 === Applications
 ID:     default_catalog.default_database.Applications
 Type:   state
@@ -48,17 +31,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[=($7, 1)])
-    LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $6 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE VIEW `Applications`
-AS
-SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`
-FROM (SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ApplicationsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomerUpdates
 ID:     default_catalog.default_database.CustomerUpdates
 Type:   state
@@ -69,18 +42,6 @@ Timestamp  : -
 Schema:
  - customer_id: BIGINT NOT NULL
  - num_updates: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], num_updates=[COUNT()])
-  LogicalProject(customer_id=[$0])
-    LogicalJoin(condition=[=($8, $15)], joinType=[inner])
-      LogicalJoin(condition=[=($0, $9)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-        LogicalTableScan(table=[[default_catalog, default_database, Applications]])
-      LogicalTableScan(table=[[default_catalog, default_database, ApplicationUpdates]])
-SQL: CREATE VIEW `CustomerUpdates` AS  SELECT c.id AS customer_id, COUNT(*) AS num_updates FROM Customers c
-    JOIN Applications a ON c.id = a.customer_id
-    JOIN ApplicationUpdates u ON a.id = u.loan_application_id
-    GROUP BY c.id;
 
 === Customers
 ID:     default_catalog.default_database.Customers
@@ -100,17 +61,7 @@ Schema:
  - address: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - date_of_birth: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updated_at: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], phone=[$4], address=[$5], date_of_birth=[$6], updated_at=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], phone=[$4], address=[$5], date_of_birth=[$6], updated_at=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE VIEW `Customers`
-AS
-SELECT `id`, `first_name`, `last_name`, `email`, `phone`, `address`, `date_of_birth`, `updated_at`
-FROM (SELECT `id`, `first_name`, `last_name`, `email`, `phone`, `address`, `date_of_birth`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_CustomersStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _ApplicationsStream
 ID:     default_catalog.default_database._ApplicationsStream
 Type:   stream
@@ -128,27 +79,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationsStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationsStream__schema`
+
 === _CustomersStream
 ID:     default_catalog.default_database._CustomersStream
 Type:   stream
@@ -167,28 +98,7 @@ Schema:
  - address: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - date_of_birth: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updated_at: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE TEMPORARY TABLE `_CustomersStream__schema` (
-  `id` BIGINT NOT NULL,
-  `first_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `last_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `phone` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `address` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `date_of_birth` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_CustomersStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/customers.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_CustomersStream__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_CustomersStream__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-teaser--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-teaser--package.txt
@@ -12,26 +12,7 @@ Schema:
  - url: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($1, 1000:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, Click]])
-SQL: CREATE TEMPORARY TABLE `Click__schema` (
-  `url` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `userid` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Click` (
-  PRIMARY KEY (`url`, `userid`, `timestamp`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '1' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/click.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `Click__schema`
+
 === Recommendation
 ID:     default_catalog.default_database.Recommendation
 Type:   state
@@ -45,13 +26,6 @@ Schema:
  - url: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - rec: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - frequency: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], frequency=[COUNT()])
-  LogicalProject(url=[$0], rec=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, VisitAfter]])
-SQL: CREATE VIEW `Recommendation` AS  SELECT beforeURL AS url, afterURL AS rec,
-    count(1) AS frequency FROM VisitAfter
-    GROUP BY beforeURL, afterURL ORDER BY url ASC, frequency DESC;
 
 === Trending
 ID:     default_catalog.default_database.Trending
@@ -65,13 +39,6 @@ Timestamp  : -
 Schema:
  - url: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - total: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], total=[COUNT()])
-  LogicalProject(url=[$0])
-    LogicalTableScan(table=[[default_catalog, default_database, Click]])
-SQL: CREATE VIEW `Trending` AS  SELECT url, count(1) AS total
-    FROM Click
-    GROUP BY url ORDER BY total DESC, url ASC;
 
 === VisitAfter
 ID:     default_catalog.default_database.VisitAfter
@@ -84,16 +51,6 @@ Schema:
  - beforeURL: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - afterURL: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(beforeURL=[$0], afterURL=[$3], timestamp=[$4])
-  LogicalJoin(condition=[AND(=($2, $5), <($1, $4), >=($1, -($4, *(10, 60000:INTERVAL MINUTE))))], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, Click]])
-    LogicalTableScan(table=[[default_catalog, default_database, Click]])
-SQL: CREATE VIEW `VisitAfter` AS  SELECT b.url AS beforeURL, a.url AS afterURL,
-    a.`timestamp` AS `timestamp`
-    FROM Click b JOIN Click a ON b.userid=a.userid AND
-        b.`timestamp` < a.`timestamp` AND
-        b.`timestamp` >= a.`timestamp` - INTERVAL 10 MINUTE;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Click__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference--package.txt
@@ -10,13 +10,6 @@ Schema:
  - eventid: BIGINT NOT NULL
  - num: BIGINT NOT NULL
  - test: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], num=[COUNT()], test=[AVG($0)])
-  LogicalProject(eventid=[$1])
-    LogicalFilter(condition=[$3])
-      LogicalTableScan(table=[[default_catalog, default_database, _UserLikes]])
-SQL: CREATE VIEW `EventLikeCount` AS  SELECT eventid, count(*) as num, avg(eventid) as test
-                  FROM _UserLikes WHERE liked GROUP BY eventid;
 
 === Events
 ID:     default_catalog.default_database.Events
@@ -42,17 +35,7 @@ Schema:
  - startTime: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - embedding: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
  - startTimestamp: TIMESTAMP(3)
-Plan:
-LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[$11], startTimestamp=[$12])
-  LogicalFilter(condition=[=($13, 1)])
-    LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[$11], startTimestamp=[$12], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $8 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ProcessedEventStream]])
-SQL: CREATE VIEW `Events`
-AS
-SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `speakers`, `last_updated`, `id`, `full_text`, `startTime`, `embedding`, `startTimestamp`
-FROM (SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `speakers`, `last_updated`, `id`, `full_text`, `startTime`, `embedding`, `startTimestamp`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `last_updated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ProcessedEventStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === EventsLiked
 ID:     default_catalog.default_database.EventsLiked
 Type:   query
@@ -61,16 +44,6 @@ Inputs: default_catalog.default_database.Events, default_catalog.default_databas
 Annotations:
  - parameters: userid
  - base-table: Events
-Plan:
-LogicalSort(sort0=[$12], dir0=[ASC-nulls-first])
-  LogicalProject(url=[$5], date=[$6], time=[$7], title=[$8], abstract=[$9], location=[$10], speakers=[$11], last_updated=[$12], id=[$13], full_text=[$14], startTime=[$15], embedding=[$16], startTimestamp=[$17])
-    LogicalFilter(condition=[=($2, ?0)])
-      LogicalJoin(condition=[=($1, $13)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, _UserLikes]])
-        LogicalTableScan(table=[[default_catalog, default_database, Events]])
-SQL: CREATE VIEW `EventsLiked` AS  SELECT e.* FROM _UserLikes l JOIN Events e ON l.eventid = e.id
-                                WHERE l.userid = ?      
-                                ORDER BY e.startTimestamp ASC;
 
 === PersonalizedEventSearch
 ID:     default_catalog.default_database.PersonalizedEventSearch
@@ -80,19 +53,6 @@ Inputs: default_catalog.default_database.Events, default_catalog.default_databas
 Annotations:
  - parameters: query, userid
  - base-table: PersonalizedEventSearch
-Plan:
-LogicalSort(sort0=[$13], dir0=[DESC-nulls-last])
-  LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[$11], startTimestamp=[$12], score=[coalesce(cosine_similarity($14, $11), 0.0:DOUBLE)])
-    LogicalFilter(condition=[>(text_search(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $3, $4), 0)])
-      LogicalJoin(condition=[=($13, ?1)], joinType=[left])
-        LogicalTableScan(table=[[default_catalog, default_database, Events]])
-        LogicalTableScan(table=[[default_catalog, default_database, _UserInterests]])
-SQL: CREATE VIEW `PersonalizedEventSearch` AS 
-    SELECT e.*, coalesce(cosine_similarity(i.interestVector, e.embedding),0.0) as score
-        FROM Events e
-        LEFT JOIN _UserInterests i ON i.userid = ?      
-        WHERE text_search(?     , title, abstract) > 0 
-    ORDER BY score DESC;
 
 === RecommendedEvents
 ID:     default_catalog.default_database.RecommendedEvents
@@ -102,16 +62,6 @@ Inputs: default_catalog.default_database.Events, default_catalog.default_databas
 Annotations:
  - parameters: userid
  - base-table: RecommendedEvents
-Plan:
-LogicalSort(sort0=[$13], dir0=[DESC-nulls-last])
-  LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[$11], startTimestamp=[$12], score=[cosine_similarity($14, $11)])
-    LogicalJoin(condition=[=($13, ?0)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, Events]])
-      LogicalTableScan(table=[[default_catalog, default_database, _UserInterests]])
-SQL: CREATE VIEW `RecommendedEvents` AS 
-SELECT e.*, cosine_similarity(i.interestVector, e.embedding) as score
-FROM Events e JOIN _UserInterests i ON i.userid = ?      
-ORDER BY score DESC;
 
 === _AddInterest
 ID:     default_catalog.default_database._AddInterest
@@ -128,10 +78,6 @@ Schema:
  - text: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - embedding: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
-Plan:
-LogicalProject(_uuid=[$0], userid=[$1], text=[$2], event_time=[$3], embedding=[vector_embed($2, 'text-embedding-3-small')])
-  LogicalTableScan(table=[[default_catalog, default_database, _AddInterestStream]])
-SQL: CREATE VIEW `_AddInterest` AS  SELECT *, vector_embed(text, 'text-embedding-3-small') AS embedding FROM _AddInterestStream;
 
 === _AddInterestStream
 ID:     default_catalog.default_database._AddInterestStream
@@ -147,27 +93,7 @@ Schema:
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - text: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _AddInterestStream]])
-SQL: CREATE TEMPORARY TABLE `_AddInterestStream__schema` (
-  `_uuid` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `userid` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `text` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_AddInterestStream` (
-  PRIMARY KEY (`_uuid`) NOT ENFORCED,
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/add_interest.jsonl',
-  'source.monitor-interval' = '1',
-  'connector' = 'filesystem'
-)
-LIKE `_AddInterestStream__schema`
+
 === _EventStream
 ID:     default_catalog.default_database._EventStream
 Type:   stream
@@ -187,32 +113,7 @@ Schema:
  - location: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - speakers: RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" name, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" title, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" company) NOT NULL ARRAY NOT NULL
  - last_updated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[last_updated], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _EventStream]])
-SQL: CREATE TEMPORARY TABLE `_EventStream__schema` (
-  `url` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `date` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `time` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `title` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `abstract` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `location` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `speakers` ROW(`name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `title` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `company` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`) NOT NULL ARRAY NOT NULL,
-  `last_updated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_EventStream` (
-  PRIMARY KEY (`url`, `last_updated`) NOT ENFORCED,
-  WATERMARK FOR `last_updated` AS `last_updated` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'json',
-  'path' = '${DATA_PATH}/events.jsonl',
-  'json.timestamp-format.standard' = 'ISO-8601',
-  'source.monitor-interval' = '1 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_EventStream__schema`
+
 === _LikeVector
 ID:     default_catalog.default_database._LikeVector
 Type:   stream
@@ -229,16 +130,6 @@ Schema:
  - abstract: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - location: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(userid=[$2], embedding=[$16], title=[$8], abstract=[$9], location=[$10], event_time=[$4])
-  LogicalFilter(condition=[$3])
-    LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
-      LogicalTableScan(table=[[default_catalog, default_database, _Likes]])
-      LogicalFilter(condition=[=($cor1.eventid, $8)])
-        LogicalSnapshot(period=[$cor1.event_time])
-          LogicalTableScan(table=[[default_catalog, default_database, Events]])
-SQL: CREATE VIEW `_LikeVector` AS  SELECT l.userid, e.embedding, e.title, e.abstract, e.location, l.event_time
-              FROM _Likes l JOIN Events FOR SYSTEM_TIME AS OF l.event_time e ON l.eventid = e.id WHERE l.liked;
 
 === _Likes
 ID:     default_catalog.default_database._Likes
@@ -255,29 +146,7 @@ Schema:
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - liked: BOOLEAN NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _Likes]])
-SQL: CREATE TEMPORARY TABLE `_Likes__schema` (
-  `_uuid` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `eventid` BIGINT NOT NULL,
-  `userid` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `liked` BOOLEAN NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Likes` (
-  PRIMARY KEY (`_uuid`) NOT ENFORCED,
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/likes.jsonl',
-  'source.monitor-interval' = '1 sec',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'connector' = 'filesystem'
-)
-LIKE `_Likes__schema`
+
 === _ProcessedEventStream
 ID:     default_catalog.default_database._ProcessedEventStream
 Type:   stream
@@ -301,18 +170,7 @@ Schema:
  - startTime: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - embedding: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
  - startTimestamp: TIMESTAMP(3)
-Plan:
-LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[$11], startTimestamp=[TO_TIMESTAMP(CONCAT($10, ' PDT'), 'MMMM d, yyyy h:mm a z')])
-  LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[$8], full_text=[$9], startTime=[$10], embedding=[vector_embed($9, 'text-embedding-3-small')])
-    LogicalProject(url=[$0], date=[$1], time=[$2], title=[$3], abstract=[$4], location=[$5], speakers=[$6], last_updated=[$7], id=[coalesce(CAST(REGEXP_EXTRACT($0, '(\d*)$')):BIGINT, 0:BIGINT)], full_text=[CONCAT($3, '\n', $4)], startTime=[CONCAT(TRIM(FLAG(BOTH), ' ', REGEXP_EXTRACT($1, '^[^-]*')), ' ', TRIM(FLAG(BOTH), ' ', REGEXP_EXTRACT($2, '\d\d?:\d\d\s(AM|PM)')))])
-      LogicalTableScan(table=[[default_catalog, default_database, _EventStream]])
-SQL: ALTER VIEW `_ProcessedEventStream` AS SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `speakers`, `last_updated`, `id`, `full_text`, `startTime`, `embedding`,  TO_TIMESTAMP(concat(startTime,' PDT'), 'MMMM d, yyyy h:mm a z') AS `startTimestamp` FROM 
-( SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `speakers`, `last_updated`, `id`, `full_text`, `startTime`,   vector_embed(full_text, 'text-embedding-3-small') AS `embedding` FROM 
-(  SELECT *,
-    coalesce(CAST(REGEXP_EXTRACT(url, '(\d*)$') AS BIGINT),0) AS id,
-    concat(title,'\n',abstract) AS full_text,
-    concat(trim(REGEXP_EXTRACT(`date`, '^[^-]*')),' ',trim(REGEXP_EXTRACT(`time`, '\d\d?:\d\d\s(AM|PM)'))) AS startTime
-    FROM _EventStream ) );
+
 === _UserInterestVectors
 ID:     default_catalog.default_database._UserInterestVectors
 Type:   stream
@@ -324,15 +182,6 @@ Schema:
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - embedding: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalUnion(all=[true])
-  LogicalProject(userid=[$0], embedding=[$1], event_time=[$5])
-    LogicalTableScan(table=[[default_catalog, default_database, _LikeVector]])
-  LogicalProject(userid=[$1], embedding=[$4], event_time=[$3])
-    LogicalTableScan(table=[[default_catalog, default_database, _AddInterest]])
-SQL: CREATE VIEW `_UserInterestVectors` AS  SELECT userid, embedding, event_time FROM _LikeVector
-                 UNION ALL
-                 SELECT userid, embedding, event_time FROM _AddInterest;
 
 === _UserInterests
 ID:     default_catalog.default_database._UserInterests
@@ -344,11 +193,6 @@ Timestamp  : -
 Schema:
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - interestVector: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
-Plan:
-LogicalAggregate(group=[{0}], interestVector=[center($1)])
-  LogicalProject(userid=[$0], embedding=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, _UserInterestVectors]])
-SQL: CREATE VIEW `_UserInterests` AS  SELECT userid, center(embedding) as interestVector FROM _UserInterestVectors GROUP BY userid;
 
 === _UserLikes
 ID:     default_catalog.default_database._UserLikes
@@ -366,17 +210,7 @@ Schema:
  - userid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - liked: BOOLEAN NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(_uuid=[$0], eventid=[$1], userid=[$2], liked=[$3], event_time=[$4])
-  LogicalFilter(condition=[=($5, 1)])
-    LogicalProject(_uuid=[$0], eventid=[$1], userid=[$2], liked=[$3], event_time=[$4], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $2, $1 ORDER BY $4 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _Likes]])
-SQL: CREATE VIEW `_UserLikes`
-AS
-SELECT `_uuid`, `eventid`, `userid`, `liked`, `event_time`
-FROM (SELECT `_uuid`, `eventid`, `userid`, `liked`, `event_time`, ROW_NUMBER() OVER (PARTITION BY `userid`, `eventid` ORDER BY `event_time` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_Likes`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_EventStream__schema` (
   `url` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors--package.txt
@@ -9,21 +9,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, iceberg_parquet_table]])
-SQL: CREATE TABLE `iceberg_parquet_table` (
-  `user_id` INTEGER,
-  `name` STRING
-)
-PARTITIONED BY (`user_id`)
-WITH (
-  'connector' = 'iceberg',
-  'catalog-name' = 'local_fs',
-  'catalog-type' = 'hadoop',
-  'warehouse' = 'file:///tmp/iceberg/warehouse',
-  'format-version' = '2',
-  'write.format.default' = 'parquet'
-)
+
 === kafka_avro_table
 ID:     default_catalog.default_database.kafka_avro_table
 Type:   stream
@@ -34,18 +20,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, kafka_avro_table]])
-SQL: CREATE TABLE `kafka_avro_table` (
-  `user_id` INTEGER,
-  `name` STRING
-) WITH (
-  'connector' = 'kafka',
-  'topic' = 'users-avro',
-  'properties.bootstrap.servers' = 'localhost:9092',
-  'properties.group.id' = 'flink-kafka-avro-group',
-  'format' = 'avro'
-)
+
 === kafka_debezium_table
 ID:     default_catalog.default_database.kafka_debezium_table
 Type:   stream
@@ -56,18 +31,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, kafka_debezium_table]])
-SQL: CREATE TABLE `kafka_debezium_table` (
-  `user_id` INTEGER,
-  `name` STRING
-) WITH (
-  'connector' = 'kafka',
-  'topic' = 'users-debezium',
-  'properties.group.id' = 'flink-kafka-avro-group',
-  'properties.bootstrap.servers' = 'localhost:9092',
-  'format' = 'debezium-json'
-)
+
 === kafka_safe_csv_table
 ID:     default_catalog.default_database.kafka_safe_csv_table
 Type:   stream
@@ -78,18 +42,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, kafka_safe_csv_table]])
-SQL: CREATE TABLE `kafka_safe_csv_table` (
-  `user_id` INTEGER,
-  `name` STRING
-) WITH (
-  'connector' = 'kafka-safe',
-  'topic' = 'users-csv-avro',
-  'properties.bootstrap.servers' = 'localhost:9092',
-  'properties.group.id' = 'test',
-  'format' = 'flexible-csv'
-)
+
 === kafka_safe_json_table
 ID:     default_catalog.default_database.kafka_safe_json_table
 Type:   stream
@@ -100,18 +53,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, kafka_safe_json_table]])
-SQL: CREATE TABLE `kafka_safe_json_table` (
-  `user_id` INTEGER,
-  `name` STRING
-) WITH (
-  'connector' = 'kafka-safe',
-  'topic' = 'users-json-avro',
-  'properties.bootstrap.servers' = 'localhost:9092',
-  'properties.group.id' = 'test',
-  'format' = 'flexible-json'
-)
+
 === upsert_kafka_confluent_avro
 ID:     default_catalog.default_database.upsert_kafka_confluent_avro
 Type:   state
@@ -122,22 +64,7 @@ Timestamp  : -
 Schema:
  - user_id: INTEGER NOT NULL
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, upsert_kafka_confluent_avro]])
-SQL: CREATE TABLE `upsert_kafka_confluent_avro` (
-  `user_id` INTEGER NOT NULL,
-  `name` STRING,
-  PRIMARY KEY (`user_id`) NOT ENFORCED
-) WITH (
-  'connector' = 'upsert-kafka',
-  'topic' = 'users-upsert',
-  'properties.group.id' = 'flink-kafka-avro-group',
-  'properties.bootstrap.servers' = 'localhost:9092',
-  'key.format' = 'avro-confluent',
-  'key.avro-confluent.schema-registry.url' = 'http://localhost:8081',
-  'value.format' = 'avro-confluent',
-  'value.avro-confluent.schema-registry.url' = 'http://localhost:8081'
-)
+
 >>>flink-sql-no-functions.sql
 CREATE TABLE `kafka_avro_table` (
   `user_id` INTEGER,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb--package.txt
@@ -11,10 +11,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world1'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications1]])
-SQL: CREATE VIEW `MyTable1` AS  SELECT id, 'hello world1' as hello FROM _MyApplications1;
 
 === MyTable2
 ID:     default_catalog.default_database.MyTable2
@@ -28,10 +24,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world2'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications2]])
-SQL: CREATE VIEW `MyTable2` AS  SELECT id, 'hello world2' as hello FROM _MyApplications2;
 
 === MyTable3
 ID:     default_catalog.default_database.MyTable3
@@ -45,10 +37,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world3'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications2]])
-SQL: CREATE VIEW `MyTable3` AS  SELECT id, 'hello world3' as hello FROM _MyApplications2;
 
 === _Applications
 ID:     default_catalog.default_database._Applications
@@ -67,29 +55,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE TEMPORARY TABLE `_Applications__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl'
-);
-CREATE TABLE `_Applications` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'source.monitor-interval' = '1'
-)
-LIKE `_Applications__schema`
+
 === _MyApplications1
 ID:     default_catalog.default_database._MyApplications1
 Type:   stream
@@ -107,10 +73,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE VIEW `_MyApplications1` AS  SELECT * FROM _Applications;
 
 === _MyApplications2
 ID:     default_catalog.default_database._MyApplications2
@@ -129,11 +91,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[>=($0, 0)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE VIEW `_MyApplications2` AS  SELECT * FROM _Applications WHERE id >= 0;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_Applications__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache--package.txt
@@ -11,10 +11,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world1'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications1]])
-SQL: CREATE VIEW `MyTable1` AS  SELECT id, 'hello world1' as hello FROM _MyApplications1;
 
 === MyTable2
 ID:     default_catalog.default_database.MyTable2
@@ -28,10 +24,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world2'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications2]])
-SQL: CREATE VIEW `MyTable2` AS  SELECT id, 'hello world2' as hello FROM _MyApplications2;
 
 === MyTable3
 ID:     default_catalog.default_database.MyTable3
@@ -45,10 +37,6 @@ Timestamp  : -
 Schema:
  - id: BIGINT NOT NULL
  - hello: CHAR(12) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(id=[$0], hello=['hello world3'])
-  LogicalTableScan(table=[[default_catalog, default_database, _MyApplications2]])
-SQL: CREATE VIEW `MyTable3` AS  SELECT id, 'hello world3' as hello FROM _MyApplications2;
 
 === _Applications
 ID:     default_catalog.default_database._Applications
@@ -67,29 +55,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE TEMPORARY TABLE `_Applications__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl'
-);
-CREATE TABLE `_Applications` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'source.monitor-interval' = '1'
-)
-LIKE `_Applications__schema`
+
 === _MyApplications1
 ID:     default_catalog.default_database._MyApplications1
 Type:   stream
@@ -107,10 +73,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE VIEW `_MyApplications1` AS  SELECT * FROM _Applications;
 
 === _MyApplications2
 ID:     default_catalog.default_database._MyApplications2
@@ -129,11 +91,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[>=($0, 0)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE VIEW `_MyApplications2` AS  SELECT * FROM _Applications WHERE id >= 0;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `_Applications__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct--package.txt
@@ -17,27 +17,7 @@ Schema:
  - unit_price: DOUBLE
  - discount: DOUBLE
  - _ingest_time: TIMESTAMP_LTZ(3) *PROCTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[$7], $f8=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
-      LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[$7])
-        LogicalFilter(condition=[OR(AND(IS NULL($8), IS NULL($9), IS NULL($10), IS NULL($11), IS NULL($12)), <>($1, $8), <>($3, $9), <>($4, $10), <>($5, $11), AND(IS NULL($5), IS NOT NULL($11)), AND(IS NULL($11), IS NOT NULL($5)), <>($6, $12), AND(IS NULL($6), IS NOT NULL($12)), AND(IS NULL($12), IS NOT NULL($6)))])
-          LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[$7], $f8=[LAG($1, 1) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)], $f9=[LAG($3, 1) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)], $f10=[LAG($4, 1) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)], $f11=[LAG($5, 1) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)], $f12=[LAG($6, 1) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)])
-            LogicalFilter(condition=[>=($2, $8)])
-              LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[$7], $f8=[MAX($2) OVER (PARTITION BY $0 ORDER BY $7 NULLS FIRST)])
-                LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE VIEW `DistinctOrders`
-AS
-SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `unit_price`, `discount`, `_ingest_time`
-FROM (SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `unit_price`, `discount`, `_ingest_time`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `time` DESC NULLS LAST) AS `$f8`
-  FROM (SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `unit_price`, `discount`, `_ingest_time`
-    FROM (SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `unit_price`, `discount`, `_ingest_time`, LAG(`customerid`, 1) OVER (PARTITION BY `id` ORDER BY `_ingest_time`) AS `$f8`, LAG(`productid`, 1) OVER (PARTITION BY `id` ORDER BY `_ingest_time`) AS `$f9`, LAG(`quantity`, 1) OVER (PARTITION BY `id` ORDER BY `_ingest_time`) AS `$f10`, LAG(`unit_price`, 1) OVER (PARTITION BY `id` ORDER BY `_ingest_time`) AS `$f11`, LAG(`discount`, 1) OVER (PARTITION BY `id` ORDER BY `_ingest_time`) AS `$f12`
-      FROM (SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `unit_price`, `discount`, `_ingest_time`, MAX(`time`) OVER (PARTITION BY `id` ORDER BY `_ingest_time` RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `$f8`
-        FROM `default_catalog`.`default_database`.`Orders`) AS `t`
-      WHERE `time` >= `$f8`) AS `t1`
-    WHERE `$f8` IS NULL AND `$f9` IS NULL AND `$f10` IS NULL AND `$f11` IS NULL AND `$f12` IS NULL OR `customerid` <> `$f8` OR (`productid` <> `$f9` OR (`quantity` <> `$f10` OR `unit_price` <> `$f11`)) OR (`unit_price` IS NULL AND `$f11` IS NOT NULL OR `$f11` IS NULL AND `unit_price` IS NOT NULL OR (`discount` <> `$f12` OR (`discount` IS NULL AND `$f12` IS NOT NULL OR `$f12` IS NULL AND `discount` IS NOT NULL)))) AS `t3`) AS `t4`
-WHERE `$f8` = 1
+
 === Orders
 ID:     default_catalog.default_database.Orders
 Type:   stream
@@ -56,30 +36,7 @@ Schema:
  - unit_price: DOUBLE
  - discount: DOUBLE
  - _ingest_time: TIMESTAMP_LTZ(3) *PROCTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[PROCTIME()])
-  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TEMPORARY TABLE `Orders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `productid` BIGINT NOT NULL,
-  `quantity` BIGINT NOT NULL,
-  `unit_price` DOUBLE,
-  `discount` DOUBLE
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Orders` (
-  `_ingest_time` AS PROCTIME(),
-  PRIMARY KEY (`id`, `customerid`, `time`) NOT ENFORCED
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/orders.jsonl',
-  'source.monitor-interval' = '10000',
-  'connector' = 'filesystem'
-)
-LIKE `Orders__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Orders__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-functions--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-functions--package.txt
@@ -15,21 +15,6 @@ Schema:
  - name_md5: CHAR(32) CHARACTER SET "UTF-16LE" NOT NULL
  - formatted_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - name_json: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
-Plan:
-LogicalProject(name=[$0], name_upper=[UPPER($0)], name_length=[CHAR_LENGTH($0)], time_now=[NOW()], current_unix_ts=[UNIX_TIMESTAMP()], generated_uuid=[UUID()], name_md5=[MD5($0)], formatted_name=[FORMAT('Hello, %s', $0)], name_json=[TO_JSONB(CONCAT('{"a": "', $0, '"}'))])
-  LogicalValues(tuples=[[{ 'Alice' }, { 'Bob' }, { 'Charlie' }]])
-SQL: CREATE VIEW `FlinkFunctions` AS  SELECT
-  name,
-  UPPER(name) AS name_upper,
-  CHAR_LENGTH(name) AS name_length,
-  NOW() AS time_now,
-  UNIX_TIMESTAMP() AS current_unix_ts,
-  UUID() AS generated_uuid,
-  MD5(name) AS name_md5,
-  FORMAT('Hello, %s', name) AS formatted_name,
-  TO_JSONB(CONCAT('{"a": "',name,'"}')) AS name_json
-FROM (
-    VALUES ('Alice'), ('Bob'), ('Charlie')) AS names(name);
 
 === functions
 ID:     print.functions

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-kafka--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-kafka--package.txt
@@ -19,21 +19,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - max_amount: DOUBLE NOT NULL
  - min_amount: DOUBLE NOT NULL
-Plan:
-LogicalProject(status=[$1], message=[$2], event_time=[$3], id=[$4], customer_id=[$5], loan_type_id=[$6], amount=[$7], duration=[$8], max_amount=[$15], min_amount=[$16])
-  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{3, 6}])
-    LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{0, 3}])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-      LogicalFilter(condition=[=($0, $cor2.loan_application_id)])
-        LogicalSnapshot(period=[$cor2.event_time])
-          LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-    LogicalFilter(condition=[=($0, $cor3.loan_type_id)])
-      LogicalSnapshot(period=[$cor3.event_time])
-        LogicalTableScan(table=[[default_catalog, default_database, _LoanTypes]])
-SQL: CREATE VIEW `ApplicationStatus` AS  SELECT u.status, u.message, u.event_time, a.id, a.customer_id, a.loan_type_id,
-                            a.amount, a.duration, t.max_amount, t.min_amount
-                     FROM _ApplicationUpdates u JOIN _Applications FOR SYSTEM_TIME AS OF u.`event_time` a ON a.id = u.loan_application_id
-                                               JOIN _LoanTypes FOR SYSTEM_TIME AS OF u.`event_time` t ON t.id = a.loan_type_id;
 
 === _ApplicationUpdates
 ID:     default_catalog.default_database._ApplicationUpdates
@@ -49,26 +34,7 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[$3])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationUpdates__schema` (
-  `loan_application_id` BIGINT NOT NULL,
-  `status` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `message` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationUpdates` (
-  PRIMARY KEY (`loan_application_id`, `event_time`) NOT ENFORCED,
-  WATERMARK FOR `event_time` AS `event_time`
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/application_updates.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationUpdates__schema`
+
 === _Applications
 ID:     default_catalog.default_database._Applications
 Type:   state
@@ -87,17 +53,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[=($7, 1)])
-    LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $6 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE VIEW `_Applications`
-AS
-SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`
-FROM (SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ApplicationsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _ApplicationsStream
 ID:     default_catalog.default_database._ApplicationsStream
 Type:   stream
@@ -115,30 +71,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE TEMPORARY TABLE `_ApplicationsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ApplicationsStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_ApplicationsStream__schema`
+
 === _FakeStreamJoin
 ID:     default_catalog.default_database._FakeStreamJoin
 Type:   stream
@@ -151,13 +84,6 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$4], status=[$1], message=[$2], event_time=[$3])
-  LogicalJoin(condition=[=($6, $0)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, _ApplicationUpdates]])
-    LogicalTableScan(table=[[default_catalog, default_database, _ApplicationsStream]])
-SQL: CREATE VIEW `_FakeStreamJoin` AS  SELECT a.id, u.status, u.message, u.event_time
-                     FROM _ApplicationUpdates u JOIN _ApplicationsStream a ON a.loan_type_id = u.loan_application_id;
 
 === _LoanTypes
 ID:     default_catalog.default_database._LoanTypes
@@ -179,17 +105,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8])
-  LogicalFilter(condition=[=($9, 1)])
-    LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $8 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE VIEW `_LoanTypes`
-AS
-SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`
-FROM (SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_LoanTypesStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _LoanTypesStream
 ID:     default_catalog.default_database._LoanTypesStream
 Type:   stream
@@ -209,32 +125,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($8, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _LoanTypesStream]])
-SQL: CREATE TEMPORARY TABLE `_LoanTypesStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `description` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `interest_rate` DOUBLE NOT NULL,
-  `max_amount` DOUBLE NOT NULL,
-  `min_amount` DOUBLE NOT NULL,
-  `max_duration` BIGINT NOT NULL,
-  `min_duration` BIGINT NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_LoanTypesStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/loan_types.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_LoanTypesStream__schema`
+
 === StreamJoin
 ID:     logger.StreamJoin
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/hierarchy--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/hierarchy--package.txt
@@ -13,17 +13,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(employeeid=[$0], name=[$1], email=[$2], updatedDate=[$3])
-  LogicalFilter(condition=[=($4, 1)])
-    LogicalProject(employeeid=[$0], name=[$1], email=[$2], updatedDate=[$3], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, hr, Employees]])
-SQL: CREATE VIEW `Employees`
-AS
-SELECT `employeeid`, `name`, `email`, `updatedDate`
-FROM (SELECT `employeeid`, `name`, `email`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`hr`.`Employees`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === Reporting
 ID:     default_catalog.default_database.Reporting
 Type:   state
@@ -37,17 +27,7 @@ Schema:
  - employeeid: BIGINT NOT NULL
  - managerid: BIGINT NOT NULL
  - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(employeeid=[$0], managerid=[$1], updatedDate=[$2])
-  LogicalFilter(condition=[=($3, 1)])
-    LogicalProject(employeeid=[$0], managerid=[$1], updatedDate=[$2], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $1 ORDER BY $2 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, hr, Reporting]])
-SQL: CREATE VIEW `Reporting`
-AS
-SELECT `employeeid`, `managerid`, `updatedDate`
-FROM (SELECT `employeeid`, `managerid`, `updatedDate`, ROW_NUMBER() OVER (PARTITION BY `employeeid`, `managerid` ORDER BY `updatedDate` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`hr`.`Reporting`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === Employees
 ID:     default_catalog.hr.Employees
 Type:   stream
@@ -60,25 +40,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updatedDate], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, hr, Employees]])
-SQL: CREATE TEMPORARY TABLE `Employees__schema` (
-  `employeeid` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/employees.jsonl'
-);
-CREATE TABLE `Employees` (
-  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
-) WITH (
-  'source.monitor-interval' = '10 sec'
-)
-LIKE `Employees__schema`
+
 === Reporting
 ID:     default_catalog.hr.Reporting
 Type:   stream
@@ -90,24 +52,7 @@ Schema:
  - employeeid: BIGINT NOT NULL
  - managerid: BIGINT NOT NULL
  - updatedDate: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updatedDate], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, hr, Reporting]])
-SQL: CREATE TEMPORARY TABLE `Reporting__schema` (
-  `employeeid` BIGINT NOT NULL,
-  `managerid` BIGINT NOT NULL,
-  `updatedDate` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/reporting.jsonl'
-);
-CREATE TABLE `Reporting` (
-  WATERMARK FOR `updatedDate` AS `updatedDate` - INTERVAL '0.001' SECOND
-) WITH (
-  'source.monitor-interval' = '10 sec'
-)
-LIKE `Reporting__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE DATABASE IF NOT EXISTS `hr`;
 USE `hr`;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/iceberg-export--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/iceberg-export--package.txt
@@ -16,30 +16,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _Applications]])
-SQL: CREATE TEMPORARY TABLE `_Applications__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_Applications` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `_Applications__schema`
+
 === iceberg-sink
 ID:     iceberg.iceberg-sink
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized--package.txt
@@ -13,25 +13,7 @@ Schema:
  - val: BIGINT NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($3, 0:INTERVAL SECOND)])
-  LogicalProject(event_id=[$0], val=[$1], message=[$2], event_time=[CAST($3):TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL])
-    LogicalTableScan(table=[[default_catalog, default_database, AuthInputData, metadata=[timestamp]]])
-SQL: CREATE TABLE `AuthInputData` (
-  `event_id` STRING NOT NULL,
-  `val` BIGINT NOT NULL,
-  `message` STRING NOT NULL,
-  `event_time` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'AuthInputData'
-)
+
 === AuthMyTable
 ID:     default_catalog.default_database.AuthMyTable
 Type:   query
@@ -40,16 +22,6 @@ Inputs: default_catalog.default_database.MyTable
 Annotations:
  - parameters: val
  - base-table: MyTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[=($0, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-SQL: CREATE VIEW `AuthMyTable` AS 
-    SELECT t.* 
-      FROM MyTable t 
-     WHERE t.val = ?   
-     ORDER BY t.val ASC;
 
 === AuthMyTableValues
 ID:     default_catalog.default_database.AuthMyTableValues
@@ -59,16 +31,6 @@ Inputs: default_catalog.default_database.MyTable
 Annotations:
  - parameters: vals
  - base-table: MyTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[array_contains(CAST(?0):BIGINT ARRAY, CAST($0):BIGINT)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-SQL: CREATE VIEW `AuthMyTableValues` AS 
-    SELECT t.* 
-      FROM MyTable t 
-     WHERE array_contains(cast(?     as ARRAY<BIGINT>), t.val)
-     ORDER BY t.val ASC;
 
 === AuthStringMyTableValues
 ID:     default_catalog.default_database.AuthStringMyTableValues
@@ -78,16 +40,6 @@ Inputs: default_catalog.default_database.MyStringTable
 Annotations:
  - parameters: vals
  - base-table: MyStringTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[array_contains(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY, CAST($0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyStringTable]])
-SQL: CREATE VIEW `AuthStringMyTableValues` AS 
-    SELECT t.*
-      FROM MyStringTable t
-     WHERE array_contains(CAST(?     AS ARRAY<STRING>), CAST(t.val AS STRING))
-     ORDER BY t.val ASC;
 
 === MessageSubscription
 ID:     default_catalog.default_database.MessageSubscription
@@ -98,11 +50,6 @@ Annotations:
  - stream-root: AuthInputData
  - parameters: val
  - base-table: AuthInputData
-Plan:
-LogicalProject(event_id=[$0], val=[$1], message=[$2], event_time=[$3])
-  LogicalFilter(condition=[=($1, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, _Messages]])
-SQL: CREATE VIEW `MessageSubscription` AS  SELECT * FROM _Messages WHERE val = ?   ;
 
 === MyStringTable
 ID:     default_catalog.default_database.MyStringTable
@@ -114,10 +61,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 'a' }, { 'b' }, { 'c' }, { 'd' }]])
-SQL: CREATE VIEW `MyStringTable` AS  SELECT val FROM (VALUES 'a', 'b', 'c', 'd') AS t(val) ORDER BY val;
 
 === MyTable
 ID:     default_catalog.default_database.MyTable
@@ -129,12 +72,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }]])
-SQL: CREATE VIEW `MyTable` AS  SELECT val
-           FROM (VALUES ((1)), ((2)), ((3)), ((4)), ((5)),
-            ((6)), ((7)), ((8)), ((9)), ((10))) AS t(val) ORDER BY val;
 
 === _Messages
 ID:     default_catalog.default_database._Messages
@@ -150,11 +87,6 @@ Schema:
  - val: BIGINT NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(event_id=[$0], val=[$1], message=[$2], event_time=[$3])
-  LogicalFilter(condition=[<>($2, '')])
-    LogicalTableScan(table=[[default_catalog, default_database, AuthInputData]])
-SQL: CREATE VIEW `_Messages` AS  SELECT * FROM AuthInputData WHERE message <> '';
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MyTable`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-base--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-base--package.txt
@@ -7,16 +7,6 @@ Inputs: default_catalog.default_database.MyTable
 Annotations:
  - parameters: val
  - base-table: MyTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[=($0, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-SQL: CREATE VIEW `AuthMyTable` AS 
-    SELECT t.* 
-      FROM MyTable t 
-     WHERE t.val = ?   
-     ORDER BY t.val ASC;
 
 === AuthMyTableValues
 ID:     default_catalog.default_database.AuthMyTableValues
@@ -26,16 +16,6 @@ Inputs: default_catalog.default_database.MyTable
 Annotations:
  - parameters: vals
  - base-table: MyTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[array_contains(CAST(?0):BIGINT ARRAY, CAST($0):BIGINT)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-SQL: CREATE VIEW `AuthMyTableValues` AS 
-    SELECT t.* 
-      FROM MyTable t 
-     WHERE array_contains(cast(?     as ARRAY<BIGINT>), t.val)
-     ORDER BY t.val ASC;
 
 === AuthStringMyTableValues
 ID:     default_catalog.default_database.AuthStringMyTableValues
@@ -45,16 +25,6 @@ Inputs: default_catalog.default_database.MyStringTable
 Annotations:
  - parameters: vals
  - base-table: MyStringTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[array_contains(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY, CAST($0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyStringTable]])
-SQL: CREATE VIEW `AuthStringMyTableValues` AS 
-    SELECT t.*
-      FROM MyStringTable t
-     WHERE array_contains(CAST(?     AS ARRAY<STRING>), CAST(t.val AS STRING))
-     ORDER BY t.val ASC;
 
 === MyStringTable
 ID:     default_catalog.default_database.MyStringTable
@@ -66,10 +36,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 'a' }, { 'b' }, { 'c' }, { 'd' }]])
-SQL: CREATE VIEW `MyStringTable` AS  SELECT val FROM (VALUES 'a', 'b', 'c', 'd') AS t(val) ORDER BY val;
 
 === MyTable
 ID:     default_catalog.default_database.MyTable
@@ -81,12 +47,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }]])
-SQL: CREATE VIEW `MyTable` AS  SELECT val
-           FROM (VALUES ((1)), ((2)), ((3)), ((4)), ((5)),
-            ((6)), ((7)), ((8)), ((9)), ((10))) AS t(val) ORDER BY val;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MyTable`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized--package.txt
@@ -7,16 +7,6 @@ Inputs: default_catalog.default_database.MyTable
 Annotations:
  - parameters: val
  - base-table: MyTable
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(val=[$0])
-    LogicalFilter(condition=[=($0, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-SQL: CREATE VIEW `AuthMyTable` AS 
-    SELECT t.* 
-      FROM MyTable t 
-     WHERE t.val = ?   
-     ORDER BY t.val ASC;
 
 === MyTable
 ID:     default_catalog.default_database.MyTable
@@ -28,12 +18,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }]])
-SQL: CREATE VIEW `MyTable` AS  SELECT val
-           FROM (VALUES ((1)), ((2)), ((3)), ((4)), ((5)),
-            ((6)), ((7)), ((8)), ((9)), ((10))) AS t(val) ORDER BY val;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MyTable`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions--package.txt
@@ -8,13 +8,6 @@ Timestamp  : -
 Schema:
  - id: INTEGER NOT NULL
  - fct_result: BOOLEAN
-Plan:
-LogicalProject(id=[$0], fct_result=[TestFunction($0)])
-  LogicalValues(tuples=[[{ 1 }, { 2 }]])
-SQL: CREATE VIEW `FunctionApplied` AS  SELECT id, TestFunction(id) AS fct_result FROM (VALUES
-    (1),
-    (2)
-) AS data_table(id);
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `FunctionApplied`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan-loan-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/loan-loan-package.txt
@@ -16,27 +16,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - context: RecordType:peek_no_expand(INTEGER customerid) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($5, 0:INTERVAL SECOND)])
-  LogicalProject(_uuid=[$0], role=[$1], content=[$2], name=[$3], context=[$4], event_time=[CAST($5):TIMESTAMP_LTZ(3) *ROWTIME*])
-    LogicalTableScan(table=[[default_catalog, default_database, AddChatMessage, metadata=[timestamp]]])
-SQL: CREATE TABLE `AddChatMessage` (
-  `_uuid` STRING NOT NULL,
-  `role` STRING NOT NULL,
-  `content` STRING NOT NULL,
-  `name` STRING,
-  `context` ROW(`customerid` INTEGER) NOT NULL,
-  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'ChatMessage'
-)
+
 === ApplicationAlert
 ID:     default_catalog.default_database.ApplicationAlert
 Type:   stream
@@ -54,13 +34,6 @@ Schema:
  - max_amount: DOUBLE NOT NULL
  - min_amount: DOUBLE NOT NULL
  - amount: DOUBLE NOT NULL
-Plan:
-LogicalProject(_uuid=[$0], id=[$4], customer_id=[$5], loan_type_id=[$6], max_amount=[$9], min_amount=[$10], amount=[$7])
-  LogicalFilter(condition=[AND(=($1, 'underwriting'), OR(>($7, $9), <($7, $10)))])
-    LogicalTableScan(table=[[default_catalog, default_database, ApplicationStatus]])
-SQL: CREATE VIEW `ApplicationAlert` AS  SELECT _uuid, id, customer_id, loan_type_id, max_amount, min_amount, amount
-                    FROM ApplicationStatus a
-                    WHERE status = 'underwriting' AND (amount > max_amount OR amount < min_amount);
 
 === ApplicationStatus
 ID:     default_catalog.default_database.ApplicationStatus
@@ -83,21 +56,6 @@ Schema:
  - duration: BIGINT NOT NULL
  - max_amount: DOUBLE NOT NULL
  - min_amount: DOUBLE NOT NULL
-Plan:
-LogicalProject(_uuid=[$0], status=[$2], message=[$3], event_time=[$4], id=[$5], customer_id=[$6], loan_type_id=[$7], amount=[$8], duration=[$9], max_amount=[$16], min_amount=[$17])
-  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{4, 7}])
-    LogicalCorrelate(correlation=[$cor2], joinType=[inner], requiredColumns=[{1, 4}])
-      LogicalTableScan(table=[[default_catalog, default_database, ApplicationUpdates]])
-      LogicalFilter(condition=[=($0, $cor2.loan_application_id)])
-        LogicalSnapshot(period=[$cor2.event_time])
-          LogicalTableScan(table=[[default_catalog, default_database, Applications]])
-    LogicalFilter(condition=[=($0, $cor3.loan_type_id)])
-      LogicalSnapshot(period=[$cor3.event_time])
-        LogicalTableScan(table=[[default_catalog, default_database, LoanTypes]])
-SQL: CREATE VIEW `ApplicationStatus` AS  SELECT u._uuid, u.status, u.message, u.event_time, a.id, a.customer_id, a.loan_type_id,
-                            a.amount, a.duration, t.max_amount, t.min_amount
-                     FROM ApplicationUpdates u JOIN Applications FOR SYSTEM_TIME AS OF u.`event_time` a ON a.id = u.loan_application_id
-                            JOIN LoanTypes FOR SYSTEM_TIME AS OF u.`event_time` t ON t.id = a.loan_type_id;
 
 === ApplicationUpdates
 ID:     default_catalog.default_database.ApplicationUpdates
@@ -114,27 +72,7 @@ Schema:
  - status: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($4, 0:INTERVAL SECOND)])
-  LogicalProject(_uuid=[$0], loan_application_id=[$1], status=[$2], message=[$3], event_time=[CAST($4):TIMESTAMP_LTZ(3) *ROWTIME*])
-    LogicalTableScan(table=[[default_catalog, default_database, ApplicationUpdates, metadata=[timestamp]]])
-SQL: CREATE TABLE `ApplicationUpdates` (
-  `_uuid` STRING NOT NULL,
-  `loan_application_id` BIGINT NOT NULL,
-  `status` STRING NOT NULL,
-  `message` STRING,
-  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'properties.isolation.level' = 'read_committed',
-  'topic' = 'ApplicationUpdates'
-)
+
 === Applications
 ID:     default_catalog.default_database.Applications
 Type:   state
@@ -153,17 +91,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6])
-  LogicalFilter(condition=[=($7, 1)])
-    LogicalProject(id=[$0], customer_id=[$1], loan_type_id=[$2], amount=[$3], duration=[$4], application_date=[$5], updated_at=[$6], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $6 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, ApplicationsStream]])
-SQL: CREATE VIEW `Applications`
-AS
-SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`
-FROM (SELECT `id`, `customer_id`, `loan_type_id`, `amount`, `duration`, `application_date`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`ApplicationsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === ApplicationsStream
 ID:     default_catalog.default_database.ApplicationsStream
 Type:   stream
@@ -181,30 +109,7 @@ Schema:
  - duration: BIGINT NOT NULL
  - application_date: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($6, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, ApplicationsStream]])
-SQL: CREATE TEMPORARY TABLE `ApplicationsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `customer_id` BIGINT NOT NULL,
-  `loan_type_id` BIGINT NOT NULL,
-  `amount` DOUBLE NOT NULL,
-  `duration` BIGINT NOT NULL,
-  `application_date` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `ApplicationsStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/applications.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `ApplicationsStream__schema`
+
 === CustomerChatMessage
 ID:     default_catalog.default_database.CustomerChatMessage
 Type:   stream
@@ -222,12 +127,6 @@ Schema:
  - customerid: INTEGER
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME*
  - uuid: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(role=[$1], content=[$2], name=[$3], customerid=[$4.customerid], timestamp=[$5], uuid=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, AddChatMessage]])
-SQL: CREATE VIEW `CustomerChatMessage` AS  SELECT role, content, name, c.context.customerid, event_time AS `timestamp`,
-                        _uuid AS uuid
-                       FROM AddChatMessage c ORDER BY `timestamp` DESC;
 
 === Customers
 ID:     default_catalog.default_database.Customers
@@ -248,17 +147,7 @@ Schema:
  - address: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - date_of_birth: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], phone=[$4], address=[$5], date_of_birth=[$6], updated_at=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], phone=[$4], address=[$5], date_of_birth=[$6], updated_at=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, CustomersStream]])
-SQL: CREATE VIEW `Customers`
-AS
-SELECT `id`, `first_name`, `last_name`, `email`, `phone`, `address`, `date_of_birth`, `updated_at`
-FROM (SELECT `id`, `first_name`, `last_name`, `email`, `phone`, `address`, `date_of_birth`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`CustomersStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomersStream
 ID:     default_catalog.default_database.CustomersStream
 Type:   stream
@@ -277,31 +166,7 @@ Schema:
  - address: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - date_of_birth: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, CustomersStream]])
-SQL: CREATE TEMPORARY TABLE `CustomersStream__schema` (
-  `id` BIGINT NOT NULL,
-  `first_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `last_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `phone` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `address` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `date_of_birth` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `CustomersStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/customers.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `CustomersStream__schema`
+
 === LoanTypes
 ID:     default_catalog.default_database.LoanTypes
 Type:   state
@@ -322,17 +187,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8])
-  LogicalFilter(condition=[=($9, 1)])
-    LogicalProject(id=[$0], name=[$1], description=[$2], interest_rate=[$3], max_amount=[$4], min_amount=[$5], max_duration=[$6], min_duration=[$7], updated_at=[$8], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $8 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, LoanTypesStream]])
-SQL: CREATE VIEW `LoanTypes`
-AS
-SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`
-FROM (SELECT `id`, `name`, `description`, `interest_rate`, `max_amount`, `min_amount`, `max_duration`, `min_duration`, `updated_at`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`LoanTypesStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === LoanTypesStream
 ID:     default_catalog.default_database.LoanTypesStream
 Type:   stream
@@ -352,32 +207,7 @@ Schema:
  - max_duration: BIGINT NOT NULL
  - min_duration: BIGINT NOT NULL
  - updated_at: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated_at], watermark=[-($8, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, LoanTypesStream]])
-SQL: CREATE TEMPORARY TABLE `LoanTypesStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `description` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `interest_rate` DOUBLE NOT NULL,
-  `max_amount` DOUBLE NOT NULL,
-  `min_amount` DOUBLE NOT NULL,
-  `max_duration` BIGINT NOT NULL,
-  `min_duration` BIGINT NOT NULL,
-  `updated_at` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `LoanTypesStream` (
-  PRIMARY KEY (`id`, `updated_at`) NOT ENFORCED,
-  WATERMARK FOR `updated_at` AS `updated_at` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/loan_types.jsonl',
-  'source.monitor-interval' = '10 sec',
-  'connector' = 'filesystem'
-)
-LIKE `LoanTypesStream__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `CustomersStream__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-default--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-default--package.txt
@@ -13,28 +13,7 @@ Schema:
  - EPOCH_TIMESTAMP: BIGINT NOT NULL
  - SOME_VALUE: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - TIMESTAMP: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[TIMESTAMP], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(ID=[$0], EPOCH_TIMESTAMP=[$1], SOME_VALUE=[$2], TIMESTAMP=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Data]])
-SQL: CREATE TABLE `Data` (
-  `ID` BIGINT NOT NULL,
-  `EPOCH_TIMESTAMP` BIGINT NOT NULL,
-  `SOME_VALUE` STRING NOT NULL,
-  `TIMESTAMP` AS COALESCE(`TO_TIMESTAMP_LTZ`(`EPOCH_TIMESTAMP`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`ID`) NOT ENFORCED,
-  WATERMARK FOR `TIMESTAMP` AS `TIMESTAMP` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '10',
-  'fields.ID.kind' = 'sequence',
-  'fields.ID.start' = '0',
-  'fields.ID.end' = '9',
-  'fields.EPOCH_TIMESTAMP.kind' = 'sequence',
-  'fields.EPOCH_TIMESTAMP.start' = '1719318565000',
-  'fields.EPOCH_TIMESTAMP.end' = '1719319565000',
-  'fields.SOME_VALUE.kind' = 'random'
-)
+
 === LogData
 ID:     logger.LogData
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-kafka--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-kafka--package.txt
@@ -13,28 +13,7 @@ Schema:
  - EPOCH_TIMESTAMP: BIGINT NOT NULL
  - SOME_VALUE: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - TIMESTAMP: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[TIMESTAMP], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(ID=[$0], EPOCH_TIMESTAMP=[$1], SOME_VALUE=[$2], TIMESTAMP=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Data]])
-SQL: CREATE TABLE `Data` (
-  `ID` BIGINT NOT NULL,
-  `EPOCH_TIMESTAMP` BIGINT NOT NULL,
-  `SOME_VALUE` STRING NOT NULL,
-  `TIMESTAMP` AS COALESCE(`TO_TIMESTAMP_LTZ`(`EPOCH_TIMESTAMP`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`ID`) NOT ENFORCED,
-  WATERMARK FOR `TIMESTAMP` AS `TIMESTAMP` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '10',
-  'fields.ID.kind' = 'sequence',
-  'fields.ID.start' = '0',
-  'fields.ID.end' = '9',
-  'fields.EPOCH_TIMESTAMP.kind' = 'sequence',
-  'fields.EPOCH_TIMESTAMP.start' = '1719318565000',
-  'fields.EPOCH_TIMESTAMP.end' = '1719319565000',
-  'fields.SOME_VALUE.kind' = 'random'
-)
+
 === LogData
 ID:     logger.LogData
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-none--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-none--package.txt
@@ -13,28 +13,7 @@ Schema:
  - EPOCH_TIMESTAMP: BIGINT NOT NULL
  - SOME_VALUE: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - TIMESTAMP: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[TIMESTAMP], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(ID=[$0], EPOCH_TIMESTAMP=[$1], SOME_VALUE=[$2], TIMESTAMP=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Data]])
-SQL: CREATE TABLE `Data` (
-  `ID` BIGINT NOT NULL,
-  `EPOCH_TIMESTAMP` BIGINT NOT NULL,
-  `SOME_VALUE` STRING NOT NULL,
-  `TIMESTAMP` AS COALESCE(`TO_TIMESTAMP_LTZ`(`EPOCH_TIMESTAMP`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`ID`) NOT ENFORCED,
-  WATERMARK FOR `TIMESTAMP` AS `TIMESTAMP` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '10',
-  'fields.ID.kind' = 'sequence',
-  'fields.ID.start' = '0',
-  'fields.ID.end' = '9',
-  'fields.EPOCH_TIMESTAMP.kind' = 'sequence',
-  'fields.EPOCH_TIMESTAMP.start' = '1719318565000',
-  'fields.EPOCH_TIMESTAMP.end' = '1719319565000',
-  'fields.SOME_VALUE.kind' = 'random'
-)
+
 === DummyLogData
 ID:     print.DummyLogData
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-print--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/logging-print--package.txt
@@ -13,28 +13,7 @@ Schema:
  - EPOCH_TIMESTAMP: BIGINT NOT NULL
  - SOME_VALUE: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - TIMESTAMP: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[TIMESTAMP], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(ID=[$0], EPOCH_TIMESTAMP=[$1], SOME_VALUE=[$2], TIMESTAMP=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Data]])
-SQL: CREATE TABLE `Data` (
-  `ID` BIGINT NOT NULL,
-  `EPOCH_TIMESTAMP` BIGINT NOT NULL,
-  `SOME_VALUE` STRING NOT NULL,
-  `TIMESTAMP` AS COALESCE(`TO_TIMESTAMP_LTZ`(`EPOCH_TIMESTAMP`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`ID`) NOT ENFORCED,
-  WATERMARK FOR `TIMESTAMP` AS `TIMESTAMP` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '10',
-  'fields.ID.kind' = 'sequence',
-  'fields.ID.start' = '0',
-  'fields.ID.end' = '9',
-  'fields.EPOCH_TIMESTAMP.kind' = 'sequence',
-  'fields.EPOCH_TIMESTAMP.start' = '1719318565000',
-  'fields.EPOCH_TIMESTAMP.end' = '1719319565000',
-  'fields.SOME_VALUE.kind' = 'random'
-)
+
 === LogData
 ID:     logger.LogData
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/metrics-metrics-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/metrics-metrics-package.txt
@@ -13,11 +13,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: FLOAT NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalProject(uuid=[$0], sensorid=[$1], temperature=[$2], event_time=[$3])
-  LogicalFilter(condition=[>($2, 50)])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `HighTempAlert` AS  SELECT * FROM SensorReading WHERE temperature > 50;
 
 === SensorAnalysis
 ID:     default_catalog.default_database.SensorAnalysis
@@ -33,13 +28,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - avg_temperatures: FLOAT NOT NULL
  - max_temperature: FLOAT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], avg_temperatures=[AVG($1)], max_temperature=[MAX($1)])
-  LogicalProject(sensorid=[$1], temperature=[$2])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorAnalysis` AS  SELECT sensorid, AVG(temperature) AS avg_temperatures,
-                           MAX(temperature) AS max_temperature
-                    FROM SensorReading GROUP BY sensorid ORDER BY sensorid DESC;
 
 === SensorAnalysisById
 ID:     default_catalog.default_database.SensorAnalysisById
@@ -50,11 +38,6 @@ Annotations:
  - stream-root: SensorReading
  - parameters: sensorid
  - base-table: SensorAnalysis
-Plan:
-LogicalProject(sensorid=[$0], avg_temperatures=[$1], max_temperature=[$2])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorAnalysis]])
-SQL: CREATE VIEW `SensorAnalysisById` AS  SELECT * FROM SensorAnalysis WHERE sensorid = ?        ;
 
 === SensorMaxTempLastMin
 ID:     default_catalog.default_database.SensorMaxTempLastMin
@@ -70,17 +53,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - endOfMin: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - avg_temperature: FLOAT NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], endOfMin=[$1], avg_temperature=[$2])
-  LogicalFilter(condition=[=($3, 1)])
-    LogicalProject(sensorid=[$0], endOfMin=[$1], avg_temperature=[$2], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _SensorMaxTempLastMinWindow]])
-SQL: CREATE VIEW `SensorMaxTempLastMin`
-AS
-SELECT `sensorid`, `endOfMin`, `avg_temperature`
-FROM (SELECT `sensorid`, `endOfMin`, `avg_temperature`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `endOfMin` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_SensorMaxTempLastMinWindow`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
 Type:   stream
@@ -95,25 +68,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: FLOAT NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($3, 0:INTERVAL SECOND)])
-  LogicalProject(uuid=[$0], sensorid=[$1], temperature=[$2], event_time=[CAST($3):TIMESTAMP_LTZ(3) *ROWTIME*])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading, metadata=[timestamp]]])
-SQL: CREATE TABLE `SensorReading` (
-  `uuid` STRING NOT NULL,
-  `sensorid` INTEGER NOT NULL,
-  `temperature` FLOAT NOT NULL,
-  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorReading'
-)
+
 === SensorReadingById
 ID:     default_catalog.default_database.SensorReadingById
 Type:   query
@@ -123,13 +78,6 @@ Annotations:
  - stream-root: SensorReading
  - parameters: sensorid
  - base-table: SensorReading
-Plan:
-LogicalSort(sort0=[$3], dir0=[DESC-nulls-last])
-  LogicalProject(uuid=[$0], sensorid=[$1], temperature=[$2], event_time=[$3])
-    LogicalFilter(condition=[=($1, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorReadingById` AS  SELECT * FROM SensorReading
-                                              WHERE sensorid = ?         ORDER BY event_time DESC;
 
 === _SensorMaxTempLastMinWindow
 ID:     default_catalog.default_database._SensorMaxTempLastMinWindow
@@ -145,17 +93,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - endOfMin: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - avg_temperature: FLOAT NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], endOfMin=[$3], avg_temperature=[$4])
-  LogicalAggregate(group=[{0, 1, 2, 3}], avg_temperature=[AVG($4)])
-    LogicalProject(sensorid=[$1], window_start=[$4], window_end=[$5], endOfMin=[$6], temperature=[$2])
-      LogicalTableFunctionScan(invocation=[HOP(TABLE(#0), DESCRIPTOR('event_time'), 10000:INTERVAL SECOND, 60000:INTERVAL MINUTE)], rowType=[RecordType(VARCHAR(2147483647) uuid, INTEGER sensorid, FLOAT temperature, TIMESTAMP_LTZ(3) *ROWTIME* event_time, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(uuid=[$0], sensorid=[$1], temperature=[$2], event_time=[$3])
-          LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `_SensorMaxTempLastMinWindow` AS  SELECT sensorid, window_time as endOfMin,
-                                      AVG(temperature) AS avg_temperature
-                     FROM TABLE(HOP(TABLE SensorReading, DESCRIPTOR(event_time), INTERVAL '10' SECONDS, INTERVAL '1' MINUTES))
-                     GROUP BY sensorid, window_start, window_end, window_time;
 
 >>>flink-sql-no-functions.sql
 CREATE TABLE `SensorReading` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/minimal-flink--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/minimal-flink--package.txt
@@ -12,13 +12,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - maxTemp: FLOAT NOT NULL
  - avgTemp: FLOAT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], maxTemp=[MAX($1)], avgTemp=[AVG($1)])
-  LogicalProject(sensorid=[$0], temperature=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorAggregate` AS  SELECT sensorid, MAX(temperature) AS maxTemp, AVG(temperature) AS avgTemp
-                   FROM SensorReading
-                   GROUP BY sensorid ORDER BY sensorid ASC;
 
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
@@ -33,27 +26,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: FLOAT NOT NULL
  - event_time: BIGINT NOT NULL
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE TABLE `SensorReading` (
-  `sensorid` INTEGER NOT NULL,
-  `temperature` FLOAT NOT NULL,
-  `event_time` BIGINT NOT NULL,
-  PRIMARY KEY (`sensorid`, `event_time`) NOT ENFORCED
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '10',
-  'rows-per-second' = '10',
-  'fields.sensorid.kind' = 'random',
-  'fields.sensorid.min' = '1',
-  'fields.sensorid.max' = '1',
-  'fields.temperature.kind' = 'sequence',
-  'fields.temperature.start' = '20',
-  'fields.temperature.end' = '29',
-  'fields.event_time.kind' = 'sequence',
-  'fields.event_time.start' = '1750533400',
-  'fields.event_time.end' = '1750533429'
-)
+
 === SensorReadingById
 ID:     default_catalog.default_database.SensorReadingById
 Type:   query
@@ -63,13 +36,6 @@ Annotations:
  - stream-root: SensorReading
  - parameters: sensorid
  - base-table: SensorReading
-Plan:
-LogicalSort(sort0=[$2], dir0=[DESC-nulls-last])
-  LogicalProject(sensorid=[$0], temperature=[$1], event_time=[$2])
-    LogicalFilter(condition=[=($0, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorReadingById` AS  SELECT * FROM SensorReading
-                    WHERE sensorid = ?         ORDER BY event_time DESC;
 
 >>>flink-sql-no-functions.sql
 CREATE TABLE `SensorReading` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch--package.txt
@@ -8,18 +8,7 @@ Primary Key: -
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalTableScan(table=[[default_catalog, default_database, Src]])
-SQL: CREATE TABLE `Src` (
-  `val` INTEGER NOT NULL
-) WITH (
-  'connector' = 'datagen',
-  'number-of-rows' = '5',
-  'rows-per-second' = '5',
-  'fields.val.kind' = 'random',
-  'fields.val.min' = '1',
-  'fields.val.max' = '5'
-)
+
 === sink_a
 ID:     tables.sink_a
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/myudf--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/myudf--package.txt
@@ -10,11 +10,6 @@ Timestamp  : -
 Schema:
  - val: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL
  - myFnc: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalProject(val=[$0], myFnc=[MyAsyncScalarFunction($0, $1)])
-  LogicalValues(tuples=[[{ '1', 1 }, { '2', 2 }, { '3', 3 }]])
-SQL: CREATE VIEW `MyAsyncTable` AS  SELECT val, MyAsyncScalarFunction(val, ival) AS myFnc
-           FROM (VALUES (('1'), (1)), (('2'), (2)), (('3'), (3))) AS t(val, ival) ORDER BY val;
 
 === MyTable
 ID:     default_catalog.default_database.MyTable
@@ -27,12 +22,6 @@ Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
  - myFnc: BIGINT
-Plan:
-LogicalProject(val=[$0], myFnc=[MyScalarFunction(CAST($0):BIGINT, CAST($0):BIGINT)])
-  LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }]])
-SQL: CREATE VIEW `MyTable` AS  SELECT val, MyScalarFunction(val, val) AS myFnc
-           FROM (VALUES ((1)), ((2)), ((3)), ((4)), ((5)),
-            ((6)), ((7)), ((8)), ((9)), ((10))) AS t(val) ORDER BY val;
 
 === MyTableAnother
 ID:     default_catalog.default_database.MyTableAnother
@@ -45,11 +34,6 @@ Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
  - myFnc: BIGINT
-Plan:
-LogicalProject(val=[$0], myFnc=[AnotherFunction(CAST($0):BIGINT, CAST($0):BIGINT)])
-  LogicalValues(tuples=[[{ 1 }, { 2 }]])
-SQL: CREATE VIEW `MyTableAnother` AS  SELECT val, AnotherFunction(val, val) AS myFnc
-           FROM (VALUES ((1)), ((2))) AS t(val) ORDER BY val;
 
 === MyTableDifferentCase
 ID:     default_catalog.default_database.MyTableDifferentCase
@@ -62,10 +46,6 @@ Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
  - fn: BIGINT
-Plan:
-LogicalProject(val=[$0], fn=[anotherFunction(CAST($0):BIGINT, CAST($0):BIGINT)])
-  LogicalValues(tuples=[[{ 1 }, { 2 }]])
-SQL: CREATE VIEW `MyTableDifferentCase` AS  SELECT val, anotherFunction(val, val) as fn FROM (VALUES ((1)), ((2))) AS t(val) ORDER BY val;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MyTable`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-arrays--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-arrays--package.txt
@@ -8,26 +8,6 @@ Timestamp  : -
 Schema:
  - id: INTEGER NOT NULL
  - int_array: INTEGER NOT NULL ARRAY NOT NULL
-Plan:
-LogicalProject(id=[$0], int_array=[$1])
-  LogicalProject(id=[$0], int_array=[$1])
-    LogicalUnion(all=[true])
-      LogicalProject(EXPR$0=[1], EXPR$1=[ARRAY(1, 2)])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[2], EXPR$1=[ARRAY(3)])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[3], EXPR$1=[ARRAY(4)])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[4], EXPR$1=[ARRAY(5, 6)])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `IntArray` AS 
-  SELECT id, int_array
-  FROM (VALUES
-    (1, ARRAY[1, 2]),
-    (2, ARRAY[3]),
-    (3, ARRAY[4]),
-    (4, ARRAY[5, 6])
-  ) AS T(id, int_array);
 
 === NestedArray
 ID:     default_catalog.default_database.NestedArray
@@ -38,32 +18,6 @@ Timestamp  : -
 Schema:
  - id: INTEGER NOT NULL
  - nested_array: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL ARRAY NOT NULL ARRAY NOT NULL
-Plan:
-LogicalProject(id=[$0], nested_array=[$1])
-  LogicalProject(id=[$0], nested_array=[$1])
-    LogicalUnion(all=[true])
-      LogicalProject(EXPR$0=[1], EXPR$1=[ARRAY(ARRAY('a', 'b'), ARRAY('c', 'd'))])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[2], EXPR$1=[ARRAY(ARRAY('x', 'y'), ARRAY('z'))])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `NestedArray` AS 
-  SELECT id, nested_array
-  FROM (VALUES
-    (
-      1,
-      ARRAY[
-        ARRAY['a', 'b'],
-        ARRAY['c', 'd']
-      ]
-    ),
-    (
-      2,
-      ARRAY[
-        ARRAY['x', 'y'],
-        ARRAY['z']
-      ]
-    )
-  ) AS T(id, nested_array);
 
 === StringArray
 ID:     default_catalog.default_database.StringArray
@@ -74,26 +28,6 @@ Timestamp  : -
 Schema:
  - id: INTEGER NOT NULL
  - string_array: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL ARRAY NOT NULL
-Plan:
-LogicalProject(id=[$0], string_array=[$1])
-  LogicalProject(id=[$0], string_array=[$1])
-    LogicalUnion(all=[true])
-      LogicalProject(EXPR$0=[1], EXPR$1=[ARRAY('a', 'b')])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[2], EXPR$1=[ARRAY('c')])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[3], EXPR$1=[ARRAY('d')])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[4], EXPR$1=[ARRAY('e', 'f')])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `StringArray` AS 
-  SELECT id, string_array
-  FROM (VALUES
-    (1, ARRAY['a', 'b']),
-    (2, ARRAY['c']),
-    (3, ARRAY['d']),
-    (4, ARRAY['e', 'f'])
-  ) AS T(id, string_array);
 
 === StringArrayFn
 ID:     default_catalog.default_database.StringArrayFn
@@ -103,11 +37,6 @@ Inputs: default_catalog.default_database.StringVals
 Annotations:
  - parameters: vals
  - base-table: StringVals
-Plan:
-LogicalProject(val=[$0])
-  LogicalFilter(condition=[array_contains(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY, $0)])
-    LogicalTableScan(table=[[default_catalog, default_database, StringVals]])
-SQL: CREATE VIEW `StringArrayFn` AS  SELECT val FROM StringVals WHERE array_contains(CAST(?     AS ARRAY<STRING>), val);
 
 === StringVals
 ID:     default_catalog.default_database.StringVals
@@ -117,10 +46,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 'a' }, { 'b' }, { 'c' }]])
-SQL: CREATE VIEW `StringVals` AS  SELECT val FROM (VALUES ('a'), ('b'), ('c')) AS T(val);
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `IntArray`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repo-repo-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repo-repo-package.txt
@@ -8,11 +8,6 @@ Primary Key: name
 Timestamp  : -
 Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalAggregate(group=[{0}])
-  LogicalProject(name=[$0])
-    LogicalTableScan(table=[[default_catalog, default_database, Submission]])
-SQL: CREATE VIEW `Package` AS  SELECT DISTINCT name FROM Submission;
 
 === Submission
 ID:     default_catalog.default_database.Submission
@@ -42,12 +37,6 @@ Schema:
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - variant0: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - repoURL: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
-Plan:
-LogicalProject(name=[$0], version=[$1], variant=[$2], latest=[$3], type=[$4], license=[$5], repository=[$6], homepage=[$7], documentation=[$8], readme=[$9], description=[$10], keywords=[$11], uniqueId=[$12], file=[$13], hash=[$14], authorId=[$15], submissionTime=[$16], event_time=[$17], variant0=[IFNULL($2, 'default')], repoURL=[CONCAT('https://repository.datasqrl.com/', $13)])
-  LogicalTableScan(table=[[default_catalog, default_database, _SubmissionRaw]])
-SQL: CREATE VIEW `Submission` AS  SELECT *, IFNULL(`variant`, 'default') AS variant0,
-                     concat('https://repository.datasqrl.com/',file) AS repoURL
-              FROM _SubmissionRaw;
 
 === SubmissionTopics
 ID:     default_catalog.default_database.SubmissionTopics
@@ -60,16 +49,6 @@ Schema:
  - pkgName: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - topicName: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - submissionTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalProject(pkgName=[$0], topicName=[$20], submissionTime=[$16])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{11}])
-    LogicalTableScan(table=[[default_catalog, default_database, Submission]])
-    LogicalProject(name=[$0])
-      Uncollect
-        LogicalProject(keywords=[$cor1.keywords])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `SubmissionTopics` AS  SELECT s.name AS pkgName, k.name AS topicName, s.submissionTime
-                    FROM Submission s CROSS JOIN UNNEST(keywords) k(name);
 
 === TopicPackages
 ID:     default_catalog.default_database.TopicPackages
@@ -85,13 +64,6 @@ Schema:
  - topicName: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - numSubmissions: BIGINT NOT NULL
  - lastSubmission: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], numSubmissions=[COUNT()], lastSubmission=[MAX($2)])
-  LogicalProject(pkgName=[$0], topicName=[$1], submissionTime=[$2])
-    LogicalTableScan(table=[[default_catalog, default_database, SubmissionTopics]])
-SQL: CREATE VIEW `TopicPackages` AS  SELECT pkgName, topicName, COUNT(1) AS numSubmissions, MAX(submissionTime) AS lastSubmission
-                 FROM SubmissionTopics
-                 GROUP BY pkgName, topicName ORDER BY numSubmissions DESC, pkgName ASC;
 
 === TopicSearch
 ID:     default_catalog.default_database.TopicSearch
@@ -105,13 +77,6 @@ Timestamp  : -
 Schema:
  - topicName: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - numPackages: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], numPackages=[COUNT(DISTINCT $1)])
-  LogicalProject(topicName=[$1], pkgName=[$0])
-    LogicalTableScan(table=[[default_catalog, default_database, SubmissionTopics]])
-SQL: CREATE VIEW `TopicSearch` AS  SELECT topicName, COUNT(DISTINCT pkgName) AS numPackages
-               FROM SubmissionTopics
-               GROUP BY topicName ORDER BY numPackages DESC, topicName ASC;
 
 === _SubmissionRaw
 ID:     default_catalog.default_database._SubmissionRaw
@@ -139,36 +104,7 @@ Schema:
  - authorId: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - submissionTime: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($17, 1:INTERVAL SECOND)])
-  LogicalProject(name=[$0], version=[$1], variant=[$2], latest=[$3], type=[$4], license=[$5], repository=[$6], homepage=[$7], documentation=[$8], readme=[$9], description=[$10], keywords=[$11], uniqueId=[$12], file=[$13], hash=[$14], authorId=[$15], submissionTime=[$16], event_time=[NOW()])
-    LogicalTableScan(table=[[default_catalog, default_database, _SubmissionRaw]])
-SQL: CREATE TABLE `_SubmissionRaw` (
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `version` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `variant` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `latest` BOOLEAN NOT NULL,
-  `type` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `license` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `repository` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `homepage` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `documentation` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `readme` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `description` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `keywords` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL ARRAY NOT NULL,
-  `uniqueId` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `file` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `hash` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `authorId` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `submissionTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `event_time` AS NOW(),
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/submission.jsonl',
-  'source.monitor-interval' = '10 sec'
-)
+
 >>>flink-sql-no-functions.sql
 CREATE TABLE `_SubmissionRaw` (
   `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro--package.txt
@@ -10,17 +10,6 @@ Schema:
  - id: BIGINT NOT NULL
  - number: BIGINT NOT NULL
  - volume: INTEGER NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], number=[COUNT()], volume=[SUM($1)])
-  LogicalProject(id=[$0], quantity=[$6])
-    LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      Uncollect
-        LogicalProject(items=[$cor1.items])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `OrderCount` AS  SELECT id, COUNT(1) as number, SUM(i.quantity) as volume
-              FROM Orders o CROSS JOIN UNNEST(o.items) i
-              GROUP BY id;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -37,30 +26,7 @@ Schema:
  - time: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - items: RecordType:peek_no_expand(INTEGER NOT NULL productid, INTEGER NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
  - _source_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalWatermarkAssigner(rowtime=[_source_time], watermark=[$4])
-  LogicalProject(id=[$0], customerid=[$1], time=[$2], items=[$3], _source_time=[CAST($4):TIMESTAMP_LTZ(3) *ROWTIME*])
-    LogicalTableScan(table=[[default_catalog, default_database, Orders, metadata=[timestamp]]])
-SQL: CREATE TEMPORARY TABLE `Orders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `items` ROW(`productid` INTEGER NOT NULL, `quantity` INTEGER NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Orders` (
-  `_source_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR `_source_time` AS `_source_time`
-) WITH (
-  'format' = 'avro',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = 'datasqrl-orders',
-  'topic' = '${sqrl:topic}',
-  'connector' = 'kafka',
-  'avro.timestamp_mapping.legacy' = 'false'
-)
-LIKE `Orders__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Orders__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package-s3.txt
@@ -15,17 +15,6 @@ Schema:
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - spend: DOUBLE NOT NULL
  - saved: DOUBLE NOT NULL
-Plan:
-LogicalProject(customerid=[$0], first_name=[$5], last_name=[$6], email=[$7], spend=[$2], saved=[$3])
-  LogicalFilter(condition=[>($2, 250)])
-    LogicalCorrelate(correlation=[$cor19], joinType=[inner], requiredColumns=[{0, 1}])
-      LogicalTableScan(table=[[default_catalog, default_database, CustomersSpending]])
-      LogicalFilter(condition=[=($cor19.customerid, $0)])
-        LogicalSnapshot(period=[$cor19.week])
-          LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `CustomerPromotion` AS  SELECT s.customerid, c.first_name, c.last_name, c.email, s.spend, s.saved
-        FROM CustomersSpending s JOIN Customers FOR SYSTEM_TIME AS OF `week` c ON s.customerid = c.id
-        WHERE s.spend > 250;
 
 === Customers
 ID:     default_catalog.default_database.Customers
@@ -46,17 +35,7 @@ Schema:
  - country: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - changed_on: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE VIEW `Customers`
-AS
-SELECT `id`, `first_name`, `last_name`, `email`, `ip_address`, `country`, `changed_on`, `timestamp`
-FROM (SELECT `id`, `first_name`, `last_name`, `email`, `ip_address`, `country`, `changed_on`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_CustomersStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomersOrderStats
 ID:     default_catalog.default_database.CustomersOrderStats
 Type:   state
@@ -70,14 +49,6 @@ Schema:
  - total_spend: DOUBLE NOT NULL
  - total_saved: DOUBLE NOT NULL
  - num_orders: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], first_order=[MIN($1)], total_spend=[SUM($2)], total_saved=[SUM($3)], num_orders=[COUNT()])
-  LogicalProject(customerid=[$2], time=[$1], price=[$3], saving=[$4])
-    LogicalTableScan(table=[[default_catalog, default_database, OrdersTotals]])
-SQL: CREATE VIEW `CustomersOrderStats` AS  SELECT customerid, min(`time`) as first_order,
-                              sum(price) as total_spend, sum(saving) as total_saved,
-                              count(1) as num_orders
-                       FROM OrdersTotals GROUP BY customerid;
 
 === CustomersPastPurchases
 ID:     default_catalog.default_database.CustomersPastPurchases
@@ -91,18 +62,6 @@ Schema:
  - productid: BIGINT NOT NULL
  - num_orders: BIGINT NOT NULL
  - total_quantity: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], num_orders=[COUNT()], total_quantity=[SUM($2)])
-  LogicalProject(customerid=[$1], productid=[$4], quantity=[$5])
-    LogicalCorrelate(correlation=[$cor12], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      Uncollect
-        LogicalProject(items=[$cor12.items])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `CustomersPastPurchases` AS  SELECT o.customerid, i.productid, count(1) as num_orders,
-         sum(i.quantity) as total_quantity
-      FROM Orders o CROSS JOIN UNNEST(o.items) i
-      GROUP BY o.customerid, i.productid;
 
 === CustomersSpending
 ID:     default_catalog.default_database.CustomersSpending
@@ -120,18 +79,6 @@ Schema:
  - week: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - spend: DOUBLE NOT NULL
  - saved: DOUBLE NOT NULL
-Plan:
-LogicalProject(customerid=[$0], week=[$3], spend=[$4], saved=[$5])
-  LogicalAggregate(group=[{0, 1, 2, 3}], spend=[SUM($4)], saved=[SUM($5)])
-    LogicalProject(customerid=[$2], window_start=[$5], window_end=[$6], week=[$7], price=[$3], saving=[$4])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('time'), 604800000:INTERVAL DAY)], rowType=[RecordType(BIGINT id, TIMESTAMP_LTZ(3) *ROWTIME* time, BIGINT customerid, DOUBLE price, DOUBLE saving, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(id=[$0], time=[$1], customerid=[$2], price=[$3], saving=[$4])
-          LogicalTableScan(table=[[default_catalog, default_database, OrdersTotals]])
-SQL: CREATE VIEW `CustomersSpending` AS  SELECT customerid, window_time AS week,
-         sum(price) AS spend, sum(saving) AS saved
-      FROM TABLE(TUMBLE(TABLE OrdersTotals, DESCRIPTOR(`time`), INTERVAL '7' DAYS))
-      GROUP BY customerid, window_start, window_end, window_time
-      ORDER BY week DESC;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -148,26 +95,7 @@ Schema:
  - customerid: BIGINT NOT NULL
  - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - items: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TEMPORARY TABLE `Orders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `items` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Orders` (
-  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
-  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/order_items.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `Orders__schema`
+
 === OrdersTotals
 ID:     default_catalog.default_database.OrdersTotals
 Type:   stream
@@ -184,17 +112,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - price: DOUBLE NOT NULL
  - saving: DOUBLE NOT NULL
-Plan:
-LogicalProject(id=[$0], time=[$4], customerid=[$1], price=[$5], saving=[$6])
-  LogicalAggregate(group=[{0, 1, 2, 3, 4}], price=[SUM($5)], saving=[SUM($6)])
-    LogicalProject(id=[$0], customerid=[$2], window_start=[$7], window_end=[$8], time=[$9], $f5=[-(*($4, $5), coalesce($6, 0.0:DOUBLE))], $f6=[coalesce($6, 0.0:DOUBLE)])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('time'), 1:INTERVAL SECOND)], rowType=[RecordType(BIGINT id, TIMESTAMP_LTZ(3) *ROWTIME* time, BIGINT customerid, BIGINT productid, BIGINT quantity, DOUBLE unit_price, DOUBLE discount, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(id=[$0], time=[$1], customerid=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6])
-          LogicalTableScan(table=[[default_catalog, default_database, _OrderItems]])
-SQL: CREATE VIEW `OrdersTotals` AS  SELECT id, window_time AS `time`, customerid, sum(quantity * unit_price - coalesce(discount, 0.0)) as price,
-                  sum(coalesce(discount, 0.0)) as saving
-                FROM TABLE(TUMBLE(TABLE _OrderItems, DESCRIPTOR(`time`), INTERVAL '0.001' SECONDS))
-                GROUP BY id, customerid, window_start, window_end, window_time;
 
 === ProductSearch
 ID:     default_catalog.default_database.ProductSearch
@@ -205,15 +122,6 @@ Annotations:
  - stream-root: _ProductsStream
  - parameters: query
  - base-table: ProductSearch
-Plan:
-LogicalSort(sort0=[$8], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first])
-  LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7], score=[text_search(?0, $1)])
-    LogicalFilter(condition=[>(text_search(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $1), 0)])
-      LogicalTableScan(table=[[default_catalog, default_database, Products]])
-SQL: CREATE VIEW `ProductSearch` AS  SELECT p.*, text_search(?     , name) as score
-                                 FROM Products p
-                                 WHERE text_search(?     , name) > 0
-                                 ORDER BY score DESC, id ASC;
 
 === ProductSearchWithId
 ID:     default_catalog.default_database.ProductSearchWithId
@@ -224,13 +132,6 @@ Annotations:
  - stream-root: _ProductsStream
  - parameters: query, id
  - base-table: Products
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7])
-    LogicalFilter(condition=[AND(>(text_search(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $1, $5), 0), >($0, ?1))])
-      LogicalTableScan(table=[[default_catalog, default_database, Products]])
-SQL: CREATE VIEW `ProductSearchWithId` AS  SELECT * FROM Products WHERE text_search(?     , name, category) > 0
-                                                                          AND id > ?   ORDER BY id ASC;
 
 === Products
 ID:     default_catalog.default_database.Products
@@ -251,17 +152,7 @@ Schema:
  - category: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - usda_id: BIGINT NOT NULL
  - updated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ProductsStream]])
-SQL: CREATE VIEW `Products`
-AS
-SELECT `id`, `name`, `sizing`, `weight_in_gram`, `type`, `category`, `usda_id`, `updated`
-FROM (SELECT `id`, `name`, `sizing`, `weight_in_gram`, `type`, `category`, `usda_id`, `updated`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ProductsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === ProductsByCountry
 ID:     default_catalog.default_database.ProductsByCountry
 Type:   state
@@ -275,24 +166,6 @@ Schema:
  - quantity: BIGINT NOT NULL
  - spend: DOUBLE NOT NULL
  - weight: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], quantity=[SUM($2)], spend=[SUM($3)], weight=[SUM($4)])
-  LogicalProject(productid=[$7], country=[$20], quantity=[$4], $f3=[*($4, $5)], $f4=[*($4, $10)])
-    LogicalCorrelate(correlation=[$cor29], joinType=[inner], requiredColumns=[{1, 2}])
-      LogicalCorrelate(correlation=[$cor28], joinType=[inner], requiredColumns=[{1, 3}])
-        LogicalTableScan(table=[[default_catalog, default_database, _OrderItems]])
-        LogicalFilter(condition=[=($cor28.productid, $0)])
-          LogicalSnapshot(period=[$cor28.time])
-            LogicalTableScan(table=[[default_catalog, default_database, Products]])
-      LogicalFilter(condition=[=($cor29.customerid, $0)])
-        LogicalSnapshot(period=[$cor29.time])
-          LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `ProductsByCountry` AS  SELECT p.id AS productid, c.country AS country, sum(o.quantity) as quantity,
-         sum(o.quantity * o.unit_price) as spend, sum(o.quantity * p.weight_in_gram) as weight
-      FROM _OrderItems o
-          JOIN Products FOR SYSTEM_TIME AS OF o.`time` p ON o.productid = p.id
-          JOIN Customers FOR SYSTEM_TIME AS OF o.`time`  c ON o.customerid =c.id
-      GROUP BY p.id, c.country;
 
 === _CustomersStream
 ID:     default_catalog.default_database._CustomersStream
@@ -312,31 +185,7 @@ Schema:
  - country: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - changed_on: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($6, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE TEMPORARY TABLE `_CustomersStream__schema` (
-  `id` BIGINT NOT NULL,
-  `first_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `last_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `ip_address` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `country` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `changed_on` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_CustomersStream` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`changed_on`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`id`, `changed_on`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/customers.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_CustomersStream__schema`
+
 === _OrderItems
 ID:     default_catalog.default_database._OrderItems
 Type:   stream
@@ -354,14 +203,6 @@ Schema:
  - quantity: BIGINT NOT NULL
  - unit_price: DOUBLE NOT NULL
  - discount: DOUBLE
-Plan:
-LogicalProject(id=[$0], time=[$2], customerid=[$1], productid=[$4], quantity=[$5], unit_price=[$6], discount=[$7])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{3}])
-    LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-    Uncollect
-      LogicalProject(items=[$cor1.items])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `_OrderItems` AS  SELECT o.id, o.`time`, o.customerid, i.* FROM Orders o CROSS JOIN UNNEST(o.items) i;
 
 === _ProductsStream
 ID:     default_catalog.default_database._ProductsStream
@@ -381,30 +222,7 @@ Schema:
  - category: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - usda_id: BIGINT NOT NULL
  - updated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _ProductsStream]])
-SQL: CREATE TEMPORARY TABLE `_ProductsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `sizing` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `weight_in_gram` BIGINT NOT NULL,
-  `type` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `category` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `usda_id` BIGINT NOT NULL,
-  `updated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ProductsStream` (
-  PRIMARY KEY (`id`, `updated`) NOT ENFORCED,
-  WATERMARK FOR `updated` AS `updated` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/products.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ProductsStream__schema`
+
 === promotion
 ID:     s3-sink.promotion
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-extended--package.txt
@@ -15,17 +15,6 @@ Schema:
  - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - spend: DOUBLE NOT NULL
  - saved: DOUBLE NOT NULL
-Plan:
-LogicalProject(customerid=[$0], first_name=[$5], last_name=[$6], email=[$7], spend=[$2], saved=[$3])
-  LogicalFilter(condition=[>($2, 250)])
-    LogicalCorrelate(correlation=[$cor19], joinType=[inner], requiredColumns=[{0, 1}])
-      LogicalTableScan(table=[[default_catalog, default_database, CustomersSpending]])
-      LogicalFilter(condition=[=($cor19.customerid, $0)])
-        LogicalSnapshot(period=[$cor19.week])
-          LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `CustomerPromotion` AS  SELECT s.customerid, c.first_name, c.last_name, c.email, s.spend, s.saved
-        FROM CustomersSpending s JOIN Customers FOR SYSTEM_TIME AS OF `week` c ON s.customerid = c.id
-        WHERE s.spend > 250;
 
 === Customers
 ID:     default_catalog.default_database.Customers
@@ -46,17 +35,7 @@ Schema:
  - country: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - changed_on: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE VIEW `Customers`
-AS
-SELECT `id`, `first_name`, `last_name`, `email`, `ip_address`, `country`, `changed_on`, `timestamp`
-FROM (SELECT `id`, `first_name`, `last_name`, `email`, `ip_address`, `country`, `changed_on`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_CustomersStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === CustomersOrderStats
 ID:     default_catalog.default_database.CustomersOrderStats
 Type:   state
@@ -70,14 +49,6 @@ Schema:
  - total_spend: DOUBLE NOT NULL
  - total_saved: DOUBLE NOT NULL
  - num_orders: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], first_order=[MIN($1)], total_spend=[SUM($2)], total_saved=[SUM($3)], num_orders=[COUNT()])
-  LogicalProject(customerid=[$2], time=[$1], price=[$3], saving=[$4])
-    LogicalTableScan(table=[[default_catalog, default_database, OrdersTotals]])
-SQL: CREATE VIEW `CustomersOrderStats` AS  SELECT customerid, min(`time`) as first_order,
-                              sum(price) as total_spend, sum(saving) as total_saved,
-                              count(1) as num_orders
-                       FROM OrdersTotals GROUP BY customerid;
 
 === CustomersPastPurchases
 ID:     default_catalog.default_database.CustomersPastPurchases
@@ -91,18 +62,6 @@ Schema:
  - productid: BIGINT NOT NULL
  - num_orders: BIGINT NOT NULL
  - total_quantity: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], num_orders=[COUNT()], total_quantity=[SUM($2)])
-  LogicalProject(customerid=[$1], productid=[$4], quantity=[$5])
-    LogicalCorrelate(correlation=[$cor12], joinType=[inner], requiredColumns=[{3}])
-      LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      Uncollect
-        LogicalProject(items=[$cor12.items])
-          LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `CustomersPastPurchases` AS  SELECT o.customerid, i.productid, count(1) as num_orders,
-         sum(i.quantity) as total_quantity
-      FROM Orders o CROSS JOIN UNNEST(o.items) i
-      GROUP BY o.customerid, i.productid;
 
 === CustomersSpending
 ID:     default_catalog.default_database.CustomersSpending
@@ -120,18 +79,6 @@ Schema:
  - week: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - spend: DOUBLE NOT NULL
  - saved: DOUBLE NOT NULL
-Plan:
-LogicalProject(customerid=[$0], week=[$3], spend=[$4], saved=[$5])
-  LogicalAggregate(group=[{0, 1, 2, 3}], spend=[SUM($4)], saved=[SUM($5)])
-    LogicalProject(customerid=[$2], window_start=[$5], window_end=[$6], week=[$7], price=[$3], saving=[$4])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('time'), 604800000:INTERVAL DAY)], rowType=[RecordType(BIGINT id, TIMESTAMP_LTZ(3) *ROWTIME* time, BIGINT customerid, DOUBLE price, DOUBLE saving, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(id=[$0], time=[$1], customerid=[$2], price=[$3], saving=[$4])
-          LogicalTableScan(table=[[default_catalog, default_database, OrdersTotals]])
-SQL: CREATE VIEW `CustomersSpending` AS  SELECT customerid, window_time AS week,
-         sum(price) AS spend, sum(saving) AS saved
-      FROM TABLE(TUMBLE(TABLE OrdersTotals, DESCRIPTOR(`time`), INTERVAL '7' DAYS))
-      GROUP BY customerid, window_start, window_end, window_time
-      ORDER BY week DESC;
 
 === Orders
 ID:     default_catalog.default_database.Orders
@@ -148,26 +95,7 @@ Schema:
  - customerid: BIGINT NOT NULL
  - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - items: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TEMPORARY TABLE `Orders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `items` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Orders` (
-  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
-  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/order_items.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `Orders__schema`
+
 === OrdersTotals
 ID:     default_catalog.default_database.OrdersTotals
 Type:   stream
@@ -184,17 +112,6 @@ Schema:
  - customerid: BIGINT NOT NULL
  - price: DOUBLE NOT NULL
  - saving: DOUBLE NOT NULL
-Plan:
-LogicalProject(id=[$0], time=[$4], customerid=[$1], price=[$5], saving=[$6])
-  LogicalAggregate(group=[{0, 1, 2, 3, 4}], price=[SUM($5)], saving=[SUM($6)])
-    LogicalProject(id=[$0], customerid=[$2], window_start=[$7], window_end=[$8], time=[$9], $f5=[-(*($4, $5), coalesce($6, 0.0:DOUBLE))], $f6=[coalesce($6, 0.0:DOUBLE)])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('time'), 1:INTERVAL SECOND)], rowType=[RecordType(BIGINT id, TIMESTAMP_LTZ(3) *ROWTIME* time, BIGINT customerid, BIGINT productid, BIGINT quantity, DOUBLE unit_price, DOUBLE discount, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(id=[$0], time=[$1], customerid=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6])
-          LogicalTableScan(table=[[default_catalog, default_database, _OrderItems]])
-SQL: CREATE VIEW `OrdersTotals` AS  SELECT id, window_time AS `time`, customerid, sum(quantity * unit_price - coalesce(discount, 0.0)) as price,
-                  sum(coalesce(discount, 0.0)) as saving
-                FROM TABLE(TUMBLE(TABLE _OrderItems, DESCRIPTOR(`time`), INTERVAL '0.001' SECONDS))
-                GROUP BY id, customerid, window_start, window_end, window_time;
 
 === ProductSearch
 ID:     default_catalog.default_database.ProductSearch
@@ -205,15 +122,6 @@ Annotations:
  - stream-root: _ProductsStream
  - parameters: query
  - base-table: ProductSearch
-Plan:
-LogicalSort(sort0=[$8], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first])
-  LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7], score=[text_search(?0, $1)])
-    LogicalFilter(condition=[>(text_search(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $1), 0)])
-      LogicalTableScan(table=[[default_catalog, default_database, Products]])
-SQL: CREATE VIEW `ProductSearch` AS  SELECT p.*, text_search(?     , name) as score
-                                 FROM Products p
-                                 WHERE text_search(?     , name) > 0
-                                 ORDER BY score DESC, id ASC;
 
 === ProductSearchWithId
 ID:     default_catalog.default_database.ProductSearchWithId
@@ -224,13 +132,6 @@ Annotations:
  - stream-root: _ProductsStream
  - parameters: query, id
  - base-table: Products
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7])
-    LogicalFilter(condition=[AND(>(text_search(CAST(?0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", $1, $5), 0), >($0, ?1))])
-      LogicalTableScan(table=[[default_catalog, default_database, Products]])
-SQL: CREATE VIEW `ProductSearchWithId` AS  SELECT * FROM Products WHERE text_search(?     , name, category) > 0
-                                                                          AND id > ?   ORDER BY id ASC;
 
 === Products
 ID:     default_catalog.default_database.Products
@@ -251,17 +152,7 @@ Schema:
  - category: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - usda_id: BIGINT NOT NULL
  - updated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7])
-  LogicalFilter(condition=[=($8, 1)])
-    LogicalProject(id=[$0], name=[$1], sizing=[$2], weight_in_gram=[$3], type=[$4], category=[$5], usda_id=[$6], updated=[$7], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $7 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _ProductsStream]])
-SQL: CREATE VIEW `Products`
-AS
-SELECT `id`, `name`, `sizing`, `weight_in_gram`, `type`, `category`, `usda_id`, `updated`
-FROM (SELECT `id`, `name`, `sizing`, `weight_in_gram`, `type`, `category`, `usda_id`, `updated`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_ProductsStream`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === ProductsByCountry
 ID:     default_catalog.default_database.ProductsByCountry
 Type:   state
@@ -275,24 +166,6 @@ Schema:
  - quantity: BIGINT NOT NULL
  - spend: DOUBLE NOT NULL
  - weight: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0, 1}], quantity=[SUM($2)], spend=[SUM($3)], weight=[SUM($4)])
-  LogicalProject(productid=[$7], country=[$20], quantity=[$4], $f3=[*($4, $5)], $f4=[*($4, $10)])
-    LogicalCorrelate(correlation=[$cor29], joinType=[inner], requiredColumns=[{1, 2}])
-      LogicalCorrelate(correlation=[$cor28], joinType=[inner], requiredColumns=[{1, 3}])
-        LogicalTableScan(table=[[default_catalog, default_database, _OrderItems]])
-        LogicalFilter(condition=[=($cor28.productid, $0)])
-          LogicalSnapshot(period=[$cor28.time])
-            LogicalTableScan(table=[[default_catalog, default_database, Products]])
-      LogicalFilter(condition=[=($cor29.customerid, $0)])
-        LogicalSnapshot(period=[$cor29.time])
-          LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `ProductsByCountry` AS  SELECT p.id AS productid, c.country AS country, sum(o.quantity) as quantity,
-         sum(o.quantity * o.unit_price) as spend, sum(o.quantity * p.weight_in_gram) as weight
-      FROM _OrderItems o
-          JOIN Products FOR SYSTEM_TIME AS OF o.`time` p ON o.productid = p.id
-          JOIN Customers FOR SYSTEM_TIME AS OF o.`time`  c ON o.customerid =c.id
-      GROUP BY p.id, c.country;
 
 === _CustomersStream
 ID:     default_catalog.default_database._CustomersStream
@@ -312,31 +185,7 @@ Schema:
  - country: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - changed_on: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalProject(id=[$0], first_name=[$1], last_name=[$2], email=[$3], ip_address=[$4], country=[$5], changed_on=[$6], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($6, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, _CustomersStream]])
-SQL: CREATE TEMPORARY TABLE `_CustomersStream__schema` (
-  `id` BIGINT NOT NULL,
-  `first_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `last_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `ip_address` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `country` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
-  `changed_on` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_CustomersStream` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`changed_on`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`id`, `changed_on`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/customers.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_CustomersStream__schema`
+
 === _OrderItems
 ID:     default_catalog.default_database._OrderItems
 Type:   stream
@@ -354,14 +203,6 @@ Schema:
  - quantity: BIGINT NOT NULL
  - unit_price: DOUBLE NOT NULL
  - discount: DOUBLE
-Plan:
-LogicalProject(id=[$0], time=[$2], customerid=[$1], productid=[$4], quantity=[$5], unit_price=[$6], discount=[$7])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{3}])
-    LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-    Uncollect
-      LogicalProject(items=[$cor1.items])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `_OrderItems` AS  SELECT o.id, o.`time`, o.customerid, i.* FROM Orders o CROSS JOIN UNNEST(o.items) i;
 
 === _ProductsStream
 ID:     default_catalog.default_database._ProductsStream
@@ -381,30 +222,7 @@ Schema:
  - category: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - usda_id: BIGINT NOT NULL
  - updated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[updated], watermark=[-($7, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, _ProductsStream]])
-SQL: CREATE TEMPORARY TABLE `_ProductsStream__schema` (
-  `id` BIGINT NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `sizing` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `weight_in_gram` BIGINT NOT NULL,
-  `type` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `category` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `usda_id` BIGINT NOT NULL,
-  `updated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `_ProductsStream` (
-  PRIMARY KEY (`id`, `updated`) NOT ENFORCED,
-  WATERMARK FOR `updated` AS `updated` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/products.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `_ProductsStream__schema`
+
 === promotion
 ID:     local-sink.promotion
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full--package.txt
@@ -13,17 +13,6 @@ Schema:
  - sensorid: BIGINT NOT NULL
  - temp: DOUBLE NOT NULL
  - timeSec: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(machineId=[$4], sensorid=[$0], temp=[$2], timeSec=[$1])
-  LogicalFilter(condition=[>($2, 35)])
-    LogicalCorrelate(correlation=[$cor5], joinType=[inner], requiredColumns=[{0, 1}])
-      LogicalTableScan(table=[[default_catalog, default_database, SecReading]])
-      LogicalFilter(condition=[=($cor5.sensorid, $0)])
-        LogicalSnapshot(period=[$cor5.timeSec])
-          LogicalTableScan(table=[[default_catalog, default_database, Sensors]])
-SQL: CREATE VIEW `HighTemp` AS  SELECT machineId, sensorid, temp, timeSec
-            FROM SecReading r JOIN Sensors FOR SYSTEM_TIME AS OF r.`timeSec` s ON r.sensorid = s.id
-            WHERE temp > 35;
 
 === Machine
 ID:     default_catalog.default_database.Machine
@@ -36,18 +25,6 @@ Schema:
  - machineId: BIGINT NOT NULL
  - maxTemp: DOUBLE NOT NULL
  - avgTemp: DOUBLE NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], maxTemp=[MAX($1)], avgTemp=[AVG($1)])
-  LogicalProject(machineId=[$4], temp=[$2])
-    LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0, 1}])
-      LogicalTableScan(table=[[default_catalog, default_database, SecReading]])
-      LogicalFilter(condition=[=($cor1.sensorid, $0)])
-        LogicalSnapshot(period=[$cor1.timeSec])
-          LogicalTableScan(table=[[default_catalog, default_database, Sensors]])
-SQL: CREATE VIEW `Machine` AS  SELECT machineId, max(temp) as maxTemp,
-    avg(temp) as avgTemp
-    FROM SecReading r JOIN Sensors FOR SYSTEM_TIME AS OF r.`timeSec` s ON r.sensorid = s.id
-    GROUP BY machineId;
 
 === SecReading
 ID:     default_catalog.default_database.SecReading
@@ -64,18 +41,6 @@ Schema:
  - sensorid: BIGINT NOT NULL
  - timeSec: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - temp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], timeSec=[$3], temp=[$4])
-  LogicalAggregate(group=[{0, 1, 2, 3}], temp=[AVG($4)])
-    LogicalProject(sensorid=[$0], window_start=[$5], window_end=[$6], timeSec=[$7], temperature=[$2])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('timestamp'), 1000:INTERVAL SECOND)], rowType=[RecordType(BIGINT sensorid, BIGINT time, DOUBLE temperature, DOUBLE humidity, TIMESTAMP_LTZ(3) *ROWTIME* timestamp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(sensorid=[$0], time=[$1], temperature=[$2], humidity=[$3], timestamp=[$4])
-          LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SecReading` AS  SELECT sensorid, window_time as timeSec,
-                     avg(temperature) as temp
-              FROM TABLE(TUMBLE(TABLE SensorReading, DESCRIPTOR(`timestamp`), INTERVAL '1' SECONDS))
-              GROUP BY sensorid, window_start, window_end, window_time
-              ORDER BY timeSec DESC;
 
 === SecReadingByTemp
 ID:     default_catalog.default_database.SecReadingByTemp
@@ -86,12 +51,6 @@ Annotations:
  - stream-root: SensorReading
  - parameters: temp
  - base-table: SecReading
-Plan:
-LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
-  LogicalProject(sensorid=[$0], timeSec=[$1], temp=[$2])
-    LogicalFilter(condition=[>($2, ?0)])
-      LogicalTableScan(table=[[default_catalog, default_database, SecReading]])
-SQL: CREATE VIEW `SecReadingByTemp` AS  SELECT * FROM SecReading WHERE temp > ?     ORDER BY timeSec ASC LIMIT 10;
 
 === SensorLastHour
 ID:     default_catalog.default_database.SensorLastHour
@@ -108,17 +67,7 @@ Schema:
  - window_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - avgTemp: DOUBLE NOT NULL
  - maxTemp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], window_time=[$1], avgTemp=[$2], maxTemp=[$3])
-  LogicalFilter(condition=[=($4, 1)])
-    LogicalProject(sensorid=[$0], window_time=[$1], avgTemp=[$2], maxTemp=[$3], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _SensorMaxTempWindow]])
-SQL: CREATE VIEW `SensorLastHour`
-AS
-SELECT `sensorid`, `window_time`, `avgTemp`, `maxTemp`
-FROM (SELECT `sensorid`, `window_time`, `avgTemp`, `maxTemp`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `window_time` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_SensorMaxTempWindow`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
 Type:   stream
@@ -134,29 +83,7 @@ Schema:
  - temperature: DOUBLE NOT NULL
  - humidity: DOUBLE NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(sensorid=[$0], time=[$1], temperature=[$2], humidity=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE TEMPORARY TABLE `SensorReading__schema` (
-  `sensorid` BIGINT NOT NULL,
-  `time` BIGINT NOT NULL,
-  `temperature` DOUBLE NOT NULL,
-  `humidity` DOUBLE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `SensorReading` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`time`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`sensorid`, `time`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-csv',
-  'path' = '${DATA_PATH}/sensorreading.csv.gz',
-  'connector' = 'filesystem',
-  'flexible-csv.skip-header' = 'true'
-)
-LIKE `SensorReading__schema`
+
 === SensorUpdates
 ID:     default_catalog.default_database.SensorUpdates
 Type:   stream
@@ -171,27 +98,7 @@ Schema:
  - machineId: BIGINT NOT NULL
  - placed: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(id=[$0], machineId=[$1], placed=[$2], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($2, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorUpdates]])
-SQL: CREATE TEMPORARY TABLE `SensorUpdates__schema` (
-  `id` BIGINT NOT NULL,
-  `machineId` BIGINT NOT NULL,
-  `placed` BIGINT NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `SensorUpdates` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`placed`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`id`, `placed`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/sensors.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `SensorUpdates__schema`
+
 === Sensors
 ID:     default_catalog.default_database.Sensors
 Type:   state
@@ -207,17 +114,7 @@ Schema:
  - machineId: BIGINT NOT NULL
  - placed: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], machineId=[$1], placed=[$2], timestamp=[$3])
-  LogicalFilter(condition=[=($4, 1)])
-    LogicalProject(id=[$0], machineId=[$1], placed=[$2], timestamp=[$3], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, SensorUpdates]])
-SQL: CREATE VIEW `Sensors`
-AS
-SELECT `id`, `machineId`, `placed`, `timestamp`
-FROM (SELECT `id`, `machineId`, `placed`, `timestamp`, ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `timestamp` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`SensorUpdates`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _SensorMaxTempWindow
 ID:     default_catalog.default_database._SensorMaxTempWindow
 Type:   stream
@@ -233,16 +130,6 @@ Schema:
  - window_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - avgTemp: DOUBLE NOT NULL
  - maxTemp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], window_time=[$3], avgTemp=[$4], maxTemp=[$5])
-  LogicalAggregate(group=[{0, 1, 2, 3}], avgTemp=[AVG($4)], maxTemp=[MAX($4)])
-    LogicalProject(sensorid=[$0], window_start=[$3], window_end=[$4], window_time=[$5], temp=[$2])
-      LogicalTableFunctionScan(invocation=[HOP(TABLE(#0), DESCRIPTOR('timeSec'), 60000:INTERVAL MINUTE, 3600000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT sensorid, TIMESTAMP_LTZ(3) *ROWTIME* timeSec, DOUBLE temp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(sensorid=[$0], timeSec=[$1], temp=[$2])
-          LogicalTableScan(table=[[default_catalog, default_database, SecReading]])
-SQL: CREATE VIEW `_SensorMaxTempWindow` AS  SELECT sensorid, window_time, avg(temp) as avgTemp, max(temp) as maxTemp
-                        FROM TABLE(HOP(TABLE SecReading, DESCRIPTOR(timeSec), INTERVAL '1' MINUTES, INTERVAL '60' MINUTES))
-                        GROUP BY sensorid, window_start, window_end, window_time;
 
 >>>generated-schema.graphqls
 "An RFC-3339 compliant DateTime Scalar"

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation--package.txt
@@ -12,11 +12,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: DECIMAL(8, 2) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalProject(sensorid=[$0], temperature=[$1], event_time=[$2])
-  LogicalFilter(condition=[>($1, 50)])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `HighTempAlert` AS  SELECT * FROM SensorReading WHERE temperature > 50 ORDER BY sensorid DESC;
 
 === SensorMaxTemp
 ID:     default_catalog.default_database.SensorMaxTemp
@@ -30,14 +25,6 @@ Timestamp  : -
 Schema:
  - sensorid: INTEGER NOT NULL
  - maxTemp: DECIMAL(8, 2) NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], maxTemp=[MAX($1)])
-  LogicalProject(sensorid=[$0], temperature=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorMaxTemp` AS  SELECT sensorid, max(temperature) as maxTemp
-    FROM SensorReading
-    GROUP BY sensorid
-    ORDER BY sensorid DESC;
 
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
@@ -50,24 +37,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: DECIMAL(8, 2) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($2, 0:INTERVAL SECOND)])
-  LogicalProject(sensorid=[$0], temperature=[$1], event_time=[CAST($2):TIMESTAMP_LTZ(3) *ROWTIME*])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading, metadata=[timestamp]]])
-SQL: CREATE TABLE `SensorReading` (
-  `sensorid` INTEGER NOT NULL,
-  `temperature` DECIMAL(8, 2) NOT NULL,
-  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorReading'
-)
+
 === SensorReadingSubscription
 ID:     default_catalog.default_database.SensorReadingSubscription
 Type:   stream
@@ -79,10 +49,6 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: DECIMAL(8, 2) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME*
-Plan:
-LogicalProject(sensorid=[$0], temperature=[$1], event_time=[$2])
-  LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SensorReadingSubscription` AS  SELECT * FROM SensorReading;
 
 === SensorSubscriptionById
 ID:     default_catalog.default_database.SensorSubscriptionById
@@ -92,12 +58,6 @@ Inputs: default_catalog.default_database.SensorReadingSubscription
 Annotations:
  - parameters: sensorid
  - base-table: SensorReading
-Plan:
-LogicalProject(sensorid=[$0], temperature=[$1], event_time=[$2])
-  LogicalFilter(condition=[=($0, ?0)])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReadingSubscription]])
-SQL: CREATE VIEW `SensorSubscriptionById` AS  SELECT * FROM SensorReadingSubscription
-                                                                    WHERE sensorid = ?        ;
 
 >>>flink-sql-no-functions.sql
 CREATE TABLE `SensorReading` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser--package.txt
@@ -16,18 +16,6 @@ Schema:
  - timeStart: TIMESTAMP(3) NOT NULL
  - timeEnd: TIMESTAMP(3) NOT NULL
  - temp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], timeSec=[$3], timeStart=[$1], timeEnd=[$2], temp=[$4])
-  LogicalAggregate(group=[{0, 1, 2, 3}], temp=[AVG($4)])
-    LogicalProject(sensorid=[$0], timeStart=[$5], timeEnd=[$6], timeSec=[$7], temperature=[$2])
-      LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR('timestamp'), 1000:INTERVAL SECOND)], rowType=[RecordType(BIGINT sensorid, BIGINT time, DOUBLE temperature, DOUBLE humidity, TIMESTAMP_LTZ(3) *ROWTIME* timestamp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(sensorid=[$0], time=[$1], temperature=[$2], humidity=[$3], timestamp=[$4])
-          LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE VIEW `SecReading` AS  SELECT sensorid, window_time as timeSec, window_start as timeStart, window_end as timeEnd,
-        avg(temperature) as temp
-    FROM TABLE(TUMBLE(TABLE SensorReading, DESCRIPTOR(`timestamp`), INTERVAL '1' SECONDS))
-    GROUP BY sensorid, window_start, window_end, window_time
-    ORDER BY timeSec DESC;
 
 === SensorMaxTemp
 ID:     default_catalog.default_database.SensorMaxTemp
@@ -40,17 +28,7 @@ Schema:
  - sensorid: BIGINT NOT NULL
  - window_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - maxTemp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], window_time=[$1], maxTemp=[$2])
-  LogicalFilter(condition=[=($3, 1)])
-    LogicalProject(sensorid=[$0], window_time=[$1], maxTemp=[$2], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _SensorMaxTempWindow]])
-SQL: CREATE VIEW `SensorMaxTemp`
-AS
-SELECT `sensorid`, `window_time`, `maxTemp`
-FROM (SELECT `sensorid`, `window_time`, `maxTemp`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `window_time` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_SensorMaxTempWindow`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
 Type:   stream
@@ -66,29 +44,7 @@ Schema:
  - temperature: DOUBLE NOT NULL
  - humidity: DOUBLE NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(sensorid=[$0], time=[$1], temperature=[$2], humidity=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($1, 3), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-SQL: CREATE TEMPORARY TABLE `SensorReading__schema` (
-  `sensorid` BIGINT NOT NULL,
-  `time` BIGINT NOT NULL,
-  `temperature` DOUBLE NOT NULL,
-  `humidity` DOUBLE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `SensorReading` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`time`, 3), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`sensorid`, `time`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-csv',
-  'path' = '${DATA_PATH}/sensorreading.csv.gz',
-  'connector' = 'filesystem',
-  'flexible-csv.skip-header' = 'true'
-)
-LIKE `SensorReading__schema`
+
 === _SensorMaxTempWindow
 ID:     default_catalog.default_database._SensorMaxTempWindow
 Type:   state
@@ -102,16 +58,6 @@ Schema:
  - sensorid: BIGINT NOT NULL
  - window_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - maxTemp: DOUBLE NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], window_time=[$3], maxTemp=[$4])
-  LogicalAggregate(group=[{0, 1, 2, 3}], maxTemp=[MAX($4)])
-    LogicalProject(sensorid=[$0], window_start=[$5], window_end=[$6], window_time=[$7], temp=[$4])
-      LogicalTableFunctionScan(invocation=[HOP(TABLE(#0), DESCRIPTOR('timeSec'), 5000:INTERVAL SECOND, 60000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT sensorid, TIMESTAMP_LTZ(3) *ROWTIME* timeSec, TIMESTAMP(3) timeStart, TIMESTAMP(3) timeEnd, DOUBLE temp, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)])
-        LogicalProject(sensorid=[$0], timeSec=[$1], timeStart=[$2], timeEnd=[$3], temp=[$4])
-          LogicalTableScan(table=[[default_catalog, default_database, SecReading]])
-SQL: CREATE VIEW `_SensorMaxTempWindow` AS  SELECT sensorid, window_time, max(temp) as maxTemp
-    FROM TABLE(HOP(TABLE SecReading, DESCRIPTOR(timeSec), INTERVAL '5' SECONDS, INTERVAL '1' MINUTES))
-    GROUP BY sensorid, window_start, window_end, window_time;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `SensorReading__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions--package.txt
@@ -14,28 +14,7 @@ Schema:
  - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: BIGINT NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
-    LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE TEMPORARY TABLE `Customers__schema` (
-  `customerid` BIGINT NOT NULL,
-  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` BIGINT NOT NULL
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/customers.jsonl'
-);
-CREATE TABLE `Customers` (
-  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
-  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'source.monitor-interval' = '10 sec'
-)
-LIKE `Customers__schema`
+
 === CustomersById
 ID:     default_catalog.default_database.CustomersById
 Type:   query
@@ -45,13 +24,6 @@ Annotations:
  - stream-root: Customers
  - parameters: a, b, modId
  - base-table: Customers
-Plan:
-LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-    LogicalFilter(condition=[<($0, ?2)])
-      LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `CustomersById` AS 
-    SELECT * FROM Customers WHERE customerid < ?      ORDER BY customerid;
 
 === CustomersByName
 ID:     default_catalog.default_database.CustomersByName
@@ -62,12 +34,6 @@ Annotations:
  - stream-root: Customers
  - parameters: inputName, shortName
  - base-table: Customers
-Plan:
-LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
-  LogicalFilter(condition=[LIKE($2, ?1)])
-    LogicalTableScan(table=[[default_catalog, default_database, Customers]])
-SQL: CREATE VIEW `CustomersByName` AS 
-    SELECT * FROM Customers WHERE name LIKE ?         ;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Customers__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support--package.txt
@@ -17,30 +17,7 @@ Schema:
  - unit_price: DOUBLE
  - discount: DOUBLE
  - _ingest_time: TIMESTAMP_LTZ(3) *PROCTIME* NOT NULL
-Plan:
-LogicalProject(id=[$0], customerid=[$1], time=[$2], productid=[$3], quantity=[$4], unit_price=[$5], discount=[$6], _ingest_time=[PROCTIME()])
-  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-SQL: CREATE TEMPORARY TABLE `Orders__schema` (
-  `id` BIGINT NOT NULL,
-  `customerid` BIGINT NOT NULL,
-  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `productid` BIGINT NOT NULL,
-  `quantity` BIGINT NOT NULL,
-  `unit_price` DOUBLE,
-  `discount` DOUBLE
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Orders` (
-  `_ingest_time` AS PROCTIME(),
-  PRIMARY KEY (`id`, `customerid`, `time`) NOT ENFORCED
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/orders.jsonl',
-  'source.monitor-interval' = '10000',
-  'connector' = 'filesystem'
-)
-LIKE `Orders__schema`
+
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Orders__schema` (
   `id` BIGINT NOT NULL,

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json--package.txt
@@ -12,25 +12,7 @@ Schema:
  - id: BIGINT NOT NULL
  - val: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($2, 1:INTERVAL SECOND)])
-  LogicalTableScan(table=[[default_catalog, default_database, Json]])
-SQL: CREATE TEMPORARY TABLE `Json__schema` (
-  `id` BIGINT NOT NULL,
-  `val` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
-) WITH (
-  'connector' = 'datagen'
-);
-CREATE TABLE `Json` (
-  PRIMARY KEY (`id`) NOT ENFORCED,
-  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
-) WITH (
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/json.jsonl',
-  'connector' = 'filesystem'
-)
-LIKE `Json__schema`
+
 === UnmodifiedJsonData
 ID:     default_catalog.default_database.UnmodifiedJsonData
 Type:   stream
@@ -48,17 +30,6 @@ Schema:
  - json_col_2: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
  - json_col_3: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
  - json_col_4: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
-Plan:
-LogicalProject(id=[$0], val=[$1], json_col=[TO_JSONB('{"a": 1}')], json_col_2=[TO_JSONB('{"a": 2}')], json_col_3=[TO_JSONB('{"b": 1}')], json_col_4=[TO_JSONB('{"b": 2}')])
-  LogicalTableScan(table=[[default_catalog, default_database, Json]])
-SQL: CREATE VIEW `UnmodifiedJsonData` AS  SELECT id,
-                             val,
-                             TO_JSONB('{"a": 1}') AS json_col,
-                             TO_JSONB('{"a": 2}') AS json_col_2,
-                             TO_JSONB('{"b": 1}') AS json_col_3,
-                             TO_JSONB('{"b": 2}') AS json_col_4
-                     FROM Json
-                     ORDER BY id;
 
 >>>flink-sql-no-functions.sql
 CREATE TEMPORARY TABLE `Json__schema` (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math--package.txt
@@ -20,35 +20,6 @@ Schema:
  - exponential_distribution: DOUBLE
  - normal_distribution: DOUBLE
  - poisson_distribution: DOUBLE
-Plan:
-LogicalProject(d=[$0], b=[$1], cbrt=[cbrt(CAST($0):DOUBLE)], copy_sign=[copy_sign(CAST($0):DOUBLE, CAST($0):DOUBLE)], expm1=[expm1(CAST($0):DOUBLE)], hypot=[hypot(CAST($0):DOUBLE, CAST($0):DOUBLE)], log1p=[log1p(CAST($0):DOUBLE)], next_after=[next_after(CAST($0):DOUBLE, CAST($0):DOUBLE)], scalb=[scalb(CAST($0):DOUBLE, CAST($1):BIGINT)], ulp=[ulp(CAST($0):DOUBLE)], binomial_distribution=[binomial_distribution(CAST($1):BIGINT, 1:DOUBLE, CAST($1):BIGINT)], exponential_distribution=[exponential_distribution(CAST($0):DOUBLE, CAST($0):DOUBLE)], normal_distribution=[normal_distribution(CAST($0):DOUBLE, CAST($0):DOUBLE, CAST($0):DOUBLE)], poisson_distribution=[poisson_distribution(CAST($0):DOUBLE, CAST($1):BIGINT)])
-  LogicalValues(tuples=[[{ 1.0, 11 }, { 2.0, 12 }, { 3.0, 13 }, { 4.0, 14 }, { 5.0, 15 }, { 6.0, 16 }, { 7.0, 17 }, { 8.0, 18 }, { 9.0, 19 }, { 10.0, 20 }]])
-SQL: CREATE VIEW `MathFunctions` AS  SELECT d, b,
-            cbrt(d) AS cbrt,
-            copy_sign(d, d) AS copy_sign,
-            expm1(d) AS expm1,
-            hypot(d, d) AS hypot,
-            log1p(d) AS log1p,
-            next_after(d, d) AS next_after,
-            scalb(d, b) AS scalb,
-            ulp(d) AS ulp,
-            binomial_distribution(b, 1, b) AS binomial_distribution,
-            exponential_distribution(d, d) AS exponential_distribution,
-            normal_distribution(d, d, d) AS normal_distribution,
-            poisson_distribution(d, b) AS poisson_distribution
-           FROM (
-    VALUES 
-    ( 1.0, 11), 
-    ( 2.0, 12), 
-    ( 3.0, 13), 
-    ( 4.0, 14), 
-    ( 5.0, 15), 
-    ( 6.0, 16), 
-    ( 7.0, 17), 
-    ( 8.0, 18), 
-    ( 9.0, 19), 
-    ( 10.0, 20)
-    ) AS names(d, b);
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MathFunctions`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai--package.txt
@@ -7,10 +7,6 @@ Primary Key:
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }]])
-SQL: CREATE VIEW `data` AS  SELECT * FROM (VALUES(1)) AS t(val);
 
 === results
 ID:     default_catalog.default_database.results
@@ -23,14 +19,6 @@ Schema:
  - completions_result: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - extract_json_result_response: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - extract_json_result_with_schema_response: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalProject(completions_result=[completions('Reply this exactly: \"Crunching data like a squirrel.\"', 'gpt-4o', 50, 0.1:DOUBLE)], extract_json_result_response=[extract_json('Reply this exactly: \"Crunching data like a squirrel.\" in the \"response\" property.', 'gpt-4o', 0.1:DOUBLE)], extract_json_result_with_schema_response=[extract_json('myField should be equal to \"Hello squirrels!\" ', 'gpt-4o', 0.1:DOUBLE, 1.0:DOUBLE, '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"response":{"type":"object","properties":{"myField":{"type":"string"}},"required":["myField"],"additionalProperties":false}},"required":["response"],"additionalProperties":false}')])
-  LogicalTableScan(table=[[default_catalog, default_database, data]])
-SQL: CREATE VIEW `results` AS  SELECT
-            completions('Reply this exactly: \"Crunching data like a squirrel.\"', 'gpt-4o', 50, 0.1) AS completions_result,
-            extract_json('Reply this exactly: \"Crunching data like a squirrel.\" in the \"response\" property.', 'gpt-4o', 0.1) AS extract_json_result_response,
-            extract_json('myField should be equal to \"Hello squirrels!\" ', 'gpt-4o', 0.1, 1.0, '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"response":{"type":"object","properties":{"myField":{"type":"string"}},"required":["myField"],"additionalProperties":false}},"required":["response"],"additionalProperties":false}') as extract_json_result_with_schema_response
-           FROM data;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `data`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async--package.txt
@@ -7,10 +7,6 @@ Primary Key:
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }]])
-SQL: CREATE VIEW `data` AS  SELECT * FROM (VALUES(1)) AS t(val);
 
 === results
 ID:     default_catalog.default_database.results
@@ -23,14 +19,6 @@ Schema:
  - completions_result: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - extract_json_result_response: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
  - extract_json_result_with_schema_response: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalProject(completions_result=[completions('Reply this exactly: \"Crunching data like a squirrel.\"', 'gpt-4o', 50, 0.1:DOUBLE)], extract_json_result_response=[extract_json('Reply this exactly: \"Crunching data like a squirrel.\" in the \"response\" property.', 'gpt-4o', 0.1:DOUBLE)], extract_json_result_with_schema_response=[extract_json('myField should be equal to \"Hello squirrels!\" ', 'gpt-4o', 0.1:DOUBLE, 1.0:DOUBLE, '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"response":{"type":"object","properties":{"myField":{"type":"string"}},"required":["myField"],"additionalProperties":false}},"required":["response"],"additionalProperties":false}')])
-  LogicalTableScan(table=[[default_catalog, default_database, data]])
-SQL: CREATE VIEW `results` AS  SELECT
-            completions('Reply this exactly: \"Crunching data like a squirrel.\"', 'gpt-4o', 50, 0.1) AS completions_result,
-            extract_json('Reply this exactly: \"Crunching data like a squirrel.\" in the \"response\" property.', 'gpt-4o', 0.1) AS extract_json_result_response,
-            extract_json('myField should be equal to \"Hello squirrels!\" ', 'gpt-4o', 0.1, 1.0, '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"response":{"type":"object","properties":{"myField":{"type":"string"}},"required":["myField"],"additionalProperties":false}},"required":["response"],"additionalProperties":false}') as extract_json_result_with_schema_response
-           FROM data;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `data`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector--package.txt
@@ -9,12 +9,6 @@ Timestamp  : -
 Schema:
  - category_id: INTEGER NOT NULL
  - center_vector: DOUBLE NOT NULL ARRAY
-Plan:
-LogicalProject(category_id=[$0], center_vector=[vector_to_double($1)])
-  LogicalAggregate(group=[{0}], agg#0=[CENTER($1)])
-    LogicalProject(category_id=[$1], vector=[$2])
-      LogicalTableScan(table=[[default_catalog, default_database, VectorData]])
-SQL: CREATE VIEW `CategoryCentroids` AS  SELECT category_id, vector_to_double(CENTER(vector)) as center_vector FROM VectorData GROUP BY category_id;
 
 === DocumentSimilarity
 ID:     default_catalog.default_database.DocumentSimilarity
@@ -24,17 +18,6 @@ Inputs: default_catalog.default_database.VectorData
 Annotations:
  - parameters: doc_id
  - base-table: DocumentSimilarity
-Plan:
-LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first])
-  LogicalProject(doc_id=[$3], score=[cosine_similarity($2, $5)])
-    LogicalFilter(condition=[=($0, ?0)])
-      LogicalJoin(condition=[<>($0, $3)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, VectorData]])
-        LogicalTableScan(table=[[default_catalog, default_database, VectorData]])
-SQL: CREATE VIEW `DocumentSimilarity` AS  SELECT v2.doc_id, cosine_similarity(v1.vector, v2.vector) as score
-                                           FROM VectorData v1 JOIN VectorData v2 ON v1.doc_id <> v2.doc_id
-                                           WHERE v1.doc_id = ?      
-                                           ORDER BY score DESC, doc_id ASC;
 
 === DocumentSimilarityIndex
 ID:     default_catalog.default_database.DocumentSimilarityIndex
@@ -44,17 +27,6 @@ Inputs: default_catalog.default_database.VectorData
 Annotations:
  - parameters: doc_id
  - base-table: DocumentSimilarityIndex
-Plan:
-LogicalSort(sort0=[$3], dir0=[DESC-nulls-last])
-  LogicalProject(doc_id=[$3], category_id=[$4], vector=[$5], EXPR$3=[cosine_similarity($2, $5)])
-    LogicalFilter(condition=[AND(=($0, ?0), <>($0, $3))])
-      LogicalJoin(condition=[>(cosine_similarity($2, $5), 0.5:DECIMAL(2, 1))], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, VectorData]])
-        LogicalTableScan(table=[[default_catalog, default_database, VectorData]])
-SQL: CREATE VIEW `DocumentSimilarityIndex` AS   SELECT e.*
-                        FROM VectorData i JOIN VectorData e ON cosine_similarity(i.vector, e.vector) > 0.5
-                        WHERE i.doc_id = ?       AND i.doc_id <> e.doc_id
-                        ORDER BY cosine_similarity(i.vector, e.vector) DESC;
 
 === VectorData
 ID:     default_catalog.default_database.VectorData
@@ -66,24 +38,6 @@ Schema:
  - doc_id: INTEGER NOT NULL
  - category_id: INTEGER NOT NULL
  - vector: RAW('com.datasqrl.flinkrunner.stdlib.vector.FlinkVectorType', 'AEhjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLnZlY3Rvci5GbGlua1ZlY3RvclR5cGVTZXJpYWxpemVyU25hcHNob3QAAAAD')
-Plan:
-LogicalProject(doc_id=[$0], category_id=[$1], vector=[double_to_vector(CAST($2):DOUBLE NOT NULL ARRAY)])
-  LogicalProject(doc_id=[$0], category_id=[$1], vector=[$2])
-    LogicalUnion(all=[true])
-      LogicalProject(EXPR$0=[1], EXPR$1=[10], EXPR$2=[ARRAY(0.9:DECIMAL(3, 2), 0.8:DECIMAL(3, 2), 0.01:DECIMAL(3, 2), 0.1:DECIMAL(3, 2), 0.15:DECIMAL(3, 2))])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[2], EXPR$1=[10], EXPR$2=[ARRAY(0.85:DECIMAL(3, 2), 0.85:DECIMAL(3, 2), 0.03:DECIMAL(3, 2), 0.12:DECIMAL(3, 2), 0.09:DECIMAL(3, 2))])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[3], EXPR$1=[5], EXPR$2=[ARRAY(0.05:DECIMAL(3, 2), 0.1:DECIMAL(3, 2), 0.0:DECIMAL(3, 2), 0.9:DECIMAL(3, 2), 0.85:DECIMAL(3, 2))])
-        LogicalValues(tuples=[[{ 0 }]])
-      LogicalProject(EXPR$0=[4], EXPR$1=[5], EXPR$2=[ARRAY(0.1:DECIMAL(3, 2), 0.12:DECIMAL(3, 2), 0.05:DECIMAL(3, 2), 0.85:DECIMAL(3, 2), 0.9:DECIMAL(3, 2))])
-        LogicalValues(tuples=[[{ 0 }]])
-SQL: CREATE VIEW `VectorData` AS  SELECT doc_id, category_id, double_to_vector(vector) AS vector FROM (VALUES
-             (1, 10, ARRAY[0.9, 0.8, 0.01, 0.1, 0.15]),
-             (2, 10, ARRAY[0.85, 0.85, 0.03, 0.12, 0.09]),
-             (3, 5, ARRAY[0.05, 0.1, 0.0, 0.9, 0.85]),
-             (4, 5, ARRAY[0.1, 0.12, 0.05, 0.85, 0.9])
-     ) AS data_table(doc_id, category_id, vector);
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `VectorData`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join--package.txt
@@ -13,16 +13,6 @@ Schema:
  - temperature: FLOAT NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
-Plan:
-LogicalProject(sensorid=[$0], temperature=[$1], event_time=[$2], sensor_name=[$4])
-  LogicalCorrelate(correlation=[$cor1], joinType=[left], requiredColumns=[{0, 2}])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading]])
-    LogicalFilter(condition=[=($cor1.sensorid, $0)])
-      LogicalSnapshot(period=[$cor1.event_time])
-        LogicalTableScan(table=[[default_catalog, default_database, _SensorDistinct]])
-SQL: CREATE VIEW `EnrichedSensorReading` AS  SELECT r.sensorid, r.temperature, r.event_time, u.sensor_name
-                         FROM SensorReading r LEFT JOIN _SensorDistinct FOR SYSTEM_TIME AS OF r.event_time u on r.sensorid = u.sensorid
-                         ORDER BY r.event_time ASC;
 
 === SensorReading
 ID:     default_catalog.default_database.SensorReading
@@ -35,24 +25,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - temperature: FLOAT NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($2, 0:INTERVAL SECOND)])
-  LogicalProject(sensorid=[$0], temperature=[$1], event_time=[CAST($2):TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorReading, metadata=[timestamp]]])
-SQL: CREATE TABLE `SensorReading` (
-  `sensorid` INTEGER NOT NULL,
-  `temperature` FLOAT NOT NULL,
-  `event_time` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorReading'
-)
+
 === SensorUpdates
 ID:     default_catalog.default_database.SensorUpdates
 Type:   stream
@@ -64,24 +37,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[lastUpdated], watermark=[-($2, 0:INTERVAL SECOND)])
-  LogicalProject(sensorid=[$0], sensor_name=[$1], lastUpdated=[CAST($2):TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL])
-    LogicalTableScan(table=[[default_catalog, default_database, SensorUpdates, metadata=[timestamp]]])
-SQL: CREATE TABLE `SensorUpdates` (
-  `sensorid` INTEGER NOT NULL,
-  `sensor_name` STRING NOT NULL,
-  `lastUpdated` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
-  WATERMARK FOR `lastUpdated` AS `lastUpdated` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorUpdates'
-)
+
 === _SensorDistinct
 ID:     default_catalog.default_database._SensorDistinct
 Type:   state
@@ -95,17 +51,7 @@ Schema:
  - sensorid: INTEGER NOT NULL
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(sensorid=[$0], sensor_name=[$1], lastUpdated=[$2])
-  LogicalFilter(condition=[=($3, 1)])
-    LogicalProject(sensorid=[$0], sensor_name=[$1], lastUpdated=[$2], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, SensorUpdates]])
-SQL: CREATE VIEW `_SensorDistinct`
-AS
-SELECT `sensorid`, `sensor_name`, `lastUpdated`
-FROM (SELECT `sensorid`, `sensor_name`, `lastUpdated`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`SensorUpdates`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === Result
 ID:     logger.Result
 Type:   export

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/usertokens--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/usertokens--package.txt
@@ -10,13 +10,6 @@ Schema:
  - orgid: BIGINT NOT NULL
  - total_tokens: BIGINT NOT NULL
  - total_requests: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], total_tokens=[SUM($1)], total_requests=[COUNT()])
-  LogicalProject(orgid=[$3], tokens=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, _EnrichedUserTokens]])
-SQL: CREATE VIEW `TotalOrgTokens` AS  SELECT orgid, sum(tokens) as total_tokens,
-                         count(tokens) as total_requests
-                  FROM _EnrichedUserTokens GROUP BY orgid;
 
 === TotalOrgTokensByRange
 ID:     default_catalog.default_database.TotalOrgTokensByRange
@@ -26,13 +19,6 @@ Inputs: default_catalog.default_database.TotalOrgTokens
 Annotations:
  - parameters: minTokens, maxTokens
  - base-table: TotalOrgTokens
-Plan:
-LogicalProject(orgid=[$0], total_tokens=[$1], total_requests=[$2])
-  LogicalFilter(condition=[AND(>=($1, ?0), <=($1, ?1))])
-    LogicalTableScan(table=[[default_catalog, default_database, TotalOrgTokens]])
-SQL: CREATE VIEW `TotalOrgTokensByRange` AS 
-    SELECT * FROM TotalOrgTokens
-    WHERE total_tokens >= ?          AND total_tokens <= ?         ;
 
 === TotalUserTokens
 ID:     default_catalog.default_database.TotalUserTokens
@@ -45,13 +31,6 @@ Schema:
  - userid: BIGINT NOT NULL
  - total_tokens: BIGINT NOT NULL
  - total_requests: BIGINT NOT NULL
-Plan:
-LogicalAggregate(group=[{0}], total_tokens=[SUM($1)], total_requests=[COUNT()])
-  LogicalProject(userid=[$0], tokens=[$1])
-    LogicalTableScan(table=[[default_catalog, default_database, UserTokens]])
-SQL: CREATE VIEW `TotalUserTokens` AS  SELECT userid, sum(tokens) as total_tokens,
-                          count(tokens) as total_requests
-                   FROM UserTokens GROUP BY userid;
 
 === UsageAlert
 ID:     default_catalog.default_database.UsageAlert
@@ -64,11 +43,6 @@ Schema:
  - userid: BIGINT NOT NULL
  - tokens: BIGINT NOT NULL
  - request_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(userid=[$0], tokens=[$1], request_time=[$2])
-  LogicalFilter(condition=[>($1, 100000)])
-    LogicalTableScan(table=[[default_catalog, default_database, UserTokens]])
-SQL: CREATE VIEW `UsageAlert` AS  SELECT * FROM UserTokens WHERE tokens > 100000;
 
 === UserTokens
 ID:     default_catalog.default_database.UserTokens
@@ -81,24 +55,7 @@ Schema:
  - userid: BIGINT NOT NULL
  - tokens: BIGINT NOT NULL
  - request_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[request_time], watermark=[-($2, 0:INTERVAL SECOND)])
-  LogicalProject(userid=[$0], tokens=[$1], request_time=[CAST($2):TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL])
-    LogicalTableScan(table=[[default_catalog, default_database, UserTokens, metadata=[timestamp]]])
-SQL: CREATE TABLE `UserTokens` (
-  `userid` BIGINT NOT NULL,
-  `tokens` BIGINT NOT NULL,
-  `request_time` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
-  WATERMARK FOR `request_time` AS `request_time` - INTERVAL '0.0' SECOND
-) WITH (
-  'connector' = 'kafka',
-  'flexible-json.timestamp-format.standard' = 'ISO-8601',
-  'format' = 'flexible-json',
-  'properties.auto.offset.reset' = 'earliest',
-  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
-  'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'UserTokens'
-)
+
 === _CurrentUserInfo
 ID:     default_catalog.default_database._CurrentUserInfo
 Type:   state
@@ -111,17 +68,7 @@ Schema:
  - orgid: BIGINT NOT NULL
  - last_updated: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalProject(userid=[$0], orgid=[$1], last_updated=[$2], event_time=[$3])
-  LogicalFilter(condition=[=($4, 1)])
-    LogicalProject(userid=[$0], orgid=[$1], last_updated=[$2], event_time=[$3], __sqrlinternal_rownum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
-      LogicalTableScan(table=[[default_catalog, default_database, _UserInfo]])
-SQL: CREATE VIEW `_CurrentUserInfo`
-AS
-SELECT `userid`, `orgid`, `last_updated`, `event_time`
-FROM (SELECT `userid`, `orgid`, `last_updated`, `event_time`, ROW_NUMBER() OVER (PARTITION BY `userid` ORDER BY `last_updated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
-  FROM `default_catalog`.`default_database`.`_UserInfo`) AS `t`
-WHERE `__sqrlinternal_rownum` = 1
+
 === _EnrichedUserTokens
 ID:     default_catalog.default_database._EnrichedUserTokens
 Type:   stream
@@ -134,15 +81,6 @@ Schema:
  - tokens: BIGINT NOT NULL
  - request_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - orgid: BIGINT NOT NULL
-Plan:
-LogicalProject(userid=[$0], tokens=[$1], request_time=[$2], orgid=[$4])
-  LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0, 2}])
-    LogicalTableScan(table=[[default_catalog, default_database, UserTokens]])
-    LogicalFilter(condition=[=($0, $cor1.userid)])
-      LogicalSnapshot(period=[$cor1.request_time])
-        LogicalTableScan(table=[[default_catalog, default_database, _CurrentUserInfo]])
-SQL: CREATE VIEW `_EnrichedUserTokens` AS  SELECT t.*, u.orgid FROM UserTokens t
-   JOIN _CurrentUserInfo FOR SYSTEM_TIME AS OF t.request_time u ON u.userid = t.userid;
 
 === _UserInfo
 ID:     default_catalog.default_database._UserInfo
@@ -156,22 +94,7 @@ Schema:
  - orgid: BIGINT NOT NULL
  - last_updated: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Plan:
-LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($3, 1:INTERVAL SECOND)])
-  LogicalProject(userid=[$0], orgid=[$1], last_updated=[$2], event_time=[NOW()])
-    LogicalTableScan(table=[[default_catalog, default_database, _UserInfo]])
-SQL: CREATE TABLE `_UserInfo` (
-  `userid` BIGINT NOT NULL,
-  `orgid` BIGINT NOT NULL,
-  `last_updated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `event_time` AS NOW(),
-  WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.001' SECOND
-) WITH (
-  'connector' = 'filesystem',
-  'format' = 'flexible-json',
-  'path' = '${DATA_PATH}/userinfo.jsonl',
-  'source.monitor-interval' = '10 sec'
-)
+
 >>>schema.graphqls
 "An RFC-3339 compliant DateTime Scalar"
 scalar DateTime

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/views--package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/views--package.txt
@@ -9,10 +9,6 @@ Primary Key: val
 Timestamp  : -
 Schema:
  - val: INTEGER NOT NULL
-Plan:
-LogicalProject(val=[$0])
-  LogicalValues(tuples=[[{ 1 }, { 2 }]])
-SQL: CREATE VIEW `MyView` AS  SELECT * FROM (VALUES (1), (2)) AS t(val) ORDER BY val ASC;
 
 >>>flink-sql-no-functions.sql
 CREATE VIEW `MyView`


### PR DESCRIPTION
1) Fix issue in pipeline exporter: it did not honor the sql setting.
2) Remove text/visual configuration options - we don't use them. Update docs.