### PR TITLE
Fix converting query engine config from `package.json` to server-config format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <commons-csv.version>1.14.1</commons-csv.version>
     <commons-exec.version>1.6.0</commons-exec.version>
     <commons-io.version>2.21.0</commons-io.version>
-    <duckdb.version>1.4.2.0</duckdb.version>
+    <duckdb.version>1.4.3.0</duckdb.version>
     <feign.version>13.6</feign.version>
     <freemarker.version>2.3.34</freemarker.version>
     <glassfish.version>3.0.0</glassfish.version>

--- a/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverterImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/QueryEngineConfigConverterImpl.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -38,14 +37,13 @@ public class QueryEngineConfigConverterImpl implements QueryEngineConfigConverte
     for (var engine : enabledQueryEngines) {
       var queryEngine = (QueryEngine) engine;
       var engineConf = packageJson.getEngines().getEngineConfig(queryEngine.getName()).get();
-      var url = engineConf.getSetting("url", Optional.empty());
-      var configMap = engineConf.getConfig();
 
-      if (url != null) {
+      if (engineConf instanceof EngineConfigImpl impl) {
+        var engineConfigMap = impl.sqrlConfig.toMap();
+
         var rootNode = MAPPER.createObjectNode();
-        var configNode = rootNode.putObject(queryEngine.serverConfigName());
-        configNode.put("url", url);
-        configNode.set("config", MAPPER.valueToTree(configMap));
+        var configNode = MAPPER.valueToTree(engineConfigMap);
+        rootNode.set(queryEngine.serverConfigName(), configNode);
 
         convertedConfigs.add(rootNode);
       }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.graphql.config;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -28,6 +30,10 @@ import lombok.Setter;
 public class JdbcConfig {
 
   private String url;
+
+  public void validateConfig() {
+    checkNotNull(url, "The 'url' config must be set");
+  }
 
   @Getter
   @Setter

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
@@ -80,6 +80,11 @@ public class ServerConfig {
       kafkaSubscriptionConfig.validateConfig();
     }
 
+    // Validate DuckDB config if present
+    if (duckDbConfig != null) {
+      duckDbConfig.validateConfig();
+    }
+
     return this;
   }
 


### PR DESCRIPTION
# Key Changes
- Make `QueryEngineConfigConverterImpl` convert the whole engine config as is.
- Add `url` validator for `DuckDbConfig`
- Bump DuckDB JDBC version to current latest (not fixed Glue bug)