### PR TITLE
Make CLI command class setup more flexible

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 
-public abstract class AbstractCompileCmd extends AbstractCmd {
+public abstract class AbstractCompileCmd extends BasePackageConfCmd {
 
   public abstract ExecutionGoal getGoal();
 
@@ -99,7 +99,8 @@ public abstract class AbstractCompileCmd extends AbstractCmd {
     if (getGoal() == ExecutionGoal.COMPILE) {
       formatter.phaseStart("Generating deployment artifacts");
     }
-    postprocess(packager, getTargetDir(), plan.getLeft(), plan.getRight());
+
+    packager.postprocess(getTargetDir(), plan.getLeft(), plan.getRight());
 
     if (getGoal() == ExecutionGoal.COMPILE) {
       printCompilationResults(formatter);
@@ -128,11 +129,6 @@ public abstract class AbstractCompileCmd extends AbstractCmd {
     if (!errors.hasErrors()) {
       execute(errors);
     }
-  }
-
-  protected void postprocess(
-      Packager packager, Path targetDir, PhysicalPlan plan, TestPlan testPlan) {
-    packager.postprocess(targetDir, plan, testPlan);
   }
 
   /**

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import com.datasqrl.cli.output.OutputFormatter;
+import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.util.OsProcessManager;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+public abstract class BasePackageConfCmd extends BaseCmd {
+
+  protected static final Path DEFAULT_TARGET_DIR =
+      Path.of(SqrlConstants.BUILD_DIR_NAME, SqrlConstants.DEPLOY_DIR_NAME);
+
+  @Parameters(
+      arity = "0..*",
+      description = "Package configuration file(s)",
+      scope = CommandLine.ScopeType.INHERIT)
+  protected List<Path> packageFiles = Collections.emptyList();
+
+  @Option(
+      names = {"-t", "--target"},
+      description = "Target directory for deployment artifacts and plans")
+  protected Path targetDir = DEFAULT_TARGET_DIR;
+
+  @Option(
+      names = {"-B", "--batch-output"},
+      description = "Run in batch output mode (disable colored output)")
+  protected boolean batchMode = false;
+
+  @Override
+  protected void teardown() {
+    if (!cli.internalTestExec) {
+      getOsProcessManager().teardown(getBuildDir());
+    }
+  }
+
+  protected OutputFormatter getOutputFormatter() {
+    return new OutputFormatter(batchMode);
+  }
+
+  protected OsProcessManager getOsProcessManager() {
+    return new OsProcessManager(System.getenv());
+  }
+
+  protected Path getTargetDir() {
+    if (targetDir.isAbsolute()) {
+      return targetDir;
+    }
+
+    return cli.rootDir.resolve(targetDir);
+  }
+}

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
@@ -21,7 +21,7 @@ import lombok.NonNull;
 import picocli.CommandLine;
 
 @CommandLine.Command(
-    name = "datasqrl",
+    name = "sqrl",
     mixinStandardHelpOptions = true,
     versionProvider = CliVersionProvider.class,
     subcommands = {InitCmd.class, CompileCmd.class, TestCmd.class, RunCmd.class, ExecuteCmd.class})

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecuteCmd.java
@@ -24,7 +24,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "execute",
     description = "Executes an already compiled SQRL script using its existing build artifacts")
-public class ExecuteCmd extends AbstractCmd {
+public class ExecuteCmd extends BasePackageConfCmd {
 
   @Override
   protected void runInternal(ErrorCollector errors) throws Exception {

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/InitCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/InitCmd.java
@@ -15,9 +15,9 @@
  */
 package com.datasqrl.cli;
 
-import static com.datasqrl.config.SqrlConstants.BUILD_DIR_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ResourceUtils;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheFactory;
@@ -32,12 +32,11 @@ import lombok.SneakyThrows;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import picocli.CommandLine;
-import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @CommandLine.Command(name = "init", description = "Initializes an empty SQRL project")
-public class InitCmd implements Runnable, IExitCodeGenerator {
+public class InitCmd extends BaseCmd {
 
   private static final String INIT_PROJECT_DIR = "templates/init-project";
   private static final String PROJECT_NAME_PLACEHOLDER = "__projectname__";
@@ -59,8 +58,8 @@ public class InitCmd implements Runnable, IExitCodeGenerator {
   boolean batch = false;
 
   @Override
-  public void run() {
-    initProject(() -> Path.of('/' + BUILD_DIR_NAME));
+  protected void runInternal(ErrorCollector errors) {
+    initProject(() -> cli.rootDir);
   }
 
   @SneakyThrows
@@ -124,11 +123,6 @@ public class InitCmd implements Runnable, IExitCodeGenerator {
             .replaceFirst("^/", ""); // Strip leading slash
 
     return targetRoot.resolve(subProjectPath);
-  }
-
-  @Override
-  public int getExitCode() {
-    return 0;
   }
 
   public enum ProjectType {

--- a/sqrl-cli/src/main/java/com/datasqrl/util/OsProcessManager.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/util/OsProcessManager.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -103,9 +104,9 @@ public class OsProcessManager {
    * directory and setting proper file ownership.
    *
    * @param buildDir the build directory where logs should be moved and ownership should be set
-   * @throws Exception if log file movement fails or ownership setting encounters errors
    */
-  public void teardown(Path buildDir) throws Exception {
+  @SneakyThrows
+  public void teardown(Path buildDir) {
     Path source = Paths.get(LOGS_PATH);
     Path target = buildDir.resolve("logs");
 


### PR DESCRIPTION
## Key Changes
- **Renamed `AbstractCmd` to `BaseCmd`**: Simplified base command class name for clarity.
- **Introduced `BasePackageConfCmd`**: New intermediate base class that extends `BaseCmd` and provides common functionality for commands that work with package configuration files (`packageFiles`, `targetDir`, `batchMode` options).
- **Refactored command hierarchy**: `AbstractCompileCmd` now extends `BasePackageConfCmd`, inheriting package configuration handling and eliminating code duplication.
- **Removed `postprocess()` wrapper method**: Simplified `AbstractCompileCmd` by calling `packager.postprocess()` directly instead of through an unnecessary wrapper.
- **Updated command inheritance**: Modified `ExecuteCmd` and `InitCmd` to extend the appropriate base class for their needs.

Main motivation for this is to be able to integrate the new `init` and `add-udf` commands in a nicer and simpler way.