### PR TITLE
Redirect stdout/stderr early in test execution to capture Flink output

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
@@ -21,7 +21,6 @@ import static com.datasqrl.env.EnvVariableNames.POSTGRES_USERNAME;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.datasqrl.cli.output.OutputFormatter;
-import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.compile.TestPlan;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.engine.database.relational.JdbcStatement;
@@ -72,7 +71,6 @@ public class DatasqrlTest {
   private final PackageJson sqrlConfig;
   private final Configuration flinkConfig;
   private final Map<String, String> env;
-  private final TestOutputManager outputManager;
   private final OutputFormatter formatter;
 
   @SneakyThrows
@@ -111,7 +109,6 @@ public class DatasqrlTest {
       Thread.sleep(1000);
 
       formatter.sectionHeader("Running Tests");
-      outputManager.redirectStd();
       var subscriptionClients = new ArrayList<SubscriptionClient>();
       // 3. Execute subscription & mutation operations against the API and snapshot results
       if (testPlan != null) {
@@ -247,7 +244,6 @@ public class DatasqrlTest {
     } finally {
       run.cancel();
       Thread.sleep(1000); // wait for log lines to clear out
-      outputManager.restoreStd();
     }
 
     // 6. Print the test results on the command line

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.cli;
 
+import com.datasqrl.cli.output.OutputFormatter;
 import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.env.GlobalEnvironmentStore;
@@ -35,9 +36,11 @@ public class TestCmd extends AbstractCompileCmd {
     }
 
     try (var outputMgr = new TestOutputManager(cli.rootDir)) {
+      outputMgr.init();
       outputMgr.disableConsoleLogs();
 
-      var formatter = getOutputFormatter();
+      var formatter =
+          new OutputFormatter(batchMode, outputMgr.getOriginalOut(), outputMgr.getOriginalErr());
       formatter.header("DataSQRL Test Execution");
 
       var targetDir = getTargetDir();
@@ -53,8 +56,7 @@ public class TestCmd extends AbstractCompileCmd {
       var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
 
       var sqrlTest =
-          new DatasqrlTest(
-              cli.rootDir, planDir, sqrlConfig, flinkConfig, env, outputMgr, formatter);
+          new DatasqrlTest(cli.rootDir, planDir, sqrlConfig, flinkConfig, env, formatter);
       var testExitCode = sqrlTest.run();
       exitCode.set(testExitCode);
 

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/TestOutputManager.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/TestOutputManager.java
@@ -31,30 +31,28 @@ public class TestOutputManager implements AutoCloseable {
 
   private final Path rootDir;
 
-  private PrintStream originalOut;
-  private PrintStream originalErr;
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
   private PrintStream logStream;
 
-  public void redirectStd() {
-    originalOut = System.out;
-    originalErr = System.err;
+  @SneakyThrows
+  public void init() {
+    var logsDir = rootDir.resolve("build/logs");
+    Files.createDirectories(logsDir);
 
-    initLogStream();
+    var logFile = logsDir.resolve(TEST_LOG_FILE).toFile();
+    logStream = new PrintStream(new FileOutputStream(logFile, true));
 
     System.setOut(logStream);
     System.setErr(logStream);
   }
 
-  public void restoreStd() {
-    if (originalOut != null) {
-      System.setOut(originalOut);
-      originalOut = null;
-    }
+  public PrintStream getOriginalOut() {
+    return originalOut;
+  }
 
-    if (originalErr != null) {
-      System.setErr(originalErr);
-      originalErr = null;
-    }
+  public PrintStream getOriginalErr() {
+    return originalErr;
   }
 
   public void disableConsoleLogs() {
@@ -68,27 +66,10 @@ public class TestOutputManager implements AutoCloseable {
     context.updateLoggers();
   }
 
-  @SneakyThrows
-  private void initLogStream() {
-    if (logStream != null) {
-      return;
-    }
-
-    var logsDir = rootDir.resolve("build/logs");
-    Files.createDirectories(logsDir);
-
-    var logFile = logsDir.resolve(TEST_LOG_FILE).toFile();
-    logStream = new PrintStream(new FileOutputStream(logFile, true));
-  }
-
   @Override
-  public void close() throws Exception {
-    if (originalOut != null) {
-      System.setOut(originalOut);
-    }
-    if (originalErr != null) {
-      System.setErr(originalErr);
-    }
+  public void close() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
     if (logStream != null) {
       logStream.close();
     }

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractFullUseCaseTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractFullUseCaseTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.fail;
 import com.datasqrl.cli.AssertStatusHook;
 import com.datasqrl.cli.DatasqrlTest;
 import com.datasqrl.cli.output.OutputFormatter;
-import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.engines.TestContainersForTestGoal;
@@ -133,10 +132,8 @@ abstract class AbstractFullUseCaseTest {
               .resolve(SqrlConstants.DEPLOY_DIR_NAME)
               .resolve(SqrlConstants.PLAN_DIR);
       var flinkConfig = loadInternalTestFlinkConfig(planDir, env);
-      var outputMgr = new TestOutputManager(rootDir);
       var formatter = new OutputFormatter(true);
-      var test =
-          new DatasqrlTest(rootDir, planDir, packageJson, flinkConfig, env, outputMgr, formatter);
+      var test = new DatasqrlTest(rootDir, planDir, packageJson, flinkConfig, env, formatter);
       try {
         var run = test.run();
         if (run != 0) {


### PR DESCRIPTION
## Summary
- Redirect `System.out`/`System.err` earlier in test execution to capture all Flink and library output
- `TestOutputManager.init()` now redirects streams immediately, before Flink starts
- `OutputFormatter` uses original streams so phase messages still appear on console
- Removes now-unnecessary `redirectStd()`/`restoreStd()` calls from `DatasqrlTest`

## Test plan
- [x] `mvn test -pl sqrl-cli` passes
- [x] `mvn test-compile` passes for full project
- [ ] Manual test with Docker to verify Flink output is captured in log file