### PR TITLE
Bump MCP inspector Node from 20 to 25.6.1

### DIFF
--- a/Dockerfile.mcp-inspector
+++ b/Dockerfile.mcp-inspector
@@ -1,6 +1,6 @@
 # MCP Inspector Docker Image
 # Pre-installs @modelcontextprotocol/inspector for faster test execution
-FROM node:20-alpine
+FROM node:25.6.1-alpine
 
 # Update npm to latest version and install MCP inspector globally
 RUN npm install -g npm@11.4.2 && \


### PR DESCRIPTION
## Summary
- Bump `node:20-alpine` to `node:25.6.1-alpine` in `Dockerfile.mcp-inspector`
- Using fully versioned tag so Dependabot can track future patch releases

## Test plan
- [x] Docker build succeeds with `node:25.6.1-alpine`
- [x] `@modelcontextprotocol/inspector` installs and runs correctly