### PR TITLE
Add disk-size-gb to postgres deployment schema

### DIFF
--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -289,6 +289,10 @@
                 "replica-count": {
                   "type": "integer",
                   "minimum": 0
+                },
+                "disk-size-gb": {
+                  "type": "integer",
+                  "minimum": 1
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
## Summary
- Adds `disk-size-gb` (integer, minimum 1) to the postgres deployment section of `packageSchema.json`
- Allows users to override PostgreSQL storage size via package.json

## Related
- Cloud compilation PR: https://github.com/DataSQRL/cloud-compilation/pull/617

## Test plan
- [x] JSON schema validates as well-formed
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)