### PR TITLE
Allow additional properties in engine deployment sections

### DIFF
--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -281,7 +281,7 @@
                   "minimum": 1
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": true
             }
           },
           "additionalProperties": false
@@ -305,7 +305,7 @@
                   "minimum": 0
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": true
             }
           },
           "additionalProperties": false
@@ -330,7 +330,7 @@
               "type": "string"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       }
     },


### PR DESCRIPTION
## Summary
- Sets `additionalProperties: true` on the `deployment` sections for **vertx** and **postgres** engines
- Sets `additionalProperties: true` on the **kafka** engine (which has no deployment sub-object)
- This allows cloud-specific fields to be added without requiring schema changes, reducing hard dependencies

Follow-up from [#1847 review](https://github.com/DataSQRL/sqrl/pull/1847#pullrequestreview-3780680860).

## Test plan
- [x] `sqrl-planner` unit tests pass (173 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)