### PR TITLE
Remove unnecessary Flink connector dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,6 @@
 
     <!-- Flink versions -->
     <flink.version>2.2.0</flink.version>
-    <flink.cdc.version>3.5.0</flink.cdc.version>
-    <flink.connector.jdbc.version>4.0.0-2.0</flink.connector.jdbc.version>
-    <flink.connector.kafka.version>4.0.1-2.0</flink.connector.kafka.version>
     <flink-client.version>1.1.4</flink-client.version>
 
     <!-- Dependency versions -->
@@ -410,11 +407,6 @@
         <artifactId>flink-avro</artifactId>
         <version>${flink.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-avro-confluent-registry</artifactId>
-        <version>${flink.version}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.apache.flink</groupId>
@@ -443,11 +435,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-file-sink-common</artifactId>
-        <version>${flink.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.flink</groupId>
         <artifactId>flink-hadoop-fs</artifactId>
         <version>${flink.version}</version>
       </dependency>
@@ -460,16 +447,6 @@
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-files</artifactId>
         <version>${flink.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-jdbc-postgres</artifactId>
-        <version>${flink.connector.jdbc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-kafka</artifactId>
-        <version>${flink.connector.kafka.version}</version>
       </dependency>
 
       <!-- calcite -->

--- a/sqrl-cli/pom.xml
+++ b/sqrl-cli/pom.xml
@@ -98,24 +98,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-avro-confluent-registry</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-files</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-jdbc-postgres</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-kafka</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-postgres-cdc</artifactId>
-      <version>${flink.cdc.version}</version>
     </dependency>
 
     <!-- Kafka dependencies -->

--- a/sqrl-planner/pom.xml
+++ b/sqrl-planner/pom.xml
@@ -117,10 +117,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-jdbc-postgres</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-common</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Connectors come through the `flink-sql-runner` deps already, so no reason to specify them here.