### PR TITLE
Redirect test output to file and print reports in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,18 @@ commands:
               de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies \
               -T3
 
+  print-test-reports:
+    description: "Print test output files for debugging"
+    steps:
+      - run:
+          name: Print test output files
+          command: ./.circleci/print-test-reports.sh
+          when: always
+
   save-test-results:
     description: "Save test results and upload to Codecov"
     steps:
+      - print-test-reports
       - run:
           name: Save package results
           command: |
@@ -291,6 +300,7 @@ jobs:
               -pl :sqrl-testing-container \
               -Ddocker.image.tag=local-${CIRCLE_SHA1} \
               -Dmcp.inspector.version=$MCP_TAG
+      - save-test-results
 
   deploy:
     docker:

--- a/.circleci/print-test-reports.sh
+++ b/.circleci/print-test-reports.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+for report_dir in $(find . -type d -path "*/target/surefire-reports" -o -path "*/target/failsafe-reports" 2>/dev/null); do
+  if [ -d "$report_dir" ]; then
+    for file in "$report_dir"/*.txt; do
+      if [ -f "$file" ] && [[ ! "$file" =~ -output\.txt$ ]]; then
+        test_name=$(basename "$file" .txt)
+
+        echo ""
+        echo "==== START: $test_name ===="
+        echo "FILE: $file"
+        echo ""
+        cat "$file"
+
+        output_file="${file%.txt}-output.txt"
+        if [ -f "$output_file" ]; then
+          echo ""
+          echo "Console Output:"
+          cat "$output_file"
+        fi
+
+        echo ""
+        echo "==== END: $test_name ===="
+        echo ""
+      fi
+    done
+  fi
+done
+

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     <sortpom.plugin.version>4.0.0</sortpom.plugin.version>
   </properties>
 
@@ -947,8 +948,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <includes>
             <include>**/*Test.java</include>
           </includes>
@@ -960,8 +962,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.4</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <includes>
             <include>**/*IT.java</include>
           </includes>
@@ -1316,14 +1319,12 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-              <redirectTestOutputToFile>true</redirectTestOutputToFile>
             </configuration>
           </plugin>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-              <redirectTestOutputToFile>true</redirectTestOutputToFile>
               <rerunFailingTestsCount>1</rerunFailingTestsCount>
             </configuration>
           </plugin>


### PR DESCRIPTION
## Summary
- Configure Maven surefire/failsafe plugins to redirect test output to files (`redirectTestOutputToFile=true` in root pom.xml)
- Add `print-test-reports` command to CircleCI that prints test output files with visual grouping
- Integrate test report printing in all test jobs (unit-tests, integration-tests, container-e2e-test)

## Test plan
- [ ] Verify CircleCI jobs run successfully
- [ ] Check that test output is captured in surefire-reports/*-output.txt files
- [ ] Confirm print-test-reports step displays grouped output for each test

🤖 Generated with [Claude Code](https://claude.com/claude-code)