### PR TITLE
Add AWS MSK IAM auth library for Kafka authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <autoservice.version>1.1.1</autoservice.version>
     <avro.version>1.12.1</avro.version>
     <awaitility.version>4.3.0</awaitility.version>
+    <aws-msk-iam-auth.version>2.3.5</aws-msk-iam-auth.version>
     <aws-sdk-bom.version>2.40.3</aws-sdk-bom.version>
     <commons-collections4.version>4.5.0</commons-collections4.version>
     <commons-csv.version>1.14.1</commons-csv.version>

--- a/sqrl-server/sqrl-server-vertx-base/pom.xml
+++ b/sqrl-server/sqrl-server-vertx-base/pom.xml
@@ -212,6 +212,11 @@
       <artifactId>vertx-kafka-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>software.amazon.msk</groupId>
+      <artifactId>aws-msk-iam-auth</artifactId>
+      <version>${aws-msk-iam-auth.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- Adds `aws-msk-iam-auth` library (v2.3.5) to enable IAM authentication for AWS MSK Kafka clusters
- This library provides the `IAMClientCallbackHandler` class required for SASL authentication

## Test plan
- [x] Verified dependency resolves correctly
- [x] Build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)