### PR TITLE
Fix possible exception during primary key guessing

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/PipelineDAGExporter.java
@@ -101,7 +101,7 @@ public class PipelineDAGExporter {
                       table.getPrimaryKey().isUndefined()
                           ? null
                           : table.getPrimaryKey().asList().stream()
-                              .flatMap(set -> set.getIndexes().stream().sorted())
+                              .flatMap(set -> set.indexes().stream().sorted())
                               .map(fields::get)
                               .map(RelDataTypeField::getName)
                               .toList())

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -553,14 +553,11 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
       var pkBuilder = PrimaryKeyMap.build();
       for (PrimaryKeyMap.ColumnSet colSet : input.primaryKey.asList()) {
         Set<Integer> mappedTo =
-            colSet.getIndexes().stream()
+            colSet.indexes().stream()
                 .flatMap(idx -> mappedProjects.get(idx).stream())
                 .collect(Collectors.toUnmodifiableSet());
         if (mappedTo.isEmpty()) {
           lostPrimaryKeyMapping = true;
-          var pkIdx = colSet.pickBest(inputType);
-          //          errors.notice("Primary key column [%s] is not selected",
-          //              inputType.getFieldList().get(pkIdx).getName());
         } else {
           pkBuilder.add(mappedTo);
         }


### PR DESCRIPTION
## Key Changes

- Made primary-key index selection resilient to bad indexes by ignoring out-of-bounds candidates instead of blindly indexing into the field list.
- Removed an unused “best PK index” lookup that was still executed during analysis even though its result wasn’t used; that lookup could trigger the same out-of-bounds failure.