### PR TITLE
Add schedule configuration to Flink deployment

### DIFF
--- a/documentation/docs/configuration-engine/flink.md
+++ b/documentation/docs/configuration-engine/flink.md
@@ -44,6 +44,7 @@ Flink supports deployment-specific configuration options for managing cluster re
 | `taskmanager-size`  | **string**  | -       | Task manager instance size with resource variants               |
 | `taskmanager-count` | **integer** | -       | Number of task manager instances (minimum: 1)                   |
 | `secrets`           | **array**   | `null`  | Array of secret names to inject, or `null` if no secrets needed |
+| `schedule`          | **object**  | -       | Schedule for periodic awakening of the Flink job                |
 
 ### Task Manager Size Options
 
@@ -53,6 +54,15 @@ Available `taskmanager-size` options with resource variants:
 - `medium`, `medium.mem`, `medium.cpu` - Medium instances with resource variants  
 - `large`, `large.mem`, `large.cpu` - Large instances with resource variants
 
+### Schedule Configuration
+
+The `schedule` object configures periodic awakening of the Flink job. Both `cron` and `timezone` are required when a schedule is configured.
+
+| Key        | Type       | Required | Description                                                        |
+|------------|------------|----------|--------------------------------------------------------------------|
+| `cron`     | **string** | Yes      | Cron expression defining the schedule (e.g. `"0 0 * * *"`)        |
+| `timezone` | **string** | Yes      | IANA timezone for the cron expression (e.g. `"America/New_York"`) |
+
 ### Deployment Example
 
 ```json
@@ -61,9 +71,13 @@ Available `taskmanager-size` options with resource variants:
     "flink": {
       "deployment": {
         "jobmanager-size": "small",
-        "taskmanager-size": "medium.mem", 
+        "taskmanager-size": "medium.mem",
         "taskmanager-count": 2,
-        "secrets": ["flink-secrets", "db-credentials"]
+        "secrets": ["flink-secrets", "db-credentials"],
+        "schedule": {
+          "cron": "0 */6 * * *",
+          "timezone": "UTC"
+        }
       }
     }
   }

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -216,9 +216,23 @@
                       "minItems": 1
                     }
                   ]
+                },
+                "schedule": {
+                  "description": "Schedule for periodic awakening of the Flink job",
+                  "type": "object",
+                  "properties": {
+                    "cron": {
+                      "type": "string"
+                    },
+                    "timezone": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["cron", "timezone"],
+                  "additionalProperties": false
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": true
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary
- Adds `schedule` object (with required `cron` and `timezone` fields) under `engines.flink.deployment` in the package.json schema for periodic Flink job awakening
- Changes `additionalProperties` to `true` on the Flink deployment section to allow cloud-specific fields without hard schema dependency
- Updates Flink engine documentation with schedule configuration details and example

## Test plan
- [x] `sqrl-planner` unit tests pass (173 tests, 0 failures)
- [ ] Verify schema validation accepts valid schedule config
- [ ] Verify schema validation rejects schedule with only one of cron/timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)