### PR TITLE
Make CLI `-h`, `-V` available on every cmd, update CLI docs

### DIFF
--- a/documentation/docs/compiler.md
+++ b/documentation/docs/compiler.md
@@ -1,6 +1,6 @@
 # DataSQRL Command
 
-The DataSQRL command compiles, runs, and tests SQRL scripts.
+The DataSQRL command initializes, compiles, runs, and tests SQRL projects.
 
 You invoke the DataSQRL command in your terminal or command line.
 Choose your operating system below or use Docker which works on any machine that has Docker installed.
@@ -13,66 +13,192 @@ Always pull the latest Docker image to ensure you have the most recent updates:
 docker pull datasqrl/cmd:latest
 ```
 
-### Global Options
-All commands support the following global options:
+## Command Overview
 
-| Option/Flag Name  | Description                                                                                                                                                                                                                         |
-|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -c or --config    | 	Specifies the path to one or more package configuration files. Contents of multiple files are merged in the specified order. Defaults to package.json in the current directory, generating a default configuration if none exists. |
+The DataSQRL CLI provides the following commands:
 
-Note, that most commands require that you either specify the SQRL script (and, optionally, a GraphQL schema)
-as command line arguments or use the `-c` option to specify a project configuration file that allows you to configure
-all aspects of the project. See the [configuration documentation](configuration.md) for more details.
+```bash
+docker run --rm -v $PWD:/build datasqrl/cmd -h
+```
+
+```
+Usage: sqrl [-hV] [COMMAND]
+  -h, --help      Show this help message and exit.
+  -V, --version   Print version information and exit.
+Commands:
+  init      Initializes an empty SQRL project.
+  add-func  Adds a new function definition into the 'functions' folder of an
+              existing project.
+  compile   Compiles an SQRL project and produces all build artifacts.
+  test      Compiles, then tests a SQRL project.
+  run       Compiles, then runs a SQRL project in a lightweight, standalone
+              environment.
+  exec      Executes an already compiled SQRL script using its existing build
+              artifacts.
+```
+
+:::warning
+You need to mount the current directory (`$PWD` or `${PWD}` on Windows with Powershell) to the `/build`
+directory for file access in Docker.
+:::
+
+:::info
+Note that most commands accept package configuration files as arguments to configure all aspects of the project.
+See the [configuration documentation](configuration.md) for more details.
+:::
+
+## Init Command
+
+The `init` command creates a new SQRL project with the necessary files and directory structure.
+
+```bash
+docker run --rm -v $PWD/<project-folder>:/build datasqrl/cmd init -h
+```
+
+```
+Usage: sqrl init [-hV] [--batch] <projectType> <projectName>
+Initializes an empty SQRL project.
+      <projectType>   Project type. Valid values: STREAM, DATASET, API.
+      <projectName>   Project name — used as the base name for both the SQRL
+                        script and the package configuration files.
+      --batch         Use BATCH mode in Flink.
+  -h, --help          Show this help message and exit.
+  -V, --version       Print version information and exit.
+```
+
+### Example
+
+```bash
+mkdir my-project
+
+docker run --rm -v $PWD/my-project:/build datasqrl/cmd init stream my-project
+```
+
+This creates a new streaming project named `my-project` with the default configuration and directory structure.
+
+## Add-Func Command
+
+The `add-func` command adds a new user-defined function (UDF) to an existing SQRL project.
+
+```bash
+docker run --rm -v $PWD/<project-folder>:/build datasqrl/cmd add-func -h
+```
+
+```
+Usage: sqrl add-func [-hV] [--aggregate] <fnName>
+Adds a new function definition into the 'functions' folder of an existing
+project.
+      <fnName>      Name of the function.
+      --aggregate   Adds an aggregate function instead of the default scalar
+                      one.
+  -h, --help        Show this help message and exit.
+  -V, --version     Print version information and exit.
+```
+
+### Example
+
+```bash
+mkdir my-project
+
+docker run --rm -v $PWD/my-project:/build datasqrl/cmd add-func MyAwesomeFunction
+```
+
+This creates a new scalar function template in the `functions/` directory.
+Use `--aggregate` to create an aggregate function instead.
 
 ## Compile Command
 
-The compile command processes a SQRL script and, optionally, an API specification, into a deployable data pipeline.
-The compile command stages all files needed by the compiler in the `build` directory and output the created deployment
-artifacts for all engines in the `build/deploy` folder.
-
-
+The `compile` command processes a SQRL project into a deployable data pipeline.
+It stages all files needed by the compiler in the `build` directory and outputs the created deployment
+artifacts for all engines in the target folder (defaults to `build/deploy`).
 
 ```bash
-docker run --rm -v $PWD:/build datasqrl/cmd compile myscript.sqrl
+docker run --rm -v $PWD:/build datasqrl/cmd compile -h
 ```
-or
+
+```
+Usage: sqrl compile [-BhV] [-t=<targetFolder>] [<packageFiles>...]
+Compiles an SQRL project and produces all build artifacts.
+      [<packageFiles>...]   Package configuration file(s) of the project.
+                              Default: "package.json".
+  -B, --batch-output        Run in batch output mode (disables colored output).
+  -h, --help                Show this help message and exit.
+  -t, --target=<targetFolder>
+                            Target folder for deployment artifacts and plans.
+                              Default: "build/deploy".
+  -V, --version             Print version information and exit.
+```
+
+### Example
+
 ```bash
-docker run --rm -v $PWD:/build datasqrl/cmd compile -c package.json
+cd my-project
+
+# Defaults to package.json
+docker run --rm -v $PWD:/build datasqrl/cmd compile
 ```
 
-Note, that you need to mount the current directory (`$PWD` or `${PWD}` on windows with Powershell) to the `/build`
-directory for file access in docker.
+Or with a specific package configuration file:
 
+```bash
+cd my-project
 
-| Option/Flag Name | Description                                                                                                                   |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| -a or --api      | Generates an API specification (GraphQL schema) in the file schema.graphqls. Overwrites any existing file with the same name. |
-| -t or --target   | Directory to write deployment artifacts, defaults to build/plan.                                                              |
+docker run --rm -v $PWD:/build datasqrl/cmd compile package-prod.json
+```
 
-Upon successful compilation, the compiler writes the data processing DAG that is planned from the SQRL script into the
-file `build/pipeline_explain.txt` and a visual representation to `build/pipeline_visual.html`.
-Open the latter file in your browser to inspect the data processing DAG.
+### Output
 
+Upon successful compilation, the compiler writes:
+- Data processing DAG to `build/pipeline_explain.txt`
+- Visual representation to `build/pipeline_visual.html` (open in browser to inspect the DAG)
+- Deployment artifacts to the target folder
 
 ## Run Command
 
-The run command compiles and runs the generated data pipeline in docker.
-
+The `run` command compiles and runs the generated data pipeline in Docker.
 
 ```bash
-docker run -it -p 8888:8888 -p 8081:8081 -p 9092:9092 --rm -v $PWD:/build datasqrl/cmd run myscript.sqrl
+docker run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd run -h
 ```
 
-Note, the additional port mappings to access the individual data systems that are running the pipeline.
+```
+Usage: sqrl run [-BhV] [-t=<targetFolder>] [<packageFiles>...]
+Compiles, then runs a SQRL project in a lightweight, standalone environment.
+      [<packageFiles>...]   Package configuration file(s) of the project.
+                              Default: "package.json".
+  -B, --batch-output        Run in batch output mode (disables colored output).
+  -h, --help                Show this help message and exit.
+  -t, --target=<targetFolder>
+                            Target folder for deployment artifacts and plans.
+                              Default: "build/deploy".
+  -V, --version             Print version information and exit.
+```
+
+:::info
+Note the additional port mappings to access the individual data systems that are running the pipeline.
 Additionally, `run` loads [configuration settings](https://raw.githubusercontent.com/DataSQRL/sqrl/refs/heads/main/sqrl-planner/src/main/resources/default-run-package.json)
-that are applicable exclusively during runtime. These `run`-specific configuration options will also be replaced if
-they are defined in any custom `package.json` that is given via the [`-c` compiler config option](#global-options).
+that are applicable exclusively during runtime.
+These `run`-specific configuration options will be replaced if they are defined in any custom package configuration file.
+:::
+
+### Example
+
+```bash
+cd my-project
+
+docker run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 --rm -v $PWD:/build datasqrl/cmd run
+```
+
+This compiles, then runs the SQRL project in the `my-project` folder,
+exposing the Flink UI on port 8081, the Vert.x server on port 8888, and Redpanda on port 9092. 
+
+### Engines
 
 The run command uses the following engines:
 * Flink as the stream engine: The Flink cluster is accessible through the WebUI at [http://localhost:8081/](http://localhost:8081/).
 * Postgres as the transactional database engine
 * Iceberg+DuckDB as the analytic database engine
-* RedPanda as the log engine: The RedPanda cluster is accessible on port 9092 (via Kafka command line tooling).
+* Redpanda as the log engine: The Redpanda cluster is accessible on port 9092 (via Kafka command line tooling).
 * Vertx as the server engine: 
   * The GraphQL API is accessible at [http://localhost:8888/v1/graphiql/](http://localhost:8888/v1/graphiql/).
   * The Swagger UI for the REST API is accessible at [http://localhost:8888/v1/swagger-ui](http://localhost:8888/v1/swagger-ui)
@@ -89,11 +215,10 @@ This allows DataSQRL to map connectors correctly and also applies to [testing](#
 
 ### Data Persistence
 
-To preserve inserted data between runs, mount a directory for RedPanda to persist the data to:
-
+To preserve inserted data between runs, mount a directory for Redpanda to persist the data to:
 
 ```bash
-docker run -it -p 8888:8888 -p 8081:8081 -p 9092:9092 --rm -v /mydata/project:/data/redpanda -v $PWD:/build datasqrl/cmd run myscript.sqrl
+docker run -it -p 8081:8081 -p 8888:8888 -p 9092:9092 --rm -v /mydata/project:/data/redpanda -v $PWD:/build datasqrl/cmd run my-package.json
 ```
 
 The volume mount contains the data written to the log engine and persists it to the local `/mydata/project` directory
@@ -114,14 +239,33 @@ services by your preferred cloud provider.
 ## Test Command
 
 The test command compiles and runs the data pipeline, then executes the provided test API queries and API endpoints
-for all tables annotated with `/*+test */` to snapshot the results.
+for all tables annotated with `/*+ test */` to snapshot the results.
 
 When you first run the test command or add additional test cases, it will create the snapshots and fail.
 All subsequent runs of the test command compare the results to the previously snapshotted results and succeed
 if the results are identical, else fail.
 
 ```bash
-docker run --rm -v $PWD:/build datasqrl/cmd test
+docker run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd test -h
+```
+
+```
+Usage: sqrl test [-BhV] [-t=<targetFolder>] [<packageFiles>...]
+Compiles, then tests a SQRL project.
+      [<packageFiles>...]   Package configuration file(s) of the project.
+                              Default: "package.json".
+  -B, --batch-output        Run in batch output mode (disables colored output).
+  -h, --help                Show this help message and exit.
+  -t, --target=<targetFolder>
+                            Target folder for deployment artifacts and plans.
+                              Default: "build/deploy".
+  -V, --version             Print version information and exit.
+```
+
+### Example
+
+```bash
+docker run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd test
 ```
 
 The Test Command related configuration can be adjusted via the [`test-runner`](configuration.md#test-runner-test-runner) configuration.
@@ -140,3 +284,33 @@ Once all queries complete, the subscriptions are terminated and the data collect
 :::warning
 Subscriptions can only be tested in conjunction with mutations at this time.
 :::
+
+## Exec Command
+
+The exec command executes an already compiled SQRL project using its existing build artifacts, without recompiling.
+This is useful when you want to run a previously compiled pipeline.
+
+```bash
+run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd exec -h
+```
+
+```
+Usage: sqrl exec [-BhV] [-t=<targetFolder>] [<packageFiles>...]
+Executes an already compiled SQRL script using its existing build artifacts.
+      [<packageFiles>...]   Package configuration file(s) of the project.
+                              Default: "package.json".
+  -B, --batch-output        Run in batch output mode (disables colored output).
+  -h, --help                Show this help message and exit.
+  -t, --target=<targetFolder>
+                            Target folder for deployment artifacts and plans.
+                              Default: "build/deploy".
+  -V, --version             Print version information and exit.
+```
+
+### Example
+
+```bash
+cd my-project
+
+docker run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd exec
+```

--- a/sqrl-cli/entrypoint.sh
+++ b/sqrl-cli/entrypoint.sh
@@ -32,5 +32,4 @@ export UDF_PATH=/build/build/deploy/flink/lib
 export BUILD_UID=$(stat -c '%u' /build)
 export BUILD_GID=$(stat -c '%g' /build)
 
-echo "Executing SQRL command: \"$1\" ..."
 exec java $SQRL_JVM_TOOL_OPTS $SQRL_JVM_ARGS -jar /opt/sqrl/sqrl-cli.jar "${@}"

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -56,14 +56,19 @@ public abstract class AbstractCompileCmd extends BasePackageConfCmd {
     }
     var sqrlConfig = initPackageJson(errors, cli.rootDir, packageFiles);
 
-    DirectoryManager.prepareTargetDirectory(getTargetDir());
+    DirectoryManager.prepareTargetDirectory(getTargetFolder());
     errors.checkFatal(
         Files.isDirectory(cli.rootDir), "Not a valid root directory: %s", cli.rootDir);
 
     var injector =
         Guice.createInjector(
             new SqrlInjector(
-                errors, cli.rootDir, getTargetDir(), sqrlConfig, getGoal(), cli.internalTestExec));
+                errors,
+                cli.rootDir,
+                getTargetFolder(),
+                sqrlConfig,
+                getGoal(),
+                cli.internalTestExec));
 
     var engineHolder = injector.getInstance(ExecutionEnginesHolder.class);
     engineHolder.initEnabledEngines();
@@ -101,7 +106,7 @@ public abstract class AbstractCompileCmd extends BasePackageConfCmd {
       formatter.phaseStart("Generating deployment artifacts");
     }
 
-    packager.postprocess(getTargetDir(), plan.getLeft(), plan.getRight());
+    packager.postprocess(getTargetFolder(), plan.getLeft(), plan.getRight());
 
     if (getGoal() == ExecutionGoal.COMPILE) {
       printCompilationResults(formatter);
@@ -166,7 +171,7 @@ public abstract class AbstractCompileCmd extends BasePackageConfCmd {
 
     formatter.newline();
     formatter.sectionHeader("Compilation Results");
-    formatter.info("Deployment artifacts: " + relativizeFromRoot(getTargetDir()));
+    formatter.info("Deployment artifacts: " + relativizeFromRoot(getTargetFolder()));
     formatter.info("Pipeline DAG:         " + relBuildDir.resolve("pipeline_explain.txt"));
     formatter.info("Visual DAG:           " + relBuildDir.resolve("pipeline_visual.html"));
     formatter.newline();

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AddFuncCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AddFuncCmd.java
@@ -25,14 +25,16 @@ import java.nio.file.StandardOpenOption;
 import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(
+@Command(
     name = "add-func",
     description =
-        "Adds a new function definition into the 'functions' folder of an existing project")
+        "Adds a new function definition into the 'functions' folder of an existing project.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
 public class AddFuncCmd extends BaseCmd {
 
   private static final String FN_TEMPLATE_DIR = "templates/functions";
@@ -40,12 +42,12 @@ public class AddFuncCmd extends BaseCmd {
   private static final String AGGREGATE_UDF_TEMPLATE = FN_TEMPLATE_DIR + "/aggregate.java";
   private static final String SCALAR_UDF_TEMPLATE = FN_TEMPLATE_DIR + "/scalar.java";
 
-  @Parameters(index = "0", description = "Name of the function")
+  @Parameters(index = "0", description = "Name of the function.")
   String fnName;
 
   @Option(
       names = {"--aggregate"},
-      description = "Adds an aggregate function instead of the default scalar one")
+      description = "Adds an aggregate function instead of the default scalar one.")
   boolean aggregate = false;
 
   @Override

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
@@ -29,23 +29,23 @@ import picocli.CommandLine.Parameters;
 
 public abstract class BasePackageConfCmd extends BaseCmd {
 
-  protected static final Path DEFAULT_TARGET_DIR =
+  protected static final Path DEFAULT_TARGET =
       Path.of(SqrlConstants.BUILD_DIR_NAME, SqrlConstants.DEPLOY_DIR_NAME);
 
   @Parameters(
       arity = "0..*",
-      description = "Package configuration file(s)",
+      description = "Package configuration file(s) of the project. Default: \"package.json\".",
       scope = CommandLine.ScopeType.INHERIT)
   protected List<Path> packageFiles = Collections.emptyList();
 
   @Option(
       names = {"-t", "--target"},
-      description = "Target directory for deployment artifacts and plans")
-  protected Path targetDir = DEFAULT_TARGET_DIR;
+      description = "Target folder for deployment artifacts and plans. Default: \"build/deploy\".")
+  protected Path targetFolder = DEFAULT_TARGET;
 
   @Option(
       names = {"-B", "--batch-output"},
-      description = "Run in batch output mode (disable colored output)")
+      description = "Run in batch output mode (disables colored output).")
   protected boolean batchMode = false;
 
   @Override
@@ -63,11 +63,11 @@ public abstract class BasePackageConfCmd extends BaseCmd {
     return new OsProcessManager(System.getenv());
   }
 
-  protected Path getTargetDir() {
-    if (targetDir.isAbsolute()) {
-      return targetDir;
+  protected Path getTargetFolder() {
+    if (targetFolder.isAbsolute()) {
+      return targetFolder;
     }
 
-    return cli.rootDir.resolve(targetDir);
+    return cli.rootDir.resolve(targetFolder);
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/CompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/CompileCmd.java
@@ -16,11 +16,13 @@
 package com.datasqrl.cli;
 
 import com.datasqrl.plan.validate.ExecutionGoal;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(
+@Command(
     name = "compile",
-    description = "Compiles an SQRL script and produces all build artifacts")
+    description = "Compiles an SQRL project and produces all build artifacts.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
 public class CompileCmd extends AbstractCompileCmd {
 
   @Override

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlCli.java
@@ -19,8 +19,9 @@ import java.nio.file.Path;
 import lombok.Getter;
 import lombok.NonNull;
 import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(
+@Command(
     name = "sqrl",
     mixinStandardHelpOptions = true,
     versionProvider = CliVersionProvider.class,
@@ -30,7 +31,7 @@ import picocli.CommandLine;
       CompileCmd.class,
       TestCmd.class,
       RunCmd.class,
-      ExecuteCmd.class
+      ExecCmd.class
     })
 @Getter
 public class DatasqrlCli implements Runnable {

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
@@ -19,16 +19,18 @@ import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ConfigLoaderUtils;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(
-    name = "execute",
-    description = "Executes an already compiled SQRL script using its existing build artifacts")
-public class ExecuteCmd extends BasePackageConfCmd {
+@Command(
+    name = "exec",
+    description = "Executes an already compiled SQRL script using its existing build artifacts.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
+public class ExecCmd extends BasePackageConfCmd {
 
   @Override
   protected void runInternal(ErrorCollector errors) throws Exception {
-    var targetDir = getTargetDir();
+    var targetDir = getTargetFolder();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
 
     // Start services before executing

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/InitCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/InitCmd.java
@@ -31,11 +31,15 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.flink.api.common.RuntimeExecutionMode;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(name = "init", description = "Initializes an empty SQRL project")
+@Command(
+    name = "init",
+    description = "Initializes an empty SQRL project.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
 public class InitCmd extends BaseCmd {
 
   private static final String INIT_PROJECT_DIR = "templates/init-project";
@@ -43,18 +47,18 @@ public class InitCmd extends BaseCmd {
 
   private final MustacheFactory mustacheFactory = new DefaultMustacheFactory();
 
-  @Parameters(index = "0", description = "Project type. Valid values: ${COMPLETION-CANDIDATES}")
+  @Parameters(index = "0", description = "Project type. Valid values: ${COMPLETION-CANDIDATES}.")
   ProjectType projectType = ProjectType.STREAM;
 
   @Parameters(
       index = "1",
       description =
-          "Project name. The SQRL script and package config files will be named like this")
+          "Project name — used as the base name for both the SQRL script and the package configuration files.")
   String projectName;
 
   @Option(
       names = {"--batch"},
-      description = "Use BATCH mode in Flink")
+      description = "Use BATCH mode in Flink.")
   boolean batch = false;
 
   @Override

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
@@ -20,11 +20,13 @@ import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.plan.validate.ExecutionGoal;
 import com.datasqrl.util.ConfigLoaderUtils;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(
+@Command(
     name = "run",
-    description = "Compiles, then runs a SQRL script in a lightweight, standalone environment")
+    description = "Compiles, then runs a SQRL project in a lightweight, standalone environment.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
 public class RunCmd extends AbstractCompileCmd {
 
   @Override
@@ -34,7 +36,7 @@ public class RunCmd extends AbstractCompileCmd {
       return;
     }
 
-    var targetDir = getTargetDir();
+    var targetDir = getTargetFolder();
     var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
 
     // Start services before running

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -22,9 +22,13 @@ import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.plan.validate.ExecutionGoal;
 import com.datasqrl.util.ConfigLoaderUtils;
 import java.time.LocalDateTime;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(name = "test", description = "Compiles, then tests a SQRL script")
+@Command(
+    name = "test",
+    description = "Compiles, then tests a SQRL project.",
+    mixinStandardHelpOptions = true,
+    versionProvider = CliVersionProvider.class)
 public class TestCmd extends AbstractCompileCmd {
 
   @Override
@@ -40,7 +44,7 @@ public class TestCmd extends AbstractCompileCmd {
       var formatter = getOutputFormatter();
       formatter.header("DataSQRL Test Execution");
 
-      var targetDir = getTargetDir();
+      var targetDir = getTargetFolder();
       var planDir = targetDir.resolve(SqrlConstants.PLAN_DIR);
 
       // Start services before testing

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/ExecCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/ExecCmdTest.java
@@ -35,26 +35,26 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ExecuteCmdTest {
+class ExecCmdTest {
 
   @Mock private ErrorCollector errors;
   @Mock private Configuration flinkConfig;
 
-  private ExecuteCmd executeCmd;
+  private ExecCmd execCmd;
 
   @TempDir private Path tempDir;
 
   @BeforeEach
   void setup() {
-    executeCmd = spy(new ExecuteCmd());
+    execCmd = spy(new ExecCmd());
   }
 
   @Test
   void runInternal_shouldStartServicesAndRunDatasqrlRun() throws Exception {
-    executeCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+    execCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
 
-    Path buildDir = executeCmd.getBuildDir();
-    Path planDir = executeCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+    Path buildDir = execCmd.getBuildDir();
+    Path planDir = execCmd.getTargetFolder().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
@@ -72,7 +72,7 @@ class ExecuteCmdTest {
               mockConstruction(
                   DatasqrlRun.class, (mock, context) -> when(mock.run()).thenReturn(null))) {
 
-        executeCmd.runInternal(errors);
+        execCmd.runInternal(errors);
 
         // Verify service manager was created and started
         assertThat(serviceManagerMocked.constructed()).hasSize(1);

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/RunCmdTest.java
@@ -63,7 +63,7 @@ class RunCmdTest {
     runCmd.execute(errors);
 
     verify(runCmd).execute(errors);
-    verify(runCmd, never()).getTargetDir();
+    verify(runCmd, never()).getTargetFolder();
   }
 
   @Test
@@ -71,7 +71,7 @@ class RunCmdTest {
     runCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
 
     Path buildDir = runCmd.getBuildDir();
-    Path planDir = runCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+    Path planDir = runCmd.getTargetFolder().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
@@ -57,7 +57,7 @@ class TestCmdTest {
     testCmd.execute(errors);
 
     verify(testCmd).execute(errors);
-    verify(testCmd, never()).getTargetDir();
+    verify(testCmd, never()).getTargetFolder();
   }
 
   @Test
@@ -65,7 +65,7 @@ class TestCmdTest {
     testCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
 
     Path buildDir = testCmd.getBuildDir();
-    Path planDir = testCmd.getTargetDir().resolve(SqrlConstants.PLAN_DIR);
+    Path planDir = testCmd.getTargetFolder().resolve(SqrlConstants.PLAN_DIR);
 
     // Mock static methods and verify arguments
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {


### PR DESCRIPTION
## Key Changes
  - Added -h/--help and -V/--version options to all CLI subcommands
  - Renamed `execute` command to `exec` for brevity
  - Updated CLI documentation (compiler.md) to reflect current command structure with complete help output for all commands (init, add-func, compile, test, run, exec)
  - Improved consistency: Updated descriptions, changed "SQRL script" to "SQRL project", renamed getTargetDir() to getTargetFolder(), and standardized parameter descriptions with proper punctuation