### PR TITLE
Remove some additional project + filter related rules in `LIMITED_RULES`

### DIFF
--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractAssetSnapshotTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractAssetSnapshotTest.java
@@ -197,7 +197,7 @@ public abstract class AbstractAssetSnapshotTest {
   }
 
   protected AssertStatusHook execute(Path rootDir, String... args) {
-    return execute(rootDir, new ArrayList<>(List.of(args)));
+    return execute(rootDir, List.of(args));
   }
 
   /**

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/PredicatePushdownTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/PredicatePushdownTest.java
@@ -77,11 +77,11 @@ class PredicatePushdownTest extends AbstractAssetSnapshotTest {
     executeTest(sqlFile, rules);
   }
 
-  @Disabled("Intended for manual usage")
+  @Disabled("Manual single SQL test")
   @ParameterizedTest
   @EnumSource(PredicatePushdownRules.class)
   void testSingleFile(PredicatePushdownRules rules) throws Exception {
-    var sqlFile = SCRIPT_DIR.resolve("multi-table-source.sql");
+    var sqlFile = SCRIPT_DIR.resolve("project-join-transpose.sql");
     assertThat(sqlFile).isRegularFile();
 
     executeTest(sqlFile, rules);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/filter-project-transpose.sql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/filter-project-transpose.sql
@@ -1,0 +1,25 @@
+CREATE TABLE events (
+  user_id INT,
+  amount INT
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='5',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.amount.min'='0', 'fields.amount.max'='100'
+);
+
+CREATE TABLE dim_users (
+  user_id INT,
+  segment STRING
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='1',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.segment.length'='5'
+);
+
+SELECT e.user_id
+FROM (SELECT user_id, amount + 1 AS amount_plus FROM events) AS e
+         JOIN dim_users AS d
+              ON e.user_id = d.user_id
+WHERE e.amount_plus > 10;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/flink-filter-project-transpose.sql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/flink-filter-project-transpose.sql
@@ -1,0 +1,27 @@
+CREATE TABLE events (
+  user_id INT,
+  ts_ms BIGINT,
+  ts AS TO_TIMESTAMP_LTZ(ts_ms, 3),
+  WATERMARK FOR ts AS ts - INTERVAL '5' SECOND
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='5',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.ts_ms.kind'='sequence', 'fields.ts_ms.start'='0', 'fields.ts_ms.end'='1000'
+);
+
+CREATE TABLE dim_users (
+  user_id INT,
+  segment STRING
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='1',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.segment.length'='5'
+);
+
+SELECT e.user_id
+FROM (SELECT user_id, ts FROM events) AS e
+         JOIN dim_users AS d
+              ON e.user_id = d.user_id
+WHERE e.ts > TO_TIMESTAMP_LTZ(1000, 3);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/project-join-transpose.sql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/predicate-pushdown/project-join-transpose.sql
@@ -1,0 +1,22 @@
+CREATE TABLE events (
+  user_id INT,
+  extra INT
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='5',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.extra.min'='0', 'fields.extra.max'='1'
+);
+
+CREATE TABLE dim_users_hist (
+  user_id INT,
+  segment STRING
+) WITH (
+  'connector'='datagen',
+  'rows-per-second'='1',
+  'fields.user_id.min'='1', 'fields.user_id.max'='3',
+  'fields.segment.length'='5'
+);
+
+SELECT e.user_id + 1 AS uid_score, CHAR_LENGTH(u.segment) AS segment_len
+FROM events AS e JOIN dim_users_hist AS u ON e.user_id = u.user_id;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_default.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_default.txt
@@ -1,0 +1,27 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], amount_plus=[+($1, 1)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[>(+(amount, 1), 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[((amount + 1) > 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_limited_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_limited_rules.txt
@@ -1,0 +1,25 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], amount_plus=[+($1, 1)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, amount_plus, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id, +(amount, 1) AS amount_plus], where=[>(+(amount, 1), 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, amount_plus, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id, (amount + 1) AS amount_plus], where=[((amount + 1) > 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_limited_table_source_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/filter-project-transpose_limited_table_source_rules.txt
@@ -1,0 +1,27 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], amount_plus=[+($1, 1)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[>(+(amount, 1), 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[((amount + 1) > 10)])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, amount])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_default.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_default.txt
@@ -1,0 +1,33 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, TO_TIMESTAMP_LTZ(1000, 3))])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], ts=[$2])
+      :  +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($2, 5000:INTERVAL SECOND)])
+      :     +- LogicalProject(user_id=[$0], ts_ms=[$1], ts=[TO_TIMESTAMP_LTZ($1, 3)])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[>(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)), 1970-01-01 00:00:01:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) > 1970-01-01 00:00:01)])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[(ts - 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_limited_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_limited_rules.txt
@@ -1,0 +1,31 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, TO_TIMESTAMP_LTZ(1000, 3))])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], ts=[$2])
+      :  +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($2, 5000:INTERVAL SECOND)])
+      :     +- LogicalProject(user_id=[$0], ts_ms=[$1], ts=[TO_TIMESTAMP_LTZ($1, 3)])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, ts, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id, CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS ts], where=[>(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)), 1970-01-01 00:00:01:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, ts, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id, CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS ts], where=[(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) > 1970-01-01 00:00:01)])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[(ts - 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_limited_table_source_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/flink-filter-project-transpose_limited_table_source_rules.txt
@@ -1,0 +1,33 @@
+== Abstract Syntax Tree ==
+LogicalProject(user_id=[$0])
++- LogicalFilter(condition=[>($1, TO_TIMESTAMP_LTZ(1000, 3))])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- LogicalProject(user_id=[$0], ts=[$2])
+      :  +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($2, 5000:INTERVAL SECOND)])
+      :     +- LogicalProject(user_id=[$0], ts_ms=[$1], ts=[TO_TIMESTAMP_LTZ($1, 3)])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, events]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim_users]])
+
+== Optimized Physical Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[>(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)), 1970-01-01 00:00:01:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[user_id])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id], where=[(CAST(ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) > 1970-01-01 00:00:01)])
+   :     +- WatermarkAssigner(rowtime=[ts], watermark=[(ts - 5000:INTERVAL SECOND)])
+   :        +- Calc(select=[user_id, TO_TIMESTAMP_LTZ(ts_ms, 3) AS ts])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, ts_ms])
+   +- Exchange(distribution=[hash[user_id]])
+      +- Calc(select=[user_id])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim_users]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/predicate-pushdown-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/predicate-pushdown-package.txt
@@ -1,0 +1,2208 @@
+>>>flink-compiled-plan.json
+{
+  "flinkVersion" : "2.2",
+  "nodes" : [ {
+    "id" : 1,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Customer`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "lastUpdated",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "timestamp",
+              "kind" : "COMPUTED",
+              "expression" : {
+                "rexNode" : {
+                  "kind" : "CALL",
+                  "internalName" : "$COALESCE$1",
+                  "operands" : [ {
+                    "kind" : "CALL",
+                    "internalName" : "$TO_TIMESTAMP_LTZ$1",
+                    "operands" : [ {
+                      "kind" : "INPUT_REF",
+                      "inputIndex" : 3,
+                      "type" : "BIGINT NOT NULL"
+                    }, {
+                      "kind" : "LITERAL",
+                      "value" : 0,
+                      "type" : "INT NOT NULL"
+                    } ],
+                    "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE"
+                  }, {
+                    "kind" : "CALL",
+                    "syntax" : "SPECIAL",
+                    "internalName" : "$CAST$1",
+                    "operands" : [ {
+                      "kind" : "LITERAL",
+                      "value" : "1970-01-01 00:00:00",
+                      "type" : "TIMESTAMP(3) NOT NULL"
+                    } ],
+                    "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                  } ],
+                  "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                },
+                "serializableString" : "COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE))"
+              }
+            } ],
+            "watermarkSpecs" : [ {
+              "rowtimeAttribute" : "timestamp",
+              "expression" : {
+                "rexNode" : {
+                  "kind" : "CALL",
+                  "syntax" : "BINARY",
+                  "internalName" : "$-$1",
+                  "operands" : [ {
+                    "kind" : "INPUT_REF",
+                    "inputIndex" : 4,
+                    "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                  }, {
+                    "kind" : "LITERAL",
+                    "value" : "1",
+                    "type" : "INTERVAL SECOND(6) NOT NULL"
+                  } ],
+                  "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                },
+                "serializableString" : "`timestamp` - INTERVAL '0.001' SECOND"
+              }
+            } ],
+            "primaryKey" : {
+              "name" : "PK_customerid_lastUpdated",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "customerid", "lastUpdated" ]
+            }
+          },
+          "options" : {
+            "connector" : "filesystem",
+            "format" : "flexible-json",
+            "path" : "file:/mock",
+            "source.monitor-interval" : "10 sec"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) NOT NULL, `name` VARCHAR(2147483647) NOT NULL, `lastUpdated` BIGINT NOT NULL>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, Customer]], fields=[customerid, email, name, lastUpdated])"
+  }, {
+    "id" : 2,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "CALL",
+      "internalName" : "$COALESCE$1",
+      "operands" : [ {
+        "kind" : "CALL",
+        "internalName" : "$TO_TIMESTAMP_LTZ$1",
+        "operands" : [ {
+          "kind" : "INPUT_REF",
+          "inputIndex" : 3,
+          "type" : "BIGINT NOT NULL"
+        }, {
+          "kind" : "LITERAL",
+          "value" : 0,
+          "type" : "INT NOT NULL"
+        } ],
+        "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE"
+      }, {
+        "kind" : "LITERAL",
+        "value" : "1970-01-01 08:00:00",
+        "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) NOT NULL, `name` VARCHAR(2147483647) NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL>",
+    "description" : "Calc(select=[customerid, email, name, lastUpdated, COALESCE(TO_TIMESTAMP_LTZ(lastUpdated, 0), 1970-01-01 08:00:00) AS timestamp])"
+  }, {
+    "id" : 3,
+    "type" : "stream-exec-watermark-assigner_1",
+    "watermarkExpr" : {
+      "kind" : "CALL",
+      "syntax" : "BINARY",
+      "internalName" : "$-$1",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 4,
+        "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "kind" : "LITERAL",
+        "value" : "1",
+        "type" : "INTERVAL SECOND(6) NOT NULL"
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    },
+    "rowtimeFieldIndex" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[timestamp], watermark=[(timestamp - 1:INTERVAL SECOND)])"
+  }, {
+    "id" : 4,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Customer_1`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "lastUpdated",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "timestamp",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_customerid_lastUpdated",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "customerid", "lastUpdated" ]
+            }
+          },
+          "options" : {
+            "connector" : "jdbc-sqrl",
+            "driver" : "org.postgresql.Driver",
+            "password" : "${POSTGRES_PASSWORD}",
+            "table-name" : "Customer",
+            "url" : "jdbc:postgresql://${POSTGRES_AUTHORITY}",
+            "username" : "${POSTGRES_USERNAME}"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputUpsertKey" : [ 0, 3 ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.Customer_1], fields=[customerid, email, name, lastUpdated, timestamp])"
+  }, {
+    "id" : 5,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`DistinctCustomer_2`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "lastUpdated",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "timestamp",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_customerid",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "customerid" ]
+            }
+          },
+          "options" : {
+            "connector" : "jdbc-sqrl",
+            "driver" : "org.postgresql.Driver",
+            "password" : "${POSTGRES_PASSWORD}",
+            "table-name" : "DistinctCustomer",
+            "url" : "jdbc:postgresql://${POSTGRES_AUTHORITY}",
+            "username" : "${POSTGRES_USERNAME}"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputUpsertKey" : [ 0, 3 ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.DistinctCustomer_2], fields=[customerid, email, name, lastUpdated, timestamp])"
+  }, {
+    "id" : 6,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Product`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "description",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "category",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "_ingest_time",
+              "dataType" : {
+                "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+                "nullable" : false,
+                "precision" : 3,
+                "kind" : "ROWTIME"
+              }
+            } ],
+            "watermarkSpecs" : [ {
+              "rowtimeAttribute" : "_ingest_time",
+              "expression" : {
+                "rexNode" : {
+                  "kind" : "CALL",
+                  "syntax" : "BINARY",
+                  "internalName" : "$-$1",
+                  "operands" : [ {
+                    "kind" : "INPUT_REF",
+                    "inputIndex" : 4,
+                    "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                  }, {
+                    "kind" : "LITERAL",
+                    "value" : "1",
+                    "type" : "INTERVAL SECOND(6) NOT NULL"
+                  } ],
+                  "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                },
+                "serializableString" : "`_ingest_time` - INTERVAL '0.001' SECOND"
+              }
+            } ],
+            "primaryKey" : {
+              "name" : "PK_productid_name_description_category",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "productid", "name", "description", "category" ]
+            }
+          },
+          "options" : {
+            "connector" : "filesystem",
+            "format" : "flexible-json",
+            "path" : "file:/mock",
+            "source.monitor-interval" : "10 sec"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`productid` BIGINT NOT NULL, `name` VARCHAR(2147483647) NOT NULL, `description` VARCHAR(2147483647) NOT NULL, `category` VARCHAR(2147483647) NOT NULL, `_ingest_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, Product]], fields=[productid, name, description, category, _ingest_time])"
+  }, {
+    "id" : 7,
+    "type" : "stream-exec-watermark-assigner_1",
+    "watermarkExpr" : {
+      "kind" : "CALL",
+      "syntax" : "BINARY",
+      "internalName" : "$-$1",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 4,
+        "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "kind" : "LITERAL",
+        "value" : "1",
+        "type" : "INTERVAL SECOND(6) NOT NULL"
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    },
+    "rowtimeFieldIndex" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[_ingest_time], watermark=[(_ingest_time - 1:INTERVAL SECOND)])"
+  }, {
+    "id" : 8,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`DistinctProduct_3`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "description",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "category",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "_ingest_time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_productid",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "productid" ]
+            }
+          },
+          "options" : {
+            "connector" : "jdbc-sqrl",
+            "driver" : "org.postgresql.Driver",
+            "password" : "${POSTGRES_PASSWORD}",
+            "table-name" : "DistinctProduct",
+            "url" : "jdbc:postgresql://${POSTGRES_AUTHORITY}",
+            "username" : "${POSTGRES_USERNAME}"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputUpsertKey" : [ 0, 1, 2, 3 ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.DistinctProduct_3], fields=[productid, name, description, category, _ingest_time])"
+  }, {
+    "id" : 9,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Orders`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "id",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "time",
+              "dataType" : {
+                "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+                "nullable" : false,
+                "precision" : 3,
+                "kind" : "ROWTIME"
+              }
+            }, {
+              "name" : "entries",
+              "dataType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+            } ],
+            "watermarkSpecs" : [ {
+              "rowtimeAttribute" : "time",
+              "expression" : {
+                "rexNode" : {
+                  "kind" : "CALL",
+                  "syntax" : "BINARY",
+                  "internalName" : "$-$1",
+                  "operands" : [ {
+                    "kind" : "INPUT_REF",
+                    "inputIndex" : 2,
+                    "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                  }, {
+                    "kind" : "LITERAL",
+                    "value" : "1",
+                    "type" : "INTERVAL SECOND(6) NOT NULL"
+                  } ],
+                  "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+                },
+                "serializableString" : "`time` - INTERVAL '0.001' SECOND"
+              }
+            } ],
+            "primaryKey" : {
+              "name" : "PK_id_time",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "id", "time" ]
+            }
+          },
+          "options" : {
+            "connector" : "filesystem",
+            "format" : "flexible-json",
+            "path" : "file:/mock",
+            "source.monitor-interval" : "10 sec"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`id` BIGINT NOT NULL, `customerid` BIGINT NOT NULL, `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL, `entries` ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[id, customerid, time, entries])"
+  }, {
+    "id" : 10,
+    "type" : "stream-exec-watermark-assigner_1",
+    "watermarkExpr" : {
+      "kind" : "CALL",
+      "syntax" : "BINARY",
+      "internalName" : "$-$1",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 2,
+        "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "kind" : "LITERAL",
+        "value" : "1",
+        "type" : "INTERVAL SECOND(6) NOT NULL"
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    },
+    "rowtimeFieldIndex" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[time], watermark=[(time - 1:INTERVAL SECOND)])"
+  }, {
+    "id" : 11,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "ROWTIME"
+      }
+    }, {
+      "kind" : "CALL",
+      "systemName" : "to_jsonb",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      } ],
+      "type" : "RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')"
+      } ]
+    },
+    "description" : "Calc(select=[id, customerid, time, to_jsonb(entries) AS entries])"
+  }, {
+    "id" : 12,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Orders_4`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "id",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            }, {
+              "name" : "entries",
+              "dataType" : "RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_id_time",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "id", "time" ]
+            }
+          },
+          "options" : {
+            "connector" : "jdbc-sqrl",
+            "driver" : "org.postgresql.Driver",
+            "password" : "${POSTGRES_PASSWORD}",
+            "table-name" : "Orders",
+            "url" : "jdbc:postgresql://${POSTGRES_AUTHORITY}",
+            "username" : "${POSTGRES_USERNAME}"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputUpsertKey" : [ 0, 2 ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.Orders_4], fields=[id, customerid, time, entries])"
+  }, {
+    "id" : 13,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Product_5`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "description",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "category",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "_ingest_time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_productid_name_description_category",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "productid", "name", "description", "category" ]
+            }
+          },
+          "options" : {
+            "connector" : "jdbc-sqrl",
+            "driver" : "org.postgresql.Driver",
+            "password" : "${POSTGRES_PASSWORD}",
+            "table-name" : "Product",
+            "url" : "jdbc:postgresql://${POSTGRES_AUTHORITY}",
+            "username" : "${POSTGRES_USERNAME}"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputUpsertKey" : [ 0, 1, 2, 3 ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.Product_5], fields=[productid, name, description, category, _ingest_time])"
+  }, {
+    "id" : 14,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 1 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[customerid]])"
+  }, {
+    "id" : 15,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[customerid]])"
+  }, {
+    "id" : 16,
+    "type" : "stream-exec-deduplicate_1",
+    "configuration" : {
+      "table.exec.deduplicate.insert-update-after-sensitive-enabled" : "true",
+      "table.exec.deduplicate.mini-batch.compact-changes-enabled" : "false",
+      "table.exec.mini-batch.enabled" : "false",
+      "table.exec.mini-batch.size" : "-1"
+    },
+    "uniqueKeys" : [ 0 ],
+    "isRowtime" : true,
+    "keepLastRow" : true,
+    "outputInsertOnly" : false,
+    "generateUpdateBefore" : false,
+    "state" : [ {
+      "index" : 0,
+      "ttl" : "0 ms",
+      "name" : "deduplicateState"
+    } ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Deduplicate(keep=[LastRow], key=[customerid], order=[ROWTIME], outputInsertOnly=[false])"
+  }, {
+    "id" : 17,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[customerid]])"
+  }, {
+    "id" : 18,
+    "type" : "stream-exec-temporal-join_1",
+    "joinSpec" : {
+      "joinType" : "INNER",
+      "leftKeys" : [ 1 ],
+      "rightKeys" : [ 0 ],
+      "filterNulls" : [ true ],
+      "nonEquiCondition" : null
+    },
+    "isTemporalFunctionJoin" : false,
+    "leftTimeAttributeIndex" : 2,
+    "rightTimeAttributeIndex" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    }, {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "TemporalJoin(joinType=[InnerJoin], where=[((customerid = customerid0) AND __TEMPORAL_JOIN_CONDITION(time, timestamp, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(customerid0), __TEMPORAL_JOIN_LEFT_KEY(customerid), __TEMPORAL_JOIN_RIGHT_KEY(customerid0)))], select=[id, customerid, time, entries, customerid0, email, name, lastUpdated, timestamp])"
+  }, {
+    "id" : 19,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "ROWTIME"
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 4,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 6,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 7,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "CALL",
+      "syntax" : "SPECIAL",
+      "internalName" : "$CAST$1",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 8,
+        "type" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ]
+    },
+    "description" : "Calc(select=[id, customerid, time, entries, customerid0, email, name, lastUpdated, CAST(timestamp AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS timestamp])"
+  }, {
+    "id" : 20,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[id]])"
+  }, {
+    "id" : 21,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[productid]])"
+  }, {
+    "id" : 22,
+    "type" : "stream-exec-deduplicate_1",
+    "configuration" : {
+      "table.exec.deduplicate.insert-update-after-sensitive-enabled" : "true",
+      "table.exec.deduplicate.mini-batch.compact-changes-enabled" : "false",
+      "table.exec.mini-batch.enabled" : "false",
+      "table.exec.mini-batch.size" : "-1"
+    },
+    "uniqueKeys" : [ 0 ],
+    "isRowtime" : true,
+    "keepLastRow" : true,
+    "outputInsertOnly" : false,
+    "generateUpdateBefore" : false,
+    "state" : [ {
+      "index" : 0,
+      "ttl" : "0 ms",
+      "name" : "deduplicateState"
+    } ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Deduplicate(keep=[LastRow], key=[productid], order=[ROWTIME], outputInsertOnly=[false])"
+  }, {
+    "id" : 23,
+    "type" : "stream-exec-exchange_1",
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[productid]])"
+  }, {
+    "id" : 24,
+    "type" : "stream-exec-temporal-join_1",
+    "joinSpec" : {
+      "joinType" : "INNER",
+      "leftKeys" : [ 0 ],
+      "rightKeys" : [ 0 ],
+      "filterNulls" : [ true ],
+      "nonEquiCondition" : null
+    },
+    "isTemporalFunctionJoin" : false,
+    "leftTimeAttributeIndex" : 2,
+    "rightTimeAttributeIndex" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    }, {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name0",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "TemporalJoin(joinType=[InnerJoin], where=[((id = productid) AND __TEMPORAL_JOIN_CONDITION(time, _ingest_time, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(productid), __TEMPORAL_JOIN_LEFT_KEY(id), __TEMPORAL_JOIN_RIGHT_KEY(productid)))], select=[id, customerid, time, entries, customerid0, email, name, lastUpdated, timestamp, productid, name0, description, category, _ingest_time])"
+  }, {
+    "id" : 25,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) NOT NULL>",
+    "description" : "Calc(select=[customerid, email])"
+  }, {
+    "id" : 26,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Out3_6`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            } ]
+          },
+          "options" : {
+            "connector" : "print",
+            "print-identifier" : "Out3"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) NOT NULL>",
+    "description" : "Sink(table=[default_catalog.default_database.Out3_6], fields=[customerid, email])"
+  }, {
+    "id" : 27,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 9,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 6,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`productid` BIGINT NOT NULL, `name` VARCHAR(2147483647) NOT NULL>",
+    "description" : "Calc(select=[productid, name])"
+  }, {
+    "id" : 28,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Out4_7`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            } ]
+          },
+          "options" : {
+            "connector" : "print",
+            "print-identifier" : "Out4"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`productid` BIGINT NOT NULL, `name` VARCHAR(2147483647) NOT NULL>",
+    "description" : "Sink(table=[default_catalog.default_database.Out4_7], fields=[productid, name])"
+  }, {
+    "id" : 29,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "ROWTIME"
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 4,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 6,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 7,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 8,
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 9,
+      "type" : "BIGINT NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 10,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 11,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 12,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "CALL",
+      "syntax" : "SPECIAL",
+      "internalName" : "$CAST$1",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 13,
+        "type" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ],
+      "type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name0",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ]
+    },
+    "description" : "Calc(select=[id, customerid, time, entries, customerid0, email, name, lastUpdated, timestamp, productid, name0, description, category, CAST(_ingest_time AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS _ingest_time])"
+  }, {
+    "id" : 30,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Out1_8`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "id",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            }, {
+              "name" : "entries",
+              "dataType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+            }, {
+              "name" : "customerid0",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "lastUpdated",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "timestamp",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            }, {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name0",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "description",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "category",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "_ingest_time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_id_time",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "id", "time" ]
+            }
+          },
+          "options" : {
+            "connector" : "print",
+            "print-identifier" : "Out1"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name0",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.Out1_8], fields=[id, customerid, time, entries, customerid0, email, name, lastUpdated, timestamp, productid, name0, description, category, _ingest_time])"
+  }, {
+    "id" : 31,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`Out2_9`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "id",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "customerid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            }, {
+              "name" : "entries",
+              "dataType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+            }, {
+              "name" : "customerid0",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "name",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "lastUpdated",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "timestamp",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            }, {
+              "name" : "productid",
+              "dataType" : "BIGINT NOT NULL"
+            }, {
+              "name" : "name0",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "description",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "category",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "_ingest_time",
+              "dataType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+            } ],
+            "primaryKey" : {
+              "name" : "PK_id_time",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "id", "time" ]
+            }
+          },
+          "options" : {
+            "connector" : "print",
+            "print-identifier" : "Out2"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "fields" : [ {
+        "name" : "id",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "customerid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "time",
+        "fieldType" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "name" : "entries",
+        "fieldType" : "ARRAY<ROW<`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE> NOT NULL> NOT NULL"
+      }, {
+        "name" : "customerid0",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "email",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "name",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "lastUpdated",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "timestamp",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      }, {
+        "name" : "productid",
+        "fieldType" : "BIGINT NOT NULL"
+      }, {
+        "name" : "name0",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "description",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "category",
+        "fieldType" : "VARCHAR(2147483647) NOT NULL"
+      }, {
+        "name" : "_ingest_time",
+        "fieldType" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.Out2_9], fields=[id, customerid, time, entries, customerid0, email, name, lastUpdated, timestamp, productid, name0, description, category, _ingest_time])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 6,
+    "target" : 7,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 7,
+    "target" : 8,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 9,
+    "target" : 10,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 10,
+    "target" : 11,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 11,
+    "target" : 12,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 7,
+    "target" : 13,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 10,
+    "target" : 14,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 15,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 15,
+    "target" : 16,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 16,
+    "target" : 17,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 14,
+    "target" : 18,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 17,
+    "target" : 18,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 18,
+    "target" : 19,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 19,
+    "target" : 20,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 7,
+    "target" : 21,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 21,
+    "target" : 22,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 22,
+    "target" : 23,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 20,
+    "target" : 24,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 23,
+    "target" : 24,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 24,
+    "target" : 25,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 25,
+    "target" : 26,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 24,
+    "target" : 27,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 27,
+    "target" : 28,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 24,
+    "target" : 29,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 29,
+    "target" : 30,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 29,
+    "target" : 31,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_default.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_default.txt
@@ -1,0 +1,23 @@
+== Abstract Syntax Tree ==
+LogicalProject(uid_score=[+($0, 1)], segment_len=[CHAR_LENGTH($3)])
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, events]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, dim_users_hist]])
+
+== Optimized Physical Plan ==
+Calc(select=[+(user_id, 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[(user_id + 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_limited_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_limited_rules.txt
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(uid_score=[+($0, 1)], segment_len=[CHAR_LENGTH($3)])
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, events]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, dim_users_hist]])
+
+== Optimized Physical Plan ==
+Calc(select=[+(user_id, 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, extra, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[(user_id + 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, extra, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_limited_table_source_rules.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/PredicatePushdownTest/project-join-transpose_limited_table_source_rules.txt
@@ -1,0 +1,23 @@
+== Abstract Syntax Tree ==
+LogicalProject(uid_score=[+($0, 1)], segment_len=[CHAR_LENGTH($3)])
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, events]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, dim_users_hist]])
+
+== Optimized Physical Plan ==
+Calc(select=[+(user_id, 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])
+
+== Optimized Execution Plan ==
+Calc(select=[(user_id + 1) AS uid_score, CHAR_LENGTH(segment) AS segment_len])
++- Join(joinType=[InnerJoin], where=[(user_id = user_id0)], select=[user_id, user_id0, segment], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[user_id]])
+   :  +- Calc(select=[user_id])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, events]], fields=[user_id, extra])
+   +- Exchange(distribution=[hash[user_id]])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim_users_hist]], fields=[user_id, segment])


### PR DESCRIPTION
## Key Changes
- Extend PredicatePushdownRules.LIMITED_RULES to also strip project/filter transpose rules that were still enabling pushdown / plan rewrites:
  - `CoreRules.FILTER_PROJECT_TRANSPOSE`
  - `FlinkFilterProjectTransposeRule.INSTANCE`
  - `FlinkProjectJoinTransposeRule.INSTANCE`
- Add test coverage