### PR TITLE
Make `compile` and `test` CLI output more consistent

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -167,22 +167,18 @@ public abstract class AbstractCompileCmd extends BasePackageConfCmd {
   }
 
   private void printCompilationResults(OutputFormatter formatter) {
-    var relBuildDir = relativizeFromRoot(getBuildDir());
+    var relBuildDir = formatter.relativizeFromCliRoot(getBuildDir());
 
-    formatter.newline();
     formatter.sectionHeader("Compilation Results");
-    formatter.info("Deployment artifacts: " + relativizeFromRoot(getTargetFolder()));
+    formatter.info("Deployment artifacts: " + formatter.relativizeFromCliRoot(getTargetFolder()));
     formatter.info("Pipeline DAG:         " + relBuildDir.resolve("pipeline_explain.txt"));
     formatter.info("Visual DAG:           " + relBuildDir.resolve("pipeline_visual.html"));
     formatter.newline();
     formatter.buildStatus(true, getElapsedTime(), LocalDateTime.now());
+    formatter.newline();
   }
 
   private boolean loadRunDefaults() {
     return getGoal() == ExecutionGoal.RUN || getGoal() == ExecutionGoal.TEST;
-  }
-
-  private Path relativizeFromRoot(Path path) {
-    return path == null || !path.startsWith(cli.rootDir) ? path : cli.rootDir.relativize(path);
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
@@ -56,7 +56,9 @@ public abstract class BasePackageConfCmd extends BaseCmd {
   }
 
   protected OutputFormatter getOutputFormatter() {
-    return cli.internalTestExec ? new NoOutputFormatter() : new DefaultOutputFormatter(batchMode);
+    return cli.internalTestExec
+        ? new NoOutputFormatter()
+        : new DefaultOutputFormatter(cli.rootDir, batchMode);
   }
 
   protected OsProcessManager getOsProcessManager() {

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -67,6 +67,7 @@ public class TestCmd extends AbstractCompileCmd {
 
       if (!success) {
         formatter.helpLink("Help 1", "https://docs.datasqrl.com/docs/howto/testing");
+        formatter.newline();
       }
     }
   }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/NoOutputFormatter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/NoOutputFormatter.java
@@ -63,5 +63,5 @@ public class NoOutputFormatter implements OutputFormatter {
 
   @Override
   public void failureDetails(
-      String testName, String testFile, String expectedFile, String actualFile, String diffFile) {}
+      String testName, String testFile, String expectedFile, String actualFile) {}
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/OutputFormatter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/OutputFormatter.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.cli.output;
 
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 
 public interface OutputFormatter {
@@ -47,6 +48,9 @@ public interface OutputFormatter {
 
   void testSummary(int totalTests, int failures);
 
-  void failureDetails(
-      String testName, String testFile, String expectedFile, String actualFile, String diffFile);
+  void failureDetails(String testName, String testFile, String expectedFile, String actualFile);
+
+  default Path relativizeFromCliRoot(Path path) {
+    return path;
+  }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractFullUseCaseTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractFullUseCaseTest.java
@@ -142,7 +142,7 @@ abstract class AbstractFullUseCaseTest {
               flinkConfig,
               env,
               outputMgr,
-              new DefaultOutputFormatter(false));
+              new DefaultOutputFormatter(rootDir, false));
       try {
         var run = test.run();
         if (run != 0) {

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
@@ -49,7 +49,7 @@ public class FullUseCaseIT extends AbstractFullUseCaseTest {
   @Test
   @Disabled("Intended for manual usage")
   void specificUseCase() {
-    var pkg = USE_CASES.resolve("banking").resolve("package.json");
+    var pkg = USE_CASES.resolve("repository").resolve("package.json");
 
     var param = new UseCaseParam(pkg);
     fullUseCaseTest(param);


### PR DESCRIPTION
## Key Changes
- Removed diff file related content from test output
- Removed non-existing `Flink metrics` log entry from "Test Reports" section
- Updated code that presents snapshot and test dirs to use relative path from CLI root instead of wrong hardcoded paths
- Made newlines more consistent for both `compile` and `test`
- Added extra newlines and some extra marking for the test case names to make snapshot mismatch output easier to read for humans