### PR TITLE
feat: Support using custom GraphQL schema for test runner

### DIFF
--- a/documentation/docs/configuration-default.md
+++ b/documentation/docs/configuration-default.md
@@ -92,6 +92,7 @@ The following is the [default configuration file](https://raw.githubusercontent.
   "test-runner": {
     "snapshot-folder": "./snapshots",
     "test-folder": "./tests",
+    "use-inferred-schema": true,
     "delay-sec": 30,
     "mutation-delay-sec": 0,
     "required-checkpoints": 0

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -95,16 +95,17 @@ MyTable := SELECT
 Configures how the DataSQRL test runner executes tests.
 For streaming pipelines, use `required-checkpoints` to set a reliable time-interval for creating snapshots. Otherwise, configure a wall-clock delay via `delay-sec`.
 
-```json
+```json5
 {
   "test-runner": {
     "snapshot-folder": "snapshots/myproject/", // Snapshots output directory (default: "./snapshots")
     "test-folder": "api/tests/",               // Directory containing test GraphQL queries (default: "./tests")
-    "delay-sec": 30,                          // Wait between data-load and taking snapshot in sec. Set -1 to disable (default: 30)
-    "mutation-delay-sec": 0,                  // Pause(s) between mutation queries (default: 0)
-    "required-checkpoints": 0,                // Minimum completed Flink checkpoints before taking snapshots (requires delay-sec = -1)
-    "create-topics": ["topic1", "topic2"],    // Kafka topics to create before tests start
-    "headers": {                              // Any HTTP headers to add during the test execution. For example, JWT auth header
+    "use-inferred-schema": true,               // Use inferred GraphQL schema when true, else use the one configured at "script.graphql" (default: true)
+    "delay-sec": 30,                           // Wait between data-load and taking snapshot in sec. Set -1 to disable (default: 30)
+    "mutation-delay-sec": 0,                   // Pause(s) between mutation queries (default: 0)
+    "required-checkpoints": 0,                 // Minimum completed Flink checkpoints before taking snapshots (requires delay-sec = -1)
+    "create-topics": ["topic1", "topic2"],     // Kafka topics to create before tests start
+    "headers": {                               // Any HTTP headers to add during the test execution. For example, JWT auth header
       "Authorization": "Bearer token"
     }
   }

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -87,7 +87,7 @@ public class CompilationProcess {
 
       var apiVersions = graphqlSourceLoader.getApiVersions();
       if (apiVersions.isEmpty()
-          || executionGoal == ExecutionGoal.TEST) { // Infer schema from functions
+          || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema())) {
 
         var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
         apiVersions = List.of(new ApiSources(inferredSchema));

--- a/sqrl-planner/src/main/java/com/datasqrl/config/TestRunnerConfigImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/TestRunnerConfigImpl.java
@@ -45,6 +45,11 @@ public class TestRunnerConfigImpl implements TestRunnerConfiguration {
   }
 
   @Override
+  public boolean useInferredSchema() {
+    return sqrlConfig.asBool("use-inferred-schema").get();
+  }
+
+  @Override
   public int getDelaySec() {
     return sqrlConfig.asInt("delay-sec").get();
   }

--- a/sqrl-planner/src/main/java/com/datasqrl/config/TestRunnerConfiguration.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/TestRunnerConfiguration.java
@@ -26,6 +26,8 @@ public interface TestRunnerConfiguration {
 
   Optional<Path> getTestDir(Path rootDir);
 
+  boolean useInferredSchema();
+
   int getDelaySec();
 
   int getMutationDelaySec();

--- a/sqrl-planner/src/main/resources/default-package.json
+++ b/sqrl-planner/src/main/resources/default-package.json
@@ -87,6 +87,7 @@
   "test-runner": {
     "snapshot-folder": "./snapshots",
     "test-folder": "./tests",
+    "use-inferred-schema": true,
     "delay-sec": 30,
     "mutation-delay-sec": 0,
     "required-checkpoints": 0

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -308,6 +308,9 @@
         "test-folder": {
           "type": "string"
         },
+        "use-inferred-schema": {
+          "type": "boolean"
+        },
         "delay-sec": {
           "type": "integer"
         },

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
@@ -49,7 +49,7 @@ public class FullUseCaseIT extends AbstractFullUseCaseTest {
   @Test
   @Disabled("Intended for manual usage")
   void specificUseCase() {
-    var pkg = USE_CASES.resolve("function-translation/duckdb").resolve("package.json");
+    var pkg = USE_CASES.resolve("repository").resolve("package.json");
 
     var param = new UseCaseParam(pkg);
     fullUseCaseTest(param);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -585,7 +585,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
           },
           "format" : "JSON",
           "apiQuery" : {
-            "query" : "query TopicPackages($topicName: String!, $limit: Int = 10, $offset: Int = 0) {\nTopicPackages(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\npkgName\nlastSubmission\nnumSubmissions\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
+            "query" : "query TopicPackages($topicName: String! = \"example\", $limit: Int = 10, $offset: Int = 0) {\nTopicPackages(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\npkgName\nlastSubmission\nnumSubmissions\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
             "queryName" : "TopicPackages",
             "operationType" : "QUERY"
           },
@@ -596,7 +596,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "type Package {\n  name: String!\n  latest: Submission\n  versions(version: String!, variant: String!, limit: Int = 10, offset: Int = 0): [Submission!]\n}\n\ntype Query {\n  Package(name: String!, limit: Int = 10, offset: Int = 0): [Package!]\n  TopicSearch(topicName: String, limit: Int = 10, offset: Int = 0): [TopicSearch!]\n  TopicPackages(topicName: String!, limit: Int = 10, offset: Int = 0): [TopicPackages!]\n}\n\ntype Submission {\n  name: String!\n  version: String!\n  variant: String!\n  latest: Boolean!\n  type: String\n  license: String\n  repository: String\n  homepage: String\n  documentation: String\n  readme: String\n  description: String\n  uniqueId: String!\n  keywords: [String!]\n  repoURL: String!\n  file: String!\n  hash: String!\n  submissionTime: String!\n}\n\ntype TopicSearch {\n  topicName: String!\n  numPackages: Int!\n}\n\ntype TopicPackages {\n  topicName: String!\n  pkgName: String!\n  lastSubmission: String!\n  numSubmissions: Int!\n  latest: Submission\n}"
+        "schema" : "type Package {\n  name: String!\n  latest: Submission\n  versions(version: String!, variant: String!, limit: Int = 10, offset: Int = 0): [Submission!]\n}\n\ntype Query {\n  Package(name: String!, limit: Int = 10, offset: Int = 0): [Package!]\n  TopicSearch(topicName: String, limit: Int = 10, offset: Int = 0): [TopicSearch!]\n  TopicPackages(topicName: String! = \"example\", limit: Int = 10, offset: Int = 0): [TopicPackages!]\n}\n\ntype Submission {\n  name: String!\n  version: String!\n  variant: String!\n  latest: Boolean!\n  type: String\n  license: String\n  repository: String\n  homepage: String\n  documentation: String\n  readme: String\n  description: String\n  uniqueId: String!\n  keywords: [String!]\n  repoURL: String!\n  file: String!\n  hash: String!\n  submissionTime: String!\n}\n\ntype TopicSearch {\n  topicName: String!\n  numPackages: Int!\n}\n\ntype TopicPackages {\n  topicName: String!\n  pkgName: String!\n  lastSubmission: String!\n  numSubmissions: Int!\n  latest: Submission\n}"
       }
     }
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/package.json
@@ -8,6 +8,7 @@
   "test-runner": {
     "snapshot-folder": "snapshots-repo",
     "test-folder": "tests-repo",
+    "use-inferred-schema": false,
     "delay-sec": -1
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/repo.graphqls
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/repo.graphqls
@@ -7,7 +7,7 @@ type Package {
 type Query {
   Package(name: String!, limit: Int = 10, offset: Int = 0): [Package!]
   TopicSearch(topicName: String, limit: Int = 10, offset: Int = 0): [TopicSearch!]
-  TopicPackages(topicName: String!, limit: Int = 10, offset: Int = 0): [TopicPackages!]
+  TopicPackages(topicName: String! = "example", limit: Int = 10, offset: Int = 0): [TopicPackages!]
 }
 
 type Submission {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/tests-repo/topicpkg-query.graphql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/repository/tests-repo/topicpkg-query.graphql
@@ -1,5 +1,5 @@
 {
-  TopicPackages(topicName: "example") {
+  TopicPackages {
     topicName
     pkgName
     numSubmissions


### PR DESCRIPTION
## Key Changes
- Introduce `use-inferred-schema` flad under `test-runner` config
- The new flag controls whether `test` command should use the inferred GraphQL schema, or the one provided by the user (if any)
- Adapted `repositroy` use-case to cover this logic