### PR TITLE
fix: Fail early with proper error message when mutation engine hint is missing

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -864,7 +864,10 @@ public class Sqrl2FlinkSQLTranslator {
       mutationBld = mutationBuilder.get().createMutation(origTableName, tableBuilder, null);
       fullTable = tableBuilder.buildSql(false);
     }
+
     var tableOp = (CreateTableOperation) executeSqlNode(fullTable);
+    validateMutationHints(tableOp, mutationBuilder);
+
     // Create table analysis
     var flinkSchema = ((ResolvedCatalogTable) tableOp.getCatalogTable()).getResolvedSchema();
     // Map primary key
@@ -1131,6 +1134,19 @@ public class Sqrl2FlinkSQLTranslator {
       // Means there is no lib directory
     }
     return urls;
+  }
+
+  private static void validateMutationHints(
+      CreateTableOperation tableOp, Optional<MutationBuilder> mutationBuilder) {
+    var tableName = tableOp.getTableIdentifier().getObjectName();
+    var options = tableOp.getCatalogTable().getOptions();
+
+    // TODO: Collect supported engines dynamically in a sane way
+    if (!tableName.endsWith("_schema") && options.isEmpty() && mutationBuilder.isEmpty()) {
+      throw new StatementParserException(
+          "Mutation engine hint \"/*+ engine(...) */\" is required for internal CREATE TABLE statements."
+              + " Supported engines: \"kafka\", \"iceberg\".");
+    }
   }
 
   public record ParsedRelDataTypeResult(

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/DAGPlannerTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/DAGPlannerTest.java
@@ -74,7 +74,7 @@ public class DAGPlannerTest extends AbstractAssetSnapshotTest {
   @Disabled
   @Test
   void specificScript() {
-    var script = SCRIPT_DIR.resolve("unionDifferentKeysAndOrder.sqrl");
+    var script = SCRIPT_DIR.resolve("mutationHintMissing-fail.sqrl");
     scripts(script);
   }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/mutationHintMissing-fail.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/mutationHintMissing-fail.sqrl
@@ -1,0 +1,16 @@
+/*+ engine(kafka) */
+CREATE TABLE _SensorsValid (
+    sensorid INT,
+    machineid INT,
+    updatedTime TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
+    PRIMARY KEY (sensorid) NOT ENFORCED
+);
+
+CREATE TABLE _SensorsInvalid (
+    sensorid INT,
+    machineid INT,
+    updatedTime TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
+    PRIMARY KEY (sensorid) NOT ENFORCED
+);
+
+Sensors := SELECT * FROM _Sensors;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationHintMissing-fail.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationHintMissing-fail.txt
@@ -1,0 +1,7 @@
+[FATAL] Mutation engine hint "/*+ engine(...) */" is required for internal CREATE TABLE statements. Supported engines: "kafka", "iceberg".
+in script:mutationHintMissing-fail.sqrl [9:1]:
+);
+
+CREATE TABLE _SensorsInvalid (
+^
+


### PR DESCRIPTION
## Key Changes
- Fail early with descriptive error message when internal `CREATE TABLE` is missing a mutation engine hint
- Add test case to cover the added logic