### PR TITLE
feat: add mem-headroom to taskmanager-size enum

### DIFF
--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -196,7 +196,7 @@
                 },
                 "taskmanager-size": {
                   "type": "string",
-                  "enum": ["dev", "small", "small.mem", "small.cpu", "medium", "medium.mem", "medium.cpu", "large", "large.mem", "large.cpu"]
+                  "enum": ["dev", "small", "small.mem", "small.cpu", "small.mem-headroom", "medium", "medium.mem", "medium.cpu", "medium.mem-headroom", "large", "large.mem", "large.cpu", "large.mem-headroom"]
                 },
                 "taskmanager-count": {
                   "type": "integer",


### PR DESCRIPTION
## Summary
- Adds `small.mem-headroom`, `medium.mem-headroom`, `large.mem-headroom` to the `taskmanager-size` enum in `packageSchema.json`
- This allows users to configure Flink TaskManagers with 3x pod memory but 1x Flink process memory, giving extra OS-level headroom for native memory and RocksDB

## Related
- Required by: https://github.com/DataSQRL/cloud-compilation (feat/mem-headroom-modifier branch)

## Test plan
- [ ] Verify schema validation accepts `small.mem-headroom`, `medium.mem-headroom`, `large.mem-headroom`
- [ ] Verify existing taskmanager-size values still work