### PR TITLE
Add date/time functions: LOCALTIME, LOCALTIMESTAMP, CURRENT_TIME, ELT

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/CurrentTimeSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/CurrentTimeSqlTranslation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class CurrentTimeSqlTranslation extends PostgresSqlTranslation {
+
+  public CurrentTimeSqlTranslation() {
+    super(SqlStdOperatorTable.CURRENT_TIME);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var zero = SqlLiteral.createExactNumeric("0", SqlParserPos.ZERO);
+
+    CalciteFunctionUtil.lightweightOp("CURRENT_TIME")
+        .createCall(SqlParserPos.ZERO, zero)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/EltSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/EltSqlTranslation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import java.util.ArrayList;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class EltSqlTranslation extends PostgresSqlTranslation {
+
+  public EltSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightOp("ELT"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var operands = call.getOperandList();
+    var index = operands.get(0);
+    var elements = new ArrayList<>(operands.subList(1, operands.size()));
+
+    var arrayCall =
+        CalciteFunctionUtil.lightweightOp("ARRAY").createCall(SqlParserPos.ZERO, elements);
+
+    SqlStdOperatorTable.ITEM
+        .createCall(SqlParserPos.ZERO, arrayCall, index)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/LocalTimeSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/LocalTimeSqlTranslation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class LocalTimeSqlTranslation extends PostgresSqlTranslation {
+
+  public LocalTimeSqlTranslation() {
+    super(SqlStdOperatorTable.LOCALTIME);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var zero = SqlLiteral.createExactNumeric("0", SqlParserPos.ZERO);
+
+    CalciteFunctionUtil.lightweightOp("LOCALTIME")
+        .createCall(SqlParserPos.ZERO, zero)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/LocalTimestampSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/LocalTimestampSqlTranslation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+@AutoService(SqlTranslation.class)
+public class LocalTimestampSqlTranslation extends PostgresSqlTranslation {
+
+  public LocalTimestampSqlTranslation() {
+    super(SqlStdOperatorTable.LOCALTIMESTAMP);
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    var three = SqlLiteral.createExactNumeric("3", SqlParserPos.ZERO);
+
+    CalciteFunctionUtil.lightweightOp("LOCALTIMESTAMP")
+        .createCall(SqlParserPos.ZERO, three)
+        .unparse(writer, leftPrec, rightPrec);
+  }
+}


### PR DESCRIPTION
## Summary
Implements 4 PostgreSQL function translations (3 date/time functions + 1 string function).

## Functions Added
**Date/Time Functions:**
- **LOCALTIME**: Maps to PostgreSQL LOCALTIME(0) with precision parameter
- **LOCALTIMESTAMP**: Maps to PostgreSQL LOCALTIMESTAMP(3) with precision parameter
- **CURRENT_TIME**: Maps to PostgreSQL CURRENT_TIME(0) with precision parameter

**String Function:**
- **ELT**: Maps to PostgreSQL array indexing using ARRAY[...][index] syntax

## Related Issue
Part of #1696 - PostgreSQL function mapping implementation

## Testing
- Compiled successfully with `mvn clean test-compile`
- All new translation files follow established patterns