### PR TITLE
fix: Make `exec` cmd apply minimal Flink configuration for deployment

### DIFF
--- a/documentation/docs/compiler.md
+++ b/documentation/docs/compiler.md
@@ -238,7 +238,7 @@ services by your preferred cloud provider.
 
 ## Test Command
 
-The test command compiles and runs the data pipeline, then executes the provided test API queries and API endpoints
+The `test` command compiles and runs the data pipeline, then executes the provided test API queries and API endpoints
 for all tables annotated with `/*+ test */` to snapshot the results.
 
 When you first run the test command or add additional test cases, it will create the snapshots and fail.
@@ -287,24 +287,26 @@ Subscriptions can only be tested in conjunction with mutations at this time.
 
 ## Exec Command
 
-The exec command executes an already compiled SQRL project using its existing build artifacts, without recompiling.
+The `exec` command executes an already compiled SQRL project using its existing build artifacts, without recompiling.
 This is useful when you want to run a previously compiled pipeline.
 
 ```bash
 run --rm -it -p 8081:8081 -p 8888:8888 -p 9092:9092 -v $PWD:/build datasqrl/cmd exec -h
 ```
 
+:::warning
+Be aware that `exec` does not apply all run-specific Flink configuration that we previously described at [run command](#run-command).
+It only sets `execution.target` to `local` if it is missing to be able to deploy, but other than that takes the configuration from the `build/deploy` folder as is.
+:::
+
 ```
-Usage: sqrl exec [-BhV] [-t=<targetFolder>] [<packageFiles>...]
+Usage: sqrl exec [-hV] [-t=<targetFolder>]
 Executes an already compiled SQRL script using its existing build artifacts.
-      [<packageFiles>...]   Package configuration file(s) of the project.
-                              Default: "package.json".
-  -B, --batch-output        Run in batch output mode (disables colored output).
-  -h, --help                Show this help message and exit.
+  -h, --help      Show this help message and exit.
   -t, --target=<targetFolder>
-                            Target folder for deployment artifacts and plans.
-                              Default: "build/deploy".
-  -V, --version             Print version information and exit.
+                  Target folder for deployment artifacts and plans. Default:
+                    "build/deploy".
+  -V, --version   Print version information and exit.
 ```
 
 ### Example

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.util.OsProcessManager;
+import java.nio.file.Path;
+import picocli.CommandLine.Option;
+
+public abstract class BaseOsProcessManagerCmd extends BaseCmd {
+
+  protected static final Path DEFAULT_TARGET =
+      Path.of(SqrlConstants.BUILD_DIR_NAME, SqrlConstants.DEPLOY_DIR_NAME);
+
+  @Option(
+      names = {"-t", "--target"},
+      description = "Target folder for deployment artifacts and plans. Default: \"build/deploy\".")
+  protected Path targetFolder = DEFAULT_TARGET;
+
+  @Override
+  protected void teardown() {
+    if (!cli.internalTestExec) {
+      getOsProcessManager().teardown(getBuildDir());
+    }
+  }
+
+  protected OsProcessManager getOsProcessManager() {
+    return new OsProcessManager(System.getenv());
+  }
+
+  protected Path getTargetFolder() {
+    if (targetFolder.isAbsolute()) {
+      return targetFolder;
+    }
+
+    return cli.rootDir.resolve(targetFolder);
+  }
+}

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BasePackageConfCmd.java
@@ -18,8 +18,6 @@ package com.datasqrl.cli;
 import com.datasqrl.cli.output.DefaultOutputFormatter;
 import com.datasqrl.cli.output.NoOutputFormatter;
 import com.datasqrl.cli.output.OutputFormatter;
-import com.datasqrl.config.SqrlConstants;
-import com.datasqrl.util.OsProcessManager;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -27,10 +25,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-public abstract class BasePackageConfCmd extends BaseCmd {
-
-  protected static final Path DEFAULT_TARGET =
-      Path.of(SqrlConstants.BUILD_DIR_NAME, SqrlConstants.DEPLOY_DIR_NAME);
+public abstract class BasePackageConfCmd extends BaseOsProcessManagerCmd {
 
   @Parameters(
       arity = "0..*",
@@ -39,37 +34,13 @@ public abstract class BasePackageConfCmd extends BaseCmd {
   protected List<Path> packageFiles = Collections.emptyList();
 
   @Option(
-      names = {"-t", "--target"},
-      description = "Target folder for deployment artifacts and plans. Default: \"build/deploy\".")
-  protected Path targetFolder = DEFAULT_TARGET;
-
-  @Option(
       names = {"-B", "--batch-output"},
       description = "Run in batch output mode (disables colored output).")
   protected boolean batchMode = false;
-
-  @Override
-  protected void teardown() {
-    if (!cli.internalTestExec) {
-      getOsProcessManager().teardown(getBuildDir());
-    }
-  }
 
   protected OutputFormatter getOutputFormatter() {
     return cli.internalTestExec
         ? new NoOutputFormatter()
         : new DefaultOutputFormatter(cli.rootDir, batchMode);
-  }
-
-  protected OsProcessManager getOsProcessManager() {
-    return new OsProcessManager(System.getenv());
-  }
-
-  protected Path getTargetFolder() {
-    if (targetFolder.isAbsolute()) {
-      return targetFolder;
-    }
-
-    return cli.rootDir.resolve(targetFolder);
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
@@ -19,6 +19,10 @@ import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ConfigLoaderUtils;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
 import picocli.CommandLine.Command;
 
 @Command(
@@ -26,7 +30,7 @@ import picocli.CommandLine.Command;
     description = "Executes an already compiled SQRL script using its existing build artifacts.",
     mixinStandardHelpOptions = true,
     versionProvider = CliVersionProvider.class)
-public class ExecCmd extends BasePackageConfCmd {
+public class ExecCmd extends BaseOsProcessManagerCmd {
 
   @Override
   protected void runInternal(ErrorCollector errors) throws Exception {
@@ -38,9 +42,23 @@ public class ExecCmd extends BasePackageConfCmd {
 
     var env = GlobalEnvironmentStore.getAll();
     var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
-    var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
+    var flinkConfig = getFlinkConfig(planDir);
 
     var sqrlRun = DatasqrlRun.blocking(planDir, sqrlConfig, flinkConfig, env);
     sqrlRun.run();
+  }
+
+  /**
+   * Loads the Flink configuration from the plan directory. If no deployment target is configured,
+   * defaults to local attached execution.
+   */
+  private Configuration getFlinkConfig(Path planDir) throws IOException {
+    var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
+    if (!flinkConfig.contains(DeploymentOptions.TARGET)) {
+      flinkConfig.set(DeploymentOptions.TARGET, "local");
+      flinkConfig.set(DeploymentOptions.ATTACHED, true);
+    }
+
+    return flinkConfig;
   }
 }

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/ExecCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/ExecCmdTest.java
@@ -15,22 +15,22 @@
  */
 package com.datasqrl.cli;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ConfigLoaderUtils;
 import com.datasqrl.util.OsProcessManager;
 import java.nio.file.Path;
+import java.util.Map;
 import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -39,6 +39,8 @@ class ExecCmdTest {
 
   @Mock private ErrorCollector errors;
   @Mock private Configuration flinkConfig;
+  @Mock private OsProcessManager osProcessManager;
+  @Mock private DatasqrlRun datasqrlRun;
 
   private ExecCmd execCmd;
 
@@ -47,6 +49,7 @@ class ExecCmdTest {
   @BeforeEach
   void setup() {
     execCmd = spy(new ExecCmd());
+    doReturn(osProcessManager).when(execCmd).getOsProcessManager();
   }
 
   @Test
@@ -56,36 +59,32 @@ class ExecCmdTest {
     Path buildDir = execCmd.getBuildDir();
     Path planDir = execCmd.getTargetFolder().resolve(SqrlConstants.PLAN_DIR);
 
-    // Mock static methods and verify arguments
-    try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
+    var mockSqrlConfig = mock(PackageJson.class);
+    var mockEnv = Map.of("key", "value");
 
-      var mockSqrlConfig = mock(PackageJson.class);
-      mocked
+    try (MockedStatic<ConfigLoaderUtils> configMocked = mockStatic(ConfigLoaderUtils.class);
+        MockedStatic<GlobalEnvironmentStore> envMocked = mockStatic(GlobalEnvironmentStore.class);
+        MockedStatic<DatasqrlRun> runMocked = mockStatic(DatasqrlRun.class)) {
+
+      configMocked
           .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir))
           .thenReturn(mockSqrlConfig);
+      configMocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
+      envMocked.when(GlobalEnvironmentStore::getAll).thenReturn(mockEnv);
+      runMocked
+          .when(() -> DatasqrlRun.blocking(eq(planDir), eq(mockSqrlConfig), any(), eq(mockEnv)))
+          .thenReturn(datasqrlRun);
+      when(datasqrlRun.run()).thenReturn(null);
 
-      mocked.when(() -> ConfigLoaderUtils.loadFlinkConfig(planDir)).thenReturn(flinkConfig);
+      execCmd.runInternal(errors);
 
-      try (MockedConstruction<OsProcessManager> serviceManagerMocked =
-              mockConstruction(OsProcessManager.class);
-          MockedConstruction<DatasqrlRun> datasqrlRunMocked =
-              mockConstruction(
-                  DatasqrlRun.class, (mock, context) -> when(mock.run()).thenReturn(null))) {
-
-        execCmd.runInternal(errors);
-
-        // Verify service manager was created and started
-        assertThat(serviceManagerMocked.constructed()).hasSize(1);
-        OsProcessManager serviceManager = serviceManagerMocked.constructed().get(0);
-        verify(serviceManager).startDependentServices(planDir);
-
-        // Verify exact arguments
-        mocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir));
-        mocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
-
-        DatasqrlRun constructed = datasqrlRunMocked.constructed().get(0);
-        verify(constructed).run();
-      }
+      verify(osProcessManager).startDependentServices(planDir);
+      configMocked.verify(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir));
+      configMocked.verify(() -> ConfigLoaderUtils.loadFlinkConfig(planDir));
+      envMocked.verify(GlobalEnvironmentStore::getAll);
+      runMocked.verify(
+          () -> DatasqrlRun.blocking(eq(planDir), eq(mockSqrlConfig), any(), eq(mockEnv)));
+      verify(datasqrlRun).run();
     }
   }
 }


### PR DESCRIPTION
## Key Changes
- Apply must-have Flink deployment configs in `exec` cmd to be able to deploy after `compile` as is
- Restructure CLI args a bit and remove `packageFiles` list arg from `exec` cmd, as it does not use or rely on it at all
- Adapt tests and docs