### PR TITLE
Add Hadoop core-site.xml for S3A IRSA credential support

### DIFF
--- a/sqrl-cli/Dockerfile
+++ b/sqrl-cli/Dockerfile
@@ -22,8 +22,10 @@ COPY pg_hba.conf /etc/postgresql/${POSTGRES_VERSION}/main/pg_hba.conf
 COPY redpanda.yaml /etc/redpanda/redpanda.yaml
 COPY target/sqrl-cli.jar /opt/sqrl/sqrl-cli.jar
 COPY entrypoint.sh /opt/sqrl/entrypoint.sh
+COPY core-site.xml /opt/sqrl/hadoop-conf/core-site.xml
 
 ENV PATH="/opt/jbang/bin:${PATH}"
+ENV HADOOP_CONF_DIR="/opt/sqrl/hadoop-conf"
 ENV SQRL_JVM_TOOL_OPTS="--add-exports=java.base/sun.net.util=ALL-UNNAMED \
   --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/sqrl-cli/core-site.xml
+++ b/sqrl-cli/core-site.xml
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright © 2021 DataSQRL (contact@datasqrl.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+  <property>
+    <name>fs.s3a.aws.credentials.provider</name>
+    <value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value>
+  </property>
+</configuration>


### PR DESCRIPTION
## Summary

- Adds `core-site.xml` with `DefaultAWSCredentialsProviderChain` for Hadoop S3A credential resolution
- Sets `HADOOP_CONF_DIR` in the CLI Dockerfile so Iceberg/Flink picks up the config

## Problem

When compiling SQRL projects with Iceberg Hadoop catalog on S3 (`compile-flink-plan: true`), `tEnv.compilePlan()` triggers Iceberg's `FlinkDynamicTableFactory` → `HadoopCatalog.isDirectory()` which tries to access S3. On EKS pods with IRSA, the credentials are provided via `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`, but Hadoop 3.3.4's default S3A credential chain only tries:

- `TemporaryAWSCredentialsProvider`
- `SimpleAWSCredentialsProvider`
- `EnvironmentVariableCredentialsProvider`
- `IAMInstanceCredentialsProvider`

It does **not** include `WebIdentityTokenCredentialsProvider` (added to defaults in Hadoop 3.3.5+).

Iceberg loads Hadoop config via `FlinkCatalogFactory.clusterHadoopConf()` → `HadoopUtils.getHadoopConfiguration()`, which reads `core-site.xml` from `HADOOP_CONF_DIR`, not from the Java classpath.

## Manual testing on EKS pod

Verified on `cloud-compilation-677cb7f9bf-b7cpk` in the `cloud-compilation` namespace:

**Before** (no `HADOOP_CONF_DIR`):
```
com.datasqrl.util.FlinkCompileException: org.apache.flink.table.api.ValidationException:
Unable to create a sink for writing table 'default_catalog.default_database.Aggregation_1'.
...
Caused by: org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException: No AWS Credentials provided
by TemporaryAWSCredentialsProvider SimpleAWSCredentialsProvider
EnvironmentVariableCredentialsProvider IAMInstanceCredentialsProvider
```

**After** (`HADOOP_CONF_DIR=/opt/sqrl/conf` with `core-site.xml`):
```
------------------------------------------------------------------------
DataSQRL Compilation
------------------------------------------------------------------------

Initializing build environment ...
Processing dependencies ...
Compiling SQRL script ...
Generating deployment artifacts ...

------------------------------------------------------------------------
Compilation Results
------------------------------------------------------------------------

Deployment artifacts: build/deploy
Pipeline DAG:         build/pipeline_explain.txt
Visual DAG:           build/pipeline_visual.html

------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  10 s
```

## Test plan

- [x] `mvn test -pl sqrl-cli` passes (82 tests, 0 failures)
- [ ] Rebuild Docker image and verify Iceberg compilation works end-to-end