### PR TITLE
chore: Remove custom CDC JAR from CLI Dockerfile

### DIFF
--- a/sqrl-cli/Dockerfile
+++ b/sqrl-cli/Dockerfile
@@ -25,10 +25,6 @@ COPY target/sqrl-cli.jar /opt/sqrl/sqrl-cli.jar
 COPY entrypoint.sh /opt/sqrl/entrypoint.sh
 COPY core-site.xml /opt/sqrl/hadoop-conf/core-site.xml
 
-# TODO: Remove the patched SQL server JAR when CDC supports Flink 2.x
-RUN wget -q -P /opt/sqrl \
-    https://github.com/DataSQRL/flink-sql-runner/raw/refs/heads/release-0.9/flink-sql-runner/artifact/flink-sql-connector-sqlserver-cdc-sqrl.jar
-
 ENV PATH="/opt/jbang/bin:${PATH}"
 ENV HADOOP_CONF_DIR="/opt/sqrl/hadoop-conf"
 ENV SQRL_JVM_TOOL_OPTS="--add-exports=java.base/sun.net.util=ALL-UNNAMED \

--- a/sqrl-cli/entrypoint.sh
+++ b/sqrl-cli/entrypoint.sh
@@ -32,5 +32,4 @@ export UDF_PATH=/build/build/deploy/flink/lib
 export BUILD_UID=$(stat -c '%u' /build)
 export BUILD_GID=$(stat -c '%g' /build)
 
-# TODO: Remove the patched SQL server JAR when CDC supports Flink 2.x
-exec java $SQRL_JVM_TOOL_OPTS $SQRL_JVM_ARGS -cp /opt/sqrl/sqrl-cli.jar:/opt/sqrl/flink-sql-connector-sqlserver-cdc-sqrl.jar com.datasqrl.cli.DatasqrlCli "${@}"
+exec java $SQRL_JVM_TOOL_OPTS $SQRL_JVM_ARGS -jar /opt/sqrl/sqrl-cli.jar "${@}"


### PR DESCRIPTION
Since https://github.com/DataSQRL/flink-sql-runner/pull/313 is delivered, we can get rid of this here too.