### PR TITLE
Fix setting the script name in package files on `init` cmd and minor improvements

### DIFF
--- a/sqrl-cli/src/main/resources/templates/init-project/__projectname__-prod-package.json.mustache
+++ b/sqrl-cli/src/main/resources/templates/init-project/__projectname__-prod-package.json.mustache
@@ -2,7 +2,7 @@
   "version": "1",
   "enabled-engines": [{{{prod-engines}}}],
   "script": {
-    "main": "hello_world.sqrl",
+    "main": "{{project-name}}.sqrl",
     "config": {
       "source-type": "prod"
     }

--- a/sqrl-cli/src/main/resources/templates/init-project/__projectname__-test-package.json.mustache
+++ b/sqrl-cli/src/main/resources/templates/init-project/__projectname__-test-package.json.mustache
@@ -2,7 +2,7 @@
   "version": "1",
   "enabled-engines": [{{{test-engines}}}],
   "script": {
-    "main": "hello_world.sqrl",
+    "main": "{{project-name}}.sqrl",
     "config": {
       "source-type": "test"
     }

--- a/sqrl-cli/src/main/resources/templates/init-project/__projectname__.sqrl
+++ b/sqrl-cli/src/main/resources/templates/init-project/__projectname__.sqrl
@@ -1,6 +1,6 @@
-IMPORT connectors.sources-{{source-type}} AS sources;
+IMPORT connectors.sources-{{source-type}}.*;
 
-HelloWorld := SELECT * FROM sources.Messages ORDER BY message_time DESC;
+HelloWorld := SELECT * FROM Messages ORDER BY message_time DESC;
 
 /*+ test */
 HelloWorldTest := SELECT COUNT(*) AS message_count FROM HelloWorld;

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/InitCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/InitCmdTest.java
@@ -96,6 +96,10 @@ class InitCmdTest {
     var prodContent = Files.readString(prodPkg);
     var testContent = Files.readString(testPkg);
 
+    // Verify project name is correctly substituted in package JSON files
+    assertThat(prodContent).contains("\"main\": \"%s.sqrl\"".formatted(PROJECT_NAME));
+    assertThat(testContent).contains("\"main\": \"%s.sqrl\"".formatted(PROJECT_NAME));
+
     // Verify type-specific expectations
     switch (type) {
       case STREAM:


### PR DESCRIPTION
# Key Changes
- Fix using the given `projectName` in the generated `package.json` as the main SQRL script
- Generate a `projectName` dir on the given root so the user can map `$PWD:/build` as a Docker volume
- Use inline imports to generate mutations