### PR TITLE
Add map and string functions: MAP_VALUES, MAP_ENTRIES, PRINTF, ENCODE, DECODE

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/DecodeSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/DecodeSqlTranslation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class DecodeSqlTranslation extends PostgresSqlTranslation {
+
+  public DecodeSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("DECODE"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var binary = call.getOperandList().get(0);
+    var charset = call.getOperandList().get(1);
+
+    CalciteFunctionUtil.lightweightOp("convert_from")
+        .createCall(SqlParserPos.ZERO, binary, charset)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/EncodeSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/EncodeSqlTranslation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class EncodeSqlTranslation extends PostgresSqlTranslation {
+
+  public EncodeSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ENCODE"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var string = call.getOperandList().get(0);
+    var charset = call.getOperandList().get(1);
+
+    CalciteFunctionUtil.lightweightOp("convert_to")
+        .createCall(SqlParserPos.ZERO, string, charset)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/MapEntriesSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/MapEntriesSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class MapEntriesSqlTranslation extends PostgresSqlTranslation {
+
+  public MapEntriesSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("MAP_ENTRIES"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var map = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("map_entries")
+        .createCall(SqlParserPos.ZERO, map)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/MapValuesSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/MapValuesSqlTranslation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class MapValuesSqlTranslation extends PostgresSqlTranslation {
+
+  public MapValuesSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("MAP_VALUES"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var map = call.getOperandList().get(0);
+
+    CalciteFunctionUtil.lightweightOp("map_values")
+        .createCall(SqlParserPos.ZERO, map)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/PrintfSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/PrintfSqlTranslation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class PrintfSqlTranslation extends PostgresSqlTranslation {
+
+  public PrintfSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("PRINTF"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    CalciteFunctionUtil.lightweightOp("format")
+        .createCall(SqlParserPos.ZERO, call.getOperandList())
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}


### PR DESCRIPTION
## Summary
Implements 5 PostgreSQL function translations (2 map functions + 3 string functions).

## Functions Added
**Map Functions:**
- **MAP_VALUES**: Maps to PostgreSQL map_values() function
- **MAP_ENTRIES**: Maps to PostgreSQL map_entries() function

**String Functions:**
- **PRINTF**: Maps to PostgreSQL format() function
- **ENCODE**: Maps to PostgreSQL convert_to() function for charset encoding
- **DECODE**: Maps to PostgreSQL convert_from() function for charset decoding

## Related Issue
Part of #1696 - PostgreSQL function mapping implementation

## Testing
- Compiled successfully with `mvn clean test-compile`
- All new translation files follow established patterns