### PR TITLE
Ignore Dependabot alerts for documentation npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm"
+    directory: "/documentation"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+


### PR DESCRIPTION
## Summary
- Adds an npm ecosystem entry to `.github/dependabot.yml` for the `/documentation` directory with all dependencies ignored
- This suppresses the flood of security alerts from `documentation/package-lock.json` which is just our docs site (Docusaurus) and not production code

## Discussion points
- Alternative: we could just delete `documentation/package-lock.json` from the repo entirely
- Alternative: run `npm audit fix` to update the lock file (but new alerts will keep appearing)
- This config only suppresses version update PRs — existing security alerts on the Security tab may need to be bulk-dismissed manually

## Test plan
- [x] Config-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)