### PR TITLE
Add string functions: CHAR_LENGTH, POSITION, OVERLAY, INITCAP, MD5

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/CharLengthSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/CharLengthSqlTranslation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+@AutoService(SqlTranslation.class)
+public class CharLengthSqlTranslation extends PostgresSqlTranslation {
+
+  public CharLengthSqlTranslation() {
+    super(SqlStdOperatorTable.CHAR_LENGTH);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    call.unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/InitCapSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/InitCapSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class InitCapSqlTranslation extends PostgresSqlTranslation {
+
+  public InitCapSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("INITCAP"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var string = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("initcap")
+        .createCall(SqlParserPos.ZERO, string)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/Md5SqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/Md5SqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class Md5SqlTranslation extends PostgresSqlTranslation {
+
+  public Md5SqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("MD5"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var string = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("md5")
+        .createCall(SqlParserPos.ZERO, string)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/OverlaySqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/OverlaySqlTranslation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+@AutoService(SqlTranslation.class)
+public class OverlaySqlTranslation extends PostgresSqlTranslation {
+
+  public OverlaySqlTranslation() {
+    super(SqlStdOperatorTable.OVERLAY);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    call.unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/PositionSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/PositionSqlTranslation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+@AutoService(SqlTranslation.class)
+public class PositionSqlTranslation extends PostgresSqlTranslation {
+
+  public PositionSqlTranslation() {
+    super(SqlStdOperatorTable.POSITION);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    call.unparse(writer, leftPrec, rightPrec);
+  }
+}


### PR DESCRIPTION
## Summary
Implements 5 PostgreSQL string function translations.

## Functions Added
- **CHAR_LENGTH**: Passthrough to PostgreSQL CHAR_LENGTH
- **POSITION**: Passthrough to PostgreSQL POSITION  
- **OVERLAY**: Passthrough to PostgreSQL OVERLAY
- **INITCAP**: Maps to PostgreSQL initcap() function
- **MD5**: Maps to PostgreSQL md5() function

## Related Issue
Part of #1696 - PostgreSQL function mapping implementation

## Testing
- Compiled successfully with `mvn clean test-compile`
- All new translation files follow established patterns