### PR TITLE
feat: Generate split SQL deployment artifacts for multi-batch projects

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPhysicalPlan.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPhysicalPlan.java
@@ -23,7 +23,9 @@ import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
 import com.datasqrl.planner.tables.FlinkConnectorConfigWrapper;
 import com.datasqrl.planner.util.CompiledPlanCondenser;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -65,6 +67,8 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
   @JsonIgnore Optional<String> explainedPlan;
   @JsonIgnore List<String> flinkSqlNoFunctions;
   @JsonIgnore Configuration config;
+  @JsonIgnore ListMultimap<Integer, String> flinkSqlBatched;
+  @JsonIgnore ListMultimap<Integer, String> flinkSqlNoFunctionsBatched;
 
   @Override
   public List<DeploymentArtifact> getDeploymentArtifacts() {
@@ -76,6 +80,9 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
             "-sql-no-functions.sql", DeploymentArtifact.toSqlString(flinkSqlNoFunctions)),
         new DeploymentArtifact("-functions.sql", DeploymentArtifact.toSqlString(functions)));
 
+    convertNestedList(flinkSqlBatched, "-sql").ifPresent(builder::addAll);
+    convertNestedList(flinkSqlNoFunctionsBatched, "-sql-no-functions").ifPresent(builder::addAll);
+
     compiledPlan.map(plan -> builder.add(new DeploymentArtifact("-compiled-plan.json", plan)));
     compiledPlan
         .map(CompiledPlanCondenser::condense)
@@ -83,6 +90,34 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
     explainedPlan.map(plan -> builder.add(new DeploymentArtifact("-explained-plan.txt", plan)));
 
     return builder.build();
+  }
+
+  /**
+   * Converts a nested list of SQL statement batches into numbered deployment artifacts. Returns
+   * empty if the list contains fewer than 2 batches, as a single batch does not require splitting.
+   *
+   * @param sqlBatches list of SQL statement batches to convert
+   * @param suffixName suffix used to name each artifact (e.g. "-sql" produces "-sql-0.sql")
+   * @return an optional list of deployment artifacts, one per batch
+   */
+  private static Optional<List<DeploymentArtifact>> convertNestedList(
+      ListMultimap<Integer, String> sqlBatches, String suffixName) {
+
+    var batchNum = sqlBatches.keySet().size();
+    if (batchNum < 2) {
+      return Optional.empty();
+    }
+
+    var res = new ArrayList<DeploymentArtifact>(batchNum);
+    for (var batchIdx : sqlBatches.keys()) {
+      var sql = sqlBatches.get(batchIdx);
+
+      res.add(
+          new DeploymentArtifact(
+              suffixName + "-" + batchIdx + ".sql", DeploymentArtifact.toSqlString(sql)));
+    }
+
+    return Optional.of(res);
   }
 
   @Getter
@@ -94,6 +129,9 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
     private final Set<String> formats = new HashSet<>();
     private final Set<String> fullyResolvedFunctions = new HashSet<>();
     private final List<List<RichSqlInsert>> statementSets = new ArrayList<>();
+    private final ArrayListMultimap<Integer, String> flinkSqlBatched = ArrayListMultimap.create();
+    private final ArrayListMultimap<Integer, String> flinkSqlNoFunctionsBatched =
+        ArrayListMultimap.create();
 
     private Configuration config;
 
@@ -112,11 +150,19 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
     }
 
     public void nextBatch() {
+      var nextIdx = statementSets.size();
+
       statementSets.add(new ArrayList<>());
+
+      // Replay all previous batches DDL statements
+      if (nextIdx > 0) {
+        flinkSqlBatched.putAll(nextIdx, flinkSqlBatched.get(nextIdx - 1));
+        flinkSqlNoFunctionsBatched.putAll(nextIdx, flinkSqlNoFunctionsBatched.get(nextIdx - 1));
+      }
     }
 
     public void add(SqlNode sqlNode) {
-      add(sqlNode, RelToFlinkSql.convertToString(sqlNode));
+      add(sqlNode, RelToFlinkSql.convertToString(sqlNode), currentBatch());
     }
 
     public void addFullyResolvedFunction(String createFunction) {
@@ -127,13 +173,15 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
       checkArgument(nodeSqls.size() == nodes.size(), "Node and SQL size mismatch during planning");
 
       for (int i = 0; i < nodes.size(); i++) {
-        add(nodes.get(i), nodeSqls.get(i));
+        add(nodes.get(i), nodeSqls.get(i), i);
       }
     }
 
-    public void add(SqlNode node, String nodeSql) {
+    private void add(SqlNode node, String nodeSql, int batchIdx) {
       flinkSql.add(nodeSql);
+      flinkSqlBatched.put(batchIdx, nodeSql);
       nodes.add(node);
+
       if (node instanceof SqlCreateTable table) {
         for (SqlNode option : table.getPropertyList().getList()) {
           var sqlTableOption = (SqlTableOption) option;
@@ -150,8 +198,10 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
           }
         }
       }
+
       if (!(node instanceof SqlCreateFunction)) {
         flinkSqlNoFunctions.add(nodeSql);
+        flinkSqlNoFunctionsBatched.put(batchIdx, nodeSql);
       }
     }
 
@@ -191,7 +241,9 @@ public class FlinkPhysicalPlan implements EnginePhysicalPlan {
           compiledPlan.map(CompiledPlan::asJsonString),
           explainedPlan,
           flinkSqlNoFunctions,
-          config);
+          config,
+          flinkSqlBatched,
+          flinkSqlNoFunctionsBatched);
     }
 
     private boolean hasSink() {

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractUseCaseTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/AbstractUseCaseTest.java
@@ -88,7 +88,7 @@ public class AbstractUseCaseTest extends AbstractAssetSnapshotTest {
   public Predicate<Path> getPlanDirFilter() {
     return path -> {
       var fileName = path.getFileName().toString();
-      if (fileName.equals("flink-sql-no-functions.sql")) {
+      if (fileName.startsWith("flink-sql-no-functions")) {
         return true;
       }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -40,7 +40,6 @@ public class UseCaseCompileTest extends AbstractUseCaseTest {
   @SneakyThrows
   @ParameterizedTest
   @ArgumentsSource(UseCaseFiles.class)
-  //  @Disabled("Intended for manual usage")
   void testUseCase(Path packageFile) {
     super.testUseCase(packageFile);
   }
@@ -48,9 +47,8 @@ public class UseCaseCompileTest extends AbstractUseCaseTest {
   @Test
   @Disabled("Intended for manual usage")
   void runTestCaseByName() {
-    var pkg = USECASE_DIR.resolve("complex-mutation").resolve("package-invalid.json");
+    var pkg = USECASE_DIR.resolve("multi-batch-compile").resolve("package.json");
     super.testUseCase(pkg);
-    System.out.println("Done");
   }
 
   static class UseCaseFiles extends ArgumentsProviders.PackageProvider {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
@@ -74,4 +74,11 @@ EXPORT Src TO tables.sink_a;
 NEXT_BATCH;
 INSERT INTO TableB SELECT * FROM Src;
 EXPORT Src TO tables.sink_b;
+NEXT_BATCH;
+CREATE TABLE TableC (
+  recordCount INT
+) WITH (
+  'connector' = 'print'
+);
+INSERT INTO TableC SELECT * FROM Src;
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
@@ -29,7 +29,47 @@ Connector:   print
 Inputs:
  - default_catalog.default_database.Src
 
->>>flink-sql-no-functions.sql
+>>>flink-sql-no-functions-0.sql
+CREATE TABLE `Src` (
+  `val` INTEGER NOT NULL
+)
+WITH (
+  'connector' = 'datagen',
+  'number-of-rows' = '5',
+  'rows-per-second' = '5',
+  'fields.val.kind' = 'random',
+  'fields.val.min' = '1',
+  'fields.val.max' = '5'
+);
+CREATE TABLE `TableA` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `TableB` (
+  `recordCount` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `SinkA_ex1` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `TableA`
+SELECT *
+ FROM `Src`
+;
+INSERT INTO `default_catalog`.`default_database`.`SinkA_ex1`
+ SELECT *
+  FROM `default_catalog`.`default_database`.`Src`
+ ;
+ END
+>>>flink-sql-no-functions-1.sql
 CREATE TABLE `Src` (
   `val` INTEGER NOT NULL
 )
@@ -66,6 +106,106 @@ WITH (
   'connector' = 'print'
 );
 EXECUTE STATEMENT SET BEGIN
+INSERT INTO `TableB`
+SELECT *
+ FROM `Src`
+;
+INSERT INTO `default_catalog`.`default_database`.`SinkB_ex2`
+ SELECT *
+  FROM `default_catalog`.`default_database`.`Src`
+ ;
+ END
+>>>flink-sql-no-functions-2.sql
+CREATE TABLE `Src` (
+  `val` INTEGER NOT NULL
+)
+WITH (
+  'connector' = 'datagen',
+  'number-of-rows' = '5',
+  'rows-per-second' = '5',
+  'fields.val.kind' = 'random',
+  'fields.val.min' = '1',
+  'fields.val.max' = '5'
+);
+CREATE TABLE `TableA` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `TableB` (
+  `recordCount` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `SinkA_ex1` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `SinkB_ex2` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `TableC` (
+  `recordCount` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `TableC`
+SELECT *
+ FROM `Src`
+;
+END
+>>>flink-sql-no-functions.sql
+CREATE TABLE `Src` (
+  `val` INTEGER NOT NULL
+)
+WITH (
+  'connector' = 'datagen',
+  'number-of-rows' = '5',
+  'rows-per-second' = '5',
+  'fields.val.kind' = 'random',
+  'fields.val.min' = '1',
+  'fields.val.max' = '5'
+);
+CREATE TABLE `TableA` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `TableB` (
+  `recordCount` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `SinkA_ex1` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `SinkB_ex2` (
+  `val` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+CREATE TABLE `TableC` (
+  `recordCount` INTEGER
+)
+WITH (
+  'connector' = 'print'
+);
+EXECUTE STATEMENT SET BEGIN
 INSERT INTO `TableA`
 SELECT *
  FROM `Src`
@@ -84,4 +224,10 @@ INSERT INTO `default_catalog`.`default_database`.`SinkB_ex2`
  SELECT *
   FROM `default_catalog`.`default_database`.`Src`
  ;
- END
+ END;
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `TableC`
+SELECT *
+ FROM `Src`
+;
+END

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/multi-batch-compile/multi-batch.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/multi-batch-compile/multi-batch.sqrl
@@ -21,3 +21,13 @@ NEXT_BATCH;
 INSERT INTO TableB SELECT * FROM Src;
 
 EXPORT Src TO tables.sink_b;
+
+NEXT_BATCH;
+
+CREATE TABLE TableC (
+  recordCount INT
+) WITH (
+  'connector' = 'print'
+);
+
+INSERT INTO TableC SELECT * FROM Src;


### PR DESCRIPTION
## Key Changes
- Generate individual split SQL deployment artifacts in case of a multi-batch project
- These extra artifacts will only be generated when there are more than 1 batch
- Every split will only contain the previous and current DDLs, so for example we don't register unnecessary tables that are defined in an upcoming batch