### PR TITLE
Fix vertx-web-client missing from shaded CLI JAR

### DIFF
--- a/sqrl-cli/pom.xml
+++ b/sqrl-cli/pom.xml
@@ -335,7 +335,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.datasqrl</groupId>


### PR DESCRIPTION
## Summary
- Remove test scope from `vertx-web-client` dependency in sqrl-cli module
- This fixes `NoClassDefFoundError: sqrl/vertx/ext/web/client/WebClientOptions` when using OAuth2 authentication

## Root Cause
The `OAuth2AuthFactory` in `sqrl-server-vertx-base` uses `WebClient` and `WebClientOptions` for OIDC discovery at runtime. However, in `sqrl-cli/pom.xml`, the `vertx-web-client` dependency was marked as `<scope>test</scope>`, which excluded it from the shaded runtime JAR.

When the shade plugin relocates `io.vertx.*` to `sqrl.vertx.*`, it updates the code references, but the actual `WebClientOptions` class wasn't present because the dependency was test-scoped.

## Test plan
- [x] Run `mvn test -pl sqrl-cli -Deasyjacoco.skip` - passes
- [ ] Deploy and verify OAuth2 authentication works with OIDC providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)