### PR TITLE
Bump `graphql-java` to 25.0 and `graphql-java-extended-scalars` to 24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,8 @@
     <feign.version>13.6</feign.version>
     <freemarker.version>2.3.34</freemarker.version>
     <glassfish.version>3.0.0</glassfish.version>
-    <graphql-java-extended-scalars.version>22.0</graphql-java-extended-scalars.version>
-    <graphql-java.version>19.2</graphql-java.version>
+    <graphql-java-extended-scalars.version>24.0</graphql-java-extended-scalars.version>
+    <graphql-java.version>25.0</graphql-java.version>
     <graphql-micrometer.version>1.0.1</graphql-micrometer.version>
     <guava.version>33.5.0-jre</guava.version>
     <guice-multibindings.version>4.2.3</guice-multibindings.version>
@@ -159,7 +159,6 @@
     <postgres.version>42.7.8</postgres.version>
     <projectreactor.version>3.7.12</projectreactor.version>
     <protobuf.version>4.33.0</protobuf.version>
-    <reactive-streams.version>1.0.4</reactive-streams.version>
     <reflections.version>0.10.2</reflections.version>
     <scala.version>2.12</scala.version>
     <scram.version>2.1</scram.version>
@@ -354,11 +353,6 @@
         <groupId>io.agroal</groupId>
         <artifactId>agroal-pool</artifactId>
         <version>${agroal.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.reactivestreams</groupId>
-        <artifactId>reactive-streams</artifactId>
-        <version>${reactive-streams.version}</version>
       </dependency>
 
       <!-- validation -->

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/converter/GraphQLSchemaConverter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/converter/GraphQLSchemaConverter.java
@@ -63,7 +63,6 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.SchemaPrinter;
-import graphql.schema.idl.TypeDefinitionRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -630,8 +629,8 @@ public class GraphQLSchemaConverter {
   }
 
   public GraphQLSchema getSchema(String schemaString) {
-    TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schemaString);
-    RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+    var typeRegistry = new SchemaParser().parse(schemaString);
+    var runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring().strictMode(false);
     CustomScalars.getExtendedScalars().forEach(runtimeWiringBuilder::scalar);
 
     return new SchemaGenerator().makeExecutableSchema(typeRegistry, runtimeWiringBuilder.build());

--- a/sqrl-server/sqrl-server-core/pom.xml
+++ b/sqrl-server/sqrl-server-core/pom.xml
@@ -33,6 +33,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
@@ -41,6 +42,11 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java-extended-scalars</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Jackson -->

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/GraphQLEngineBuilder.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/GraphQLEngineBuilder.java
@@ -174,6 +174,7 @@ public class GraphQLEngineBuilder
       TypeDefinitionRegistry registry, GraphQLCodeRegistry.Builder codeRegistry) {
     var wiring =
         RuntimeWiring.newRuntimeWiring()
+            .strictMode(false)
             .codeRegistry(codeRegistry)
             .scalar(CustomScalars.DOUBLE)
             .scalar(CustomScalars.FLEXIBLE_DATETIME)

--- a/sqrl-server/sqrl-server-vertx-base/pom.xml
+++ b/sqrl-server/sqrl-server-vertx-base/pom.xml
@@ -101,10 +101,6 @@
       <groupId>io.agroal</groupId>
       <artifactId>agroal-pool</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.reactivestreams</groupId>
-      <artifactId>reactive-streams</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/VertxContext.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/VertxContext.java
@@ -29,10 +29,8 @@ import com.datasqrl.graphql.server.QueryExecutionContext;
 import com.datasqrl.graphql.server.RootGraphqlModel;
 import com.datasqrl.graphql.server.RootGraphqlModel.Argument;
 import com.datasqrl.graphql.server.RootGraphqlModel.ResolvedQuery;
+import com.datasqrl.graphql.util.CaseInsensitiveJsonDataFetcher;
 import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.PropertyDataFetcher;
-import io.vertx.core.json.JsonObject;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -56,33 +54,7 @@ public class VertxContext implements Context {
 
   @Override
   public DataFetcher<Object> createPropertyFetcher(String name) {
-    return VertxCreateCaseInsensitivePropertyDataFetcher.createCaseInsensitive(name);
-  }
-
-  public interface VertxCreateCaseInsensitivePropertyDataFetcher {
-
-    static PropertyDataFetcher<Object> createCaseInsensitive(String propertyName) {
-      return new PropertyDataFetcher<>(propertyName) {
-        @Override
-        public Object get(DataFetchingEnvironment environment) {
-          var source = environment.getSource();
-          if (source instanceof JsonObject jsonObject) {
-            var value = jsonObject.getValue(getPropertyName());
-            if (value != null) {
-              return value;
-            }
-            // Case-insensitive lookup for drivers that may not preserve sensitivity
-            return jsonObject.getMap().entrySet().stream()
-                .filter(e -> e.getKey().equalsIgnoreCase(getPropertyName()))
-                .filter(e -> e.getValue() != null)
-                .map(Map.Entry::getValue)
-                .findAny()
-                .orElse(null);
-          }
-          return super.get(environment);
-        }
-      };
-    }
+    return new CaseInsensitiveJsonDataFetcher(name);
   }
 
   @Override

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/util/CaseInsensitiveJsonDataFetcher.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/util/CaseInsensitiveJsonDataFetcher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.graphql.util;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.PropertyDataFetcher;
+import io.vertx.core.json.JsonObject;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class CaseInsensitiveJsonDataFetcher extends PropertyDataFetcher<Object> {
+
+  public CaseInsensitiveJsonDataFetcher(String propertyName) {
+    super(propertyName);
+  }
+
+  @Override
+  public Object get(DataFetchingEnvironment environment) {
+    var source = environment.getSource();
+    if (source instanceof JsonObject jsonObj) {
+      return fetchJsonObject(jsonObj);
+    }
+
+    return super.get(environment);
+  }
+
+  @Override
+  public Object get(
+      GraphQLFieldDefinition fieldDef, Object source, Supplier<DataFetchingEnvironment> envSupplier)
+      throws Exception {
+
+    if (source instanceof JsonObject jsonObj) {
+      return fetchJsonObject(jsonObj);
+    }
+
+    return super.get(fieldDef, source, envSupplier);
+  }
+
+  Object fetchJsonObject(JsonObject jsonObj) {
+    var value = jsonObj.getValue(getPropertyName());
+    if (value != null) {
+      return value;
+    }
+    // Case-insensitive lookup for drivers that may not preserve sensitivity
+    return jsonObj.getMap().entrySet().stream()
+        .filter(e -> e.getKey().equalsIgnoreCase(getPropertyName()))
+        .filter(e -> e.getValue() != null)
+        .map(Map.Entry::getValue)
+        .findAny()
+        .orElse(null);
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/util/CaseInsensitiveJsonDataFetcherTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/util/CaseInsensitiveJsonDataFetcherTest.java
@@ -13,26 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.graphql;
+package com.datasqrl.graphql.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
 import io.vertx.core.json.JsonObject;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-class VertxContextTest {
+class CaseInsensitiveJsonDataFetcherTest {
+
+  private final CaseInsensitiveJsonDataFetcher fetcher =
+      new CaseInsensitiveJsonDataFetcher("testkey");
 
   @Test
   void caseInsensitivePropertyFetcherNonNullValue() {
     var jsonObject = new JsonObject();
     jsonObject.put("TestKey", "TestValue");
-    var result = testValue(jsonObject);
-    assertThat(result).isEqualTo("TestValue");
+
+    assertThat(fetcher.fetchJsonObject(jsonObject)).isEqualTo("TestValue");
   }
 
   @Test
@@ -41,8 +39,7 @@ class VertxContextTest {
     var jsonObject = new JsonObject();
     jsonObject.put("TestKey", null);
 
-    var result = testValue(jsonObject);
-    assertThat(result).isNull();
+    assertThat(fetcher.fetchJsonObject(jsonObject)).isNull();
   }
 
   @Test
@@ -51,20 +48,6 @@ class VertxContextTest {
     var jsonObject = new JsonObject();
     jsonObject.put("AnotherKey", "SomeValue");
 
-    var result = testValue(jsonObject);
-    assertThat(result).isNull();
-  }
-
-  @SneakyThrows
-  Object testValue(JsonObject jsonObject) {
-    // Mocking DataFetchingEnvironment
-    DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
-
-    when(env.getSource()).thenReturn(jsonObject);
-
-    DataFetcher<Object> fetcher =
-        VertxContext.VertxCreateCaseInsensitivePropertyDataFetcher.createCaseInsensitive("testkey");
-
-    return fetcher.get(env);
+    assertThat(fetcher.fetchJsonObject(jsonObject)).isNull();
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-fail-invalid-field-name.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-fail-invalid-field-name.txt
@@ -19,7 +19,7 @@ in script:comprehensiveTest.sqrl [51:1]:
 CustomerTimeWindow := SELECT
 ^
 
-[FATAL] errors=[InvalidSyntaxError{ message=Invalid Syntax : token recognition error at: '~' at line 9 column 9 ,offendingToken=null ,locations=[SourceLocation{line=9, column=9}] ,sourcePreview=type Customer {
+[FATAL] errors=[InvalidSyntaxError{ message=Invalid syntax with ANTLR error 'token recognition error at: '~'' at line 9 column 9 ,offendingToken=null ,locations=[SourceLocation{line=9, column=9}] ,sourcePreview=type Customer {
     customerid: Long!
     email: String!
     name~: String!

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-fail-invalid-type-name.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-fail-invalid-type-name.txt
@@ -19,7 +19,7 @@ in script:comprehensiveTest.sqrl [51:1]:
 CustomerTimeWindow := SELECT
 ^
 
-[FATAL] errors=[InvalidSyntaxError{ message=Invalid Syntax : token recognition error at: '~' at line 6 column 14 ,offendingToken=null ,locations=[SourceLocation{line=6, column=14}] ,sourcePreview="A 64-bit signed integer"
+[FATAL] errors=[InvalidSyntaxError{ message=Invalid syntax with ANTLR error 'token recognition error at: '~'' at line 6 column 14 ,offendingToken=null ,locations=[SourceLocation{line=6, column=14}] ,sourcePreview="A 64-bit signed integer"
 scalar Long
 
 type Customer~ {


### PR DESCRIPTION
## Key Changes
- GraphQL introduced strict mode by default, which means you cannot redefine built-in types (what we do for `Float` and `DateTime`), so now we explicitly need to disable that (possible follow-up if this could be achieved differently on our send, so we can roll with strict mode)
- `Coercing` interface method signatures changed, those had to be adapted
- The  data fetching got smarter (and more performant in some scenarios) in recent versions, so now our custom `PropertyDataFetcher` has to override 2 `get` methods
- Also separated our custom property fetcher code into its separate class `CaseInsensitiveJsonDataFetcher`
- `slf4j-api` got removed from `graphql-java` so now we need to add it explicitly into our `sqrl-server-core` to be able to define loggers
- Removed explicit `reactive-streams` dependency definition from our POMs cause it ships with `graphql-java`