### PR TITLE
fix: Resolve env vars for `jwtAuth` config properly

### DIFF
--- a/sqrl-cli/src/test/java/com/datasqrl/engine/server/GenericJavaServerEngineTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/engine/server/GenericJavaServerEngineTest.java
@@ -39,15 +39,15 @@ class GenericJavaServerEngineTest {
     var config = getConfigMap();
 
     var defaultConfig = underTest.readDefaultConfig();
-    assertThat(defaultConfig.getJwtAuth()).isNull();
+    assertThat(defaultConfig.getJwtAuthOptions()).isNull();
 
     var result = ServerConfigUtil.mergeConfigs(defaultConfig, config);
 
     assertThat(result).isNotNull();
-    assertThat(result.getJwtAuth()).isNotNull();
-    assertThat(result.getJwtAuth().getPubSecKeys()).isNotNull().isNotEmpty();
-    assertThat(result.getJwtAuth().getJWTOptions()).isNotNull();
-    assertThat(result.getJwtAuth().getJWTOptions().getIssuer()).isEqualTo("my-test-issuer");
+    assertThat(result.getJwtAuthOptions()).isNotNull();
+    assertThat(result.getJwtAuthOptions().getPubSecKeys()).isNotNull().isNotEmpty();
+    assertThat(result.getJwtAuthOptions().getJWTOptions()).isNotNull();
+    assertThat(result.getJwtAuthOptions().getJWTOptions().getIssuer()).isEqualTo("my-test-issuer");
   }
 
   @Test

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/HttpServerVerticle.java
@@ -317,7 +317,7 @@ public class HttpServerVerticle extends AbstractVerticle {
       log.info("Configuring JWT authentication");
       providerFutures.add(
           Future.succeededFuture(
-              (AuthenticationProvider) JWTAuth.create(vertx, config.getJwtAuth())));
+              (AuthenticationProvider) JWTAuth.create(vertx, config.getJwtAuthOptions())));
     }
 
     if (providerFutures.isEmpty()) {

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/ServerConfig.java
@@ -15,12 +15,13 @@
  */
 package com.datasqrl.graphql.config;
 
-import static com.datasqrl.graphql.SqrlObjectMapper.MAPPER;
-
 import com.datasqrl.env.EnvVariableNames;
 import com.datasqrl.env.GlobalEnvironmentStore;
+import com.datasqrl.graphql.SqrlObjectMapper;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
@@ -29,15 +30,20 @@ import io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.sqlclient.PoolOptions;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.SneakyThrows;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServerConfig {
+
+  @Getter(AccessLevel.NONE)
+  private final ObjectMapper MAPPER = SqrlObjectMapper.getMapperWithEnvVarResolver(null);
 
   private ServletConfig servletConfig = new ServletConfig();
   private GraphQLHandlerOptions graphQLHandlerOptions = new GraphQLHandlerOptions();
@@ -47,7 +53,7 @@ public class ServerConfig {
   private PoolOptions poolOptions = new PoolOptions();
   private CorsHandlerOptions corsHandlerOptions = new CorsHandlerOptions();
   private SwaggerConfig swaggerConfig = new SwaggerConfig();
-  private JWTAuthOptions jwtAuth;
+  private Map<String, Object> jwtAuth;
   private OAuthConfig oauthConfig;
 
   private KafkaConfig.KafkaMutationConfig kafkaMutationConfig;
@@ -88,6 +94,24 @@ public class ServerConfig {
     return this;
   }
 
+  /**
+   * Returns the JWT authentication options with environment variables resolved. This custom getter
+   * exists because {@code jwtAuth} is stored as a raw JSON string to defer environment variable
+   * resolution before runtime, causing init failure in {@link JWTAuthOptions}.
+   */
+  @JsonIgnore
+  @SneakyThrows
+  public JWTAuthOptions getJwtAuthOptions() {
+    if (jwtAuth == null) {
+      return null;
+    }
+
+    var jsonStr = MAPPER.writeValueAsString(jwtAuth);
+    var jsonObj = MAPPER.readValue(jsonStr, JsonObject.class);
+
+    return new JWTAuthOptions(jsonObj);
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
   // Custom JSON setters for Jackson deserialization of Vert.x classes
   ////////////////////////////////////////////////////////////////////////////////
@@ -116,11 +140,6 @@ public class ServerConfig {
   public void setGraphiQLHandlerOptionsFromJson(Map<String, Object> options) {
     this.graphiQLHandlerOptions =
         options == null ? null : new GraphiQLHandlerOptions(new JsonObject(options));
-  }
-
-  @JsonSetter("jwtAuth")
-  public void setJwtAuthFromJson(Map<String, Object> options) {
-    this.jwtAuth = options == null ? null : new JWTAuthOptions(new JsonObject(options));
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/GraphQLJwtHandlerIT.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/GraphQLJwtHandlerIT.java
@@ -34,9 +34,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
-import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
-import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
@@ -117,8 +115,7 @@ class GraphQLJwtHandlerIT {
     // Create server config with JWT auth and Kafka settings
     serverConfig = new ServerConfig();
     serverConfig.setJwtAuth(
-        new JWTAuthOptions()
-            .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setBuffer("dGVzdA==")));
+        Map.of("pubSecKeys", List.of(Map.of("algorithm", "HS256", "buffer", "dGVzdA=="))));
     serverConfig.setPoolOptions(new PoolOptions());
     serverConfig.setServletConfig(new ServletConfig());
     serverConfig.setCorsHandlerOptions(new CorsHandlerOptions());
@@ -171,7 +168,7 @@ class GraphQLJwtHandlerIT {
     var authProviders =
         List.of(
             (io.vertx.ext.auth.authentication.AuthenticationProvider)
-                io.vertx.ext.auth.jwt.JWTAuth.create(vertx, serverConfig.getJwtAuth()));
+                io.vertx.ext.auth.jwt.JWTAuth.create(vertx, serverConfig.getJwtAuthOptions()));
     graphQLServerVerticle =
         new GraphQLServerVerticle(
             router, serverConfig, "v1", model, authProviders, Optional.empty());
@@ -208,7 +205,7 @@ class GraphQLJwtHandlerIT {
 
   @Test
   void jwtAuthentication(VertxTestContext testContext) {
-    var provider = JWTAuth.create(vertx, this.serverConfig.getJwtAuth());
+    var provider = JWTAuth.create(vertx, this.serverConfig.getJwtAuthOptions());
 
     // Generate token
     var token = provider.generateToken(new JsonObject(), new JWTOptions().setExpiresInSeconds(60));


### PR DESCRIPTION
## Key Changes
- Introduce a custom getter for `jwtAuthOptions` in `ServerConfig`, which gets called only in runtime, where the env vars are present, and can be resolved properly
- Adapt tests