### PR TITLE
Add aggregate function: ARRAY_AGG

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayAggSqlTranslation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/builtinflink/ArrayAggSqlTranslation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.function.translation.postgres.builtinflink;
+
+import com.datasqrl.function.CalciteFunctionUtil;
+import com.datasqrl.function.translation.PostgresSqlTranslation;
+import com.datasqrl.function.translation.SqlTranslation;
+import com.google.auto.service.AutoService;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlWriter;
+
+@AutoService(SqlTranslation.class)
+public class ArrayAggSqlTranslation extends PostgresSqlTranslation {
+
+  public ArrayAggSqlTranslation() {
+    super(CalciteFunctionUtil.lightweightAggOp("ARRAY_AGG"));
+  }
+
+  @Override
+  public void unparse(SqlCall call, SqlWriter writer, int leftPrec, int rightPrec) {
+    call.unparse(writer, leftPrec, rightPrec);
+  }
+}


### PR DESCRIPTION
## Summary
Implements PostgreSQL ARRAY_AGG aggregate function translation.

## Functions Added
- **ARRAY_AGG**: PostgreSQL aggregate function that collects values into an array (passthrough implementation)

## Related Issue
Part of #1696 - PostgreSQL function mapping implementation

## Testing
- Compiled successfully with `mvn clean test-compile`
- Uses `lightweightAggOp` similar to existing COLLECT function
- Follows established patterns for aggregate function translations

## Notes
This is a simple passthrough implementation as PostgreSQL natively supports ARRAY_AGG with the same semantics as FlinkSQL.