### PR TITLE
Add array functions: ARRAY_REVERSE, ARRAY_MAX, ARRAY_MIN, ELEMENT

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayMaxSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayMaxSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class ArrayMaxSqlTranslation extends PostgresSqlTranslation {
+
+  public ArrayMaxSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ARRAY_MAX"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var array = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("array_max")
+        .createCall(SqlParserPos.ZERO, array)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayMinSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayMinSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class ArrayMinSqlTranslation extends PostgresSqlTranslation {
+
+  public ArrayMinSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ARRAY_MIN"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var array = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("array_min")
+        .createCall(SqlParserPos.ZERO, array)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayReverseSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayReverseSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class ArrayReverseSqlTranslation extends PostgresSqlTranslation {
+
+  public ArrayReverseSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ARRAY_REVERSE"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var array = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("array_reverse")
+        .createCall(SqlParserPos.ZERO, array)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ElementSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ElementSqlTranslation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class ElementSqlTranslation extends PostgresSqlTranslation {
+
+  public ElementSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ELEMENT"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var array = call.getOperandList().get(0);
+    var one = SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO);
+
+    CalciteFunctionUtil.lightweightOp("element")
+        .createCall(SqlParserPos.ZERO, array, one)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}


### PR DESCRIPTION
## Summary
Implements 4 PostgreSQL array function translations.

## Functions Added
- **ARRAY_REVERSE**: Maps to PostgreSQL array_reverse() function
- **ARRAY_MAX**: Maps to PostgreSQL array_max() function
- **ARRAY_MIN**: Maps to PostgreSQL array_min() function
- **ELEMENT**: Maps to PostgreSQL element() function with index parameter

## Related Issue
Part of #1696 - PostgreSQL function mapping implementation

## Testing
- Compiled successfully with `mvn clean test-compile`
- All new translation files follow established patterns