### PR TITLE
chore: Refactor container tests to use JUnit extensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ Container tests in `sqrl-testing-container` validate the end-to-end functionalit
 
 - **Purpose**: Test the complete Docker image deployment including compilation and server startup
 - **Requirements**: Docker must be running and DataSQRL images must be built (`datasqrl/cmd:local`, `datasqrl/sqrl-server:local`)
-- **Test Structure**: Tests extend `SqrlContainerTestBase` which provides container management utilities
+- **Test Structure**: Tests use JUnit extension `SqrlContainerExtension` and `PostgresContainerExtension` which provide container management utilities
 - **Available Endpoints**: 
   - `/graphql` - Main GraphQL API endpoint
   - `/health` - Health check endpoint (returns 204 No Content when healthy)

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ContainerError.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ContainerError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.container.testing;
+
+import lombok.Getter;
+
+@Getter
+public class ContainerError extends RuntimeException {
+
+  private static final long serialVersionUID = -2159257606710389109L;
+
+  private final Long exitCode;
+  private final String logs;
+
+  public ContainerError(String message, Long exitCode, String logs) {
+    super(message);
+    this.exitCode = exitCode;
+    this.logs = logs;
+  }
+}

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ContainerResult.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ContainerResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.container.testing;
+
+import org.testcontainers.containers.GenericContainer;
+
+public record ContainerResult(GenericContainer<?> cmd, Long exitCode, String logs) {}

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/CorsContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/CorsContainerIT.java
@@ -18,19 +18,20 @@ package com.datasqrl.container.testing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpResponse;
+import org.apache.http.Header;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Container integration tests for CORS (Cross-Origin Resource Sharing) behaviour of the Vert.x
@@ -50,19 +51,17 @@ import org.junit.jupiter.api.Test;
  * </ul>
  */
 @Slf4j
-public class CorsContainerIT extends SqrlContainerTestBase {
+public class CorsContainerIT {
 
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("avro-schema");
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String PRODUCTION_ORIGIN = "https://dev.datasqrl.com";
   private static final String STAGING_ORIGIN =
       "https://sqrl-repository-frontend-git-staging-datasqrl.vercel.app";
   private static final String LOCAL_ORIGIN = "http://localhost:3000";
   private static final String ARBITRARY_ORIGIN = "https://some-app.example.com";
   private static final String GRAPHQL_QUERY = "{\"query\":\"query { __typename }\"}";
-
-  @Override
-  protected String getTestCaseName() {
-    return "avro-schema";
-  }
 
   // ─────────────────────────────────────────────────────────────────────────
   // Preflight (OPTIONS) — wildcard origin config
@@ -71,7 +70,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightFromKnownFrontendOrigins_then_corsHeadersPresent() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "POST", "Content-Type");
     assertPreflightAllowed(STAGING_ORIGIN, "POST", "Content-Type");
@@ -82,7 +81,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightWithAuthorizationHeader_then_headerAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "POST", "Authorization");
   }
@@ -90,7 +89,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightWithContentTypeHeader_then_headerAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "POST", "Content-Type");
   }
@@ -98,7 +97,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightWithCustomHeader_then_headerAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "POST", "X-Custom-Header");
   }
@@ -107,7 +106,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @SneakyThrows
   void
       given_wildcardOriginConfig_when_preflightWithMultipleRequestHeaders_then_allHeadersAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "POST", "Content-Type, Authorization");
   }
@@ -115,7 +114,7 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightForGetMethod_then_getAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     assertPreflightAllowed(PRODUCTION_ORIGIN, "GET", "Content-Type");
   }
@@ -123,15 +122,17 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_preflightRequested_then_optionsInAllowedMethods() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var request = new HttpOptions(getGraphQLEndpoint());
+    var request = new HttpOptions(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", PRODUCTION_ORIGIN);
     request.setHeader("Access-Control-Request-Method", "POST");
 
-    var response = sharedHttpClient.execute(request);
+    Header allowMethods;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      allowMethods = response.getFirstHeader("Access-Control-Allow-Methods");
+    }
 
-    var allowMethods = response.getFirstHeader("Access-Control-Allow-Methods");
     assertThat(allowMethods).as("Access-Control-Allow-Methods header must be present").isNotNull();
     assertThat(allowMethods.getValue())
         .as("OPTIONS must be explicitly listed in allowed methods for preflight to work")
@@ -145,46 +146,44 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_graphqlPostWithOriginHeader_then_allowOriginInResponse() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var request = new HttpPost(getGraphQLEndpoint());
+    var request = new HttpPost(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", PRODUCTION_ORIGIN);
     request.setEntity(new StringEntity(GRAPHQL_QUERY, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-
-    assertSoftly(
-        softly -> {
-          softly
-              .assertThat(response.getStatusLine().getStatusCode())
-              .as("Cross-origin GraphQL POST should succeed")
-              .isEqualTo(200);
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
-              .as("Access-Control-Allow-Origin must be present on actual request response")
-              .isNotNull();
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin").getValue())
-              .as("Wildcard config must return '*' as allowed origin")
-              .isEqualTo("*");
-        });
-
-    validateBasicGraphQLResponse(response);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertSoftly(
+          softly -> {
+            softly
+                .assertThat(response.getStatusLine().getStatusCode())
+                .as("Cross-origin GraphQL POST should succeed")
+                .isEqualTo(200);
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
+                .as("Access-Control-Allow-Origin must be present on actual request response")
+                .isNotNull();
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin").getValue())
+                .as("Wildcard config must return '*' as allowed origin")
+                .isEqualTo("*");
+          });
+      sqrl.validateBasicGraphQLResponse(response);
+    }
   }
 
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_graphqlPostFromMultipleOrigins_then_allAllowed() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     for (var origin :
         new String[] {PRODUCTION_ORIGIN, STAGING_ORIGIN, LOCAL_ORIGIN, ARBITRARY_ORIGIN}) {
-      var request = new HttpPost(getGraphQLEndpoint());
+      var request = new HttpPost(sqrl.getGraphQLEndpoint());
       request.setHeader("Origin", origin);
       request.setEntity(new StringEntity(GRAPHQL_QUERY, ContentType.APPLICATION_JSON));
 
-      var response = sharedHttpClient.execute(request);
-      try {
+      try (var response = sqrl.getHttpClient().execute(request)) {
         assertSoftly(
             softly -> {
               softly
@@ -196,8 +195,6 @@ public class CorsContainerIT extends SqrlContainerTestBase {
                   .as("Access-Control-Allow-Origin must be present for %s", origin)
                   .isNotNull();
             });
-      } finally {
-        EntityUtils.consume(response.getEntity());
       }
     }
   }
@@ -205,25 +202,25 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_getRequestWithOriginHeader_then_allowOriginInResponse() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     // Health endpoint is a simple GET that doesn't require auth
-    var request = new HttpGet(getHealthEndpoint());
+    var request = new HttpGet(sqrl.getHealthEndpoint());
     request.setHeader("Origin", PRODUCTION_ORIGIN);
 
-    var response = sharedHttpClient.execute(request);
-
-    assertSoftly(
-        softly -> {
-          softly
-              .assertThat(response.getStatusLine().getStatusCode())
-              .as("Cross-origin GET to health endpoint should succeed")
-              .isIn(200, 204);
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
-              .as("Access-Control-Allow-Origin must be present on GET response")
-              .isNotNull();
-        });
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertSoftly(
+          softly -> {
+            softly
+                .assertThat(response.getStatusLine().getStatusCode())
+                .as("Cross-origin GET to health endpoint should succeed")
+                .isIn(200, 204);
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
+                .as("Access-Control-Allow-Origin must be present on GET response")
+                .isNotNull();
+          });
+    }
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -233,15 +230,15 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_wildcardOriginConfig_when_requestWithoutOriginHeader_then_requestSucceeds() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var response = executeGraphQLQuery(GRAPHQL_QUERY);
+    try (var response = sqrl.executeGraphQLQuery(GRAPHQL_QUERY)) {
+      assertThat(response.getStatusLine().getStatusCode())
+          .as("Direct request without Origin header must always succeed")
+          .isEqualTo(200);
 
-    assertThat(response.getStatusLine().getStatusCode())
-        .as("Direct request without Origin header must always succeed")
-        .isEqualTo(200);
-
-    validateBasicGraphQLResponse(response);
+      sqrl.validateBasicGraphQLResponse(response);
+    }
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -251,39 +248,39 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_specificOriginsConfig_when_requestFromAllowedOrigin_then_originEchoedInResponse() {
-    compileSqrlProject(testDir);
-    configureSpecificOrigins(testDir, PRODUCTION_ORIGIN, STAGING_ORIGIN, LOCAL_ORIGIN);
-    startGraphQLServer(testDir);
+    sqrl.compileSqrlProject();
+    configureSpecificOrigins(sqrl.getTestDir(), PRODUCTION_ORIGIN, STAGING_ORIGIN, LOCAL_ORIGIN);
+    sqrl.startGraphQLServer();
 
-    var request = new HttpPost(getGraphQLEndpoint());
+    var request = new HttpPost(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", PRODUCTION_ORIGIN);
     request.setEntity(new StringEntity(GRAPHQL_QUERY, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-
-    assertSoftly(
-        softly -> {
-          softly
-              .assertThat(response.getStatusLine().getStatusCode())
-              .as("Request from allowed origin should succeed")
-              .isEqualTo(200);
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
-              .as("Access-Control-Allow-Origin must be present for allowed origin")
-              .isNotNull();
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin").getValue())
-              .as("Server must echo back the specific allowed origin (not wildcard)")
-              .isEqualTo(PRODUCTION_ORIGIN);
-        });
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertSoftly(
+          softly -> {
+            softly
+                .assertThat(response.getStatusLine().getStatusCode())
+                .as("Request from allowed origin should succeed")
+                .isEqualTo(200);
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
+                .as("Access-Control-Allow-Origin must be present for allowed origin")
+                .isNotNull();
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin").getValue())
+                .as("Server must echo back the specific allowed origin (not wildcard)")
+                .isEqualTo(PRODUCTION_ORIGIN);
+          });
+    }
   }
 
   @Test
   @SneakyThrows
   void given_specificOriginsConfig_when_preflightFromAllowedOrigin_then_preflightAccepted() {
-    compileSqrlProject(testDir);
-    configureSpecificOrigins(testDir, PRODUCTION_ORIGIN, STAGING_ORIGIN, LOCAL_ORIGIN);
-    startGraphQLServer(testDir);
+    sqrl.compileSqrlProject();
+    configureSpecificOrigins(sqrl.getTestDir(), PRODUCTION_ORIGIN, STAGING_ORIGIN, LOCAL_ORIGIN);
+    sqrl.startGraphQLServer();
 
     assertPreflightAllowed(STAGING_ORIGIN, "POST", "Content-Type, Authorization");
   }
@@ -291,38 +288,40 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void given_specificOriginsConfig_when_preflightFromDisallowedOrigin_then_preflightRejected() {
-    compileSqrlProject(testDir);
-    configureSpecificOrigins(testDir, PRODUCTION_ORIGIN);
-    startGraphQLServer(testDir);
+    sqrl.compileSqrlProject();
+    configureSpecificOrigins(sqrl.getTestDir(), PRODUCTION_ORIGIN);
+    sqrl.startGraphQLServer();
 
-    var request = new HttpOptions(getGraphQLEndpoint());
+    var request = new HttpOptions(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", ARBITRARY_ORIGIN);
     request.setHeader("Access-Control-Request-Method", "POST");
     request.setHeader("Access-Control-Request-Headers", "Content-Type");
 
-    var response = sharedHttpClient.execute(request);
-
-    assertThat(response.getStatusLine().getStatusCode())
-        .as("Preflight from an origin not in the allowed list must be rejected with 403")
-        .isEqualTo(403);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertThat(response.getStatusLine().getStatusCode())
+          .as("Preflight from an origin not in the allowed list must be rejected with 403")
+          .isEqualTo(403);
+    }
   }
 
   @Test
   @SneakyThrows
   void given_specificOriginsConfig_when_simpleRequestFromDisallowedOrigin_then_noCorsHeader() {
-    compileSqrlProject(testDir);
-    configureSpecificOrigins(testDir, PRODUCTION_ORIGIN);
-    startGraphQLServer(testDir);
+    sqrl.compileSqrlProject();
+    configureSpecificOrigins(sqrl.getTestDir(), PRODUCTION_ORIGIN);
+    sqrl.startGraphQLServer();
 
-    var request = new HttpPost(getGraphQLEndpoint());
+    var request = new HttpPost(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", ARBITRARY_ORIGIN);
     request.setEntity(new StringEntity(GRAPHQL_QUERY, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
+    Header allowOrigin;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      allowOrigin = response.getFirstHeader("Access-Control-Allow-Origin");
+    }
 
     // The server still processes the request, but the browser would block it because
     // Access-Control-Allow-Origin is absent or does not match the requesting origin.
-    var allowOrigin = response.getFirstHeader("Access-Control-Allow-Origin");
     if (allowOrigin != null) {
       assertThat(allowOrigin.getValue())
           .as("If Allow-Origin is present it must NOT match the disallowed origin")
@@ -336,38 +335,39 @@ public class CorsContainerIT extends SqrlContainerTestBase {
 
   @SneakyThrows
   private void assertPreflightAllowed(String origin, String requestMethod, String requestHeaders) {
-    var request = new HttpOptions(getGraphQLEndpoint());
+    var request = new HttpOptions(sqrl.getGraphQLEndpoint());
     request.setHeader("Origin", origin);
     request.setHeader("Access-Control-Request-Method", requestMethod);
     request.setHeader("Access-Control-Request-Headers", requestHeaders);
 
-    HttpResponse response = sharedHttpClient.execute(request);
-    log.debug(
-        "Preflight {} origin={} method={} headers={} → status={}",
-        getGraphQLEndpoint(),
-        origin,
-        requestMethod,
-        requestHeaders,
-        response.getStatusLine().getStatusCode());
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      log.debug(
+          "Preflight {} origin={} method={} headers={} → status={}",
+          sqrl.getGraphQLEndpoint(),
+          origin,
+          requestMethod,
+          requestHeaders,
+          response.getStatusLine().getStatusCode());
 
-    assertSoftly(
-        softly -> {
-          softly
-              .assertThat(response.getStatusLine().getStatusCode())
-              .as(
-                  "Preflight OPTIONS from origin='%s' requesting method='%s' headers='%s'"
-                      + " should be accepted (200 or 204)",
-                  origin, requestMethod, requestHeaders)
-              .isIn(200, 204);
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
-              .as("Access-Control-Allow-Origin must be present in preflight response")
-              .isNotNull();
-          softly
-              .assertThat(response.getFirstHeader("Access-Control-Allow-Methods"))
-              .as("Access-Control-Allow-Methods must be present in preflight response")
-              .isNotNull();
-        });
+      assertSoftly(
+          softly -> {
+            softly
+                .assertThat(response.getStatusLine().getStatusCode())
+                .as(
+                    "Preflight OPTIONS from origin='%s' requesting method='%s' headers='%s'"
+                        + " should be accepted (200 or 204)",
+                    origin, requestMethod, requestHeaders)
+                .isIn(200, 204);
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Origin"))
+                .as("Access-Control-Allow-Origin must be present in preflight response")
+                .isNotNull();
+            softly
+                .assertThat(response.getFirstHeader("Access-Control-Allow-Methods"))
+                .as("Access-Control-Allow-Methods must be present in preflight response")
+                .isNotNull();
+          });
+    }
   }
 
   /** Replaces {@code corsHandlerOptions.allowedOrigin} with a specific list of origins. */
@@ -375,11 +375,11 @@ public class CorsContainerIT extends SqrlContainerTestBase {
   private void configureSpecificOrigins(Path testDir, String... origins) {
     var vertxConfigPath = testDir.resolve("build/deploy/plan/vertx-config.json");
     var configContent = Files.readString(vertxConfigPath);
-    var configNode = (ObjectNode) objectMapper.readTree(configContent);
+    var configNode = (ObjectNode) OBJECT_MAPPER.readTree(configContent);
 
-    var corsOptions = objectMapper.createObjectNode();
+    var corsOptions = OBJECT_MAPPER.createObjectNode();
     corsOptions.putNull("allowedOrigin");
-    var originsArray = objectMapper.createArrayNode();
+    var originsArray = OBJECT_MAPPER.createArrayNode();
     for (var origin : origins) {
       originsArray.add(origin);
     }
@@ -388,15 +388,15 @@ public class CorsContainerIT extends SqrlContainerTestBase {
     corsOptions.put("maxAgeSeconds", -1);
     corsOptions.put("allowPrivateNetwork", false);
     corsOptions.set(
-        "allowedMethods", objectMapper.createArrayNode().add("POST").add("GET").add("OPTIONS"));
+        "allowedMethods", OBJECT_MAPPER.createArrayNode().add("POST").add("GET").add("OPTIONS"));
     corsOptions.set(
-        "allowedHeaders", objectMapper.createArrayNode().add("Content-Type").add("Authorization"));
-    corsOptions.set("exposedHeaders", objectMapper.createArrayNode());
+        "allowedHeaders", OBJECT_MAPPER.createArrayNode().add("Content-Type").add("Authorization"));
+    corsOptions.set("exposedHeaders", OBJECT_MAPPER.createArrayNode());
 
     configNode.set("corsHandlerOptions", corsOptions);
     Files.writeString(
         vertxConfigPath,
-        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(configNode));
+        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(configNode));
 
     log.info("Configured specific allowed origins: {}", (Object) origins);
   }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/DuckDbExtensionIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/DuckDbExtensionIT.java
@@ -19,18 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class DuckDbExtensionIT extends SqrlContainerTestBase {
+public class DuckDbExtensionIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "duckdb";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("duckdb");
 
   @Test
   @SneakyThrows
   void givenUdfScript_whenCompiledAndServerStarted_thenApiRespondsCorrectly() {
-    var res = sqrlCmd(testDir, "test", "package.json");
+    var res = sqrl.sqrlCmd("test", "package.json");
 
     // Verify the expected success messages are present in the logs
     assertThat(res.logs())

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ExternalRedpandaContainerIT.java
@@ -26,24 +26,23 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
-public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
+public class ExternalRedpandaContainerIT {
 
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("flink-kafka");
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String REDPANDA_IMAGE = "redpandadata/redpanda:latest";
   private static final String REDPANDA_CONTAINER_NAME = "redpanda";
   private static final int REDPANDA_PORT = 9093;
 
   private GenericContainer<?> redpandaContainer;
-
-  @Override
-  protected String getTestCaseName() {
-    return "flink-kafka";
-  }
 
   @BeforeEach
   void setUpExternalRedpanda() {
@@ -67,11 +66,11 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
     assertThat(redpandaContainer.getMappedPort(REDPANDA_PORT)).isPositive();
 
     // When - Compile SQRL script with external Kafka configuration
-    var cmdContainer = createCmdContainerWithExternalKafka();
-    cmd = cmdContainer.withCommand("test", "package.json");
+    var cmd = createCmdContainerWithExternalKafka();
+    cmd.withCommand("test", "package.json");
 
     log.info("Starting compilation with external Redpanda container");
-    log.info(getDockerRunCommand(cmd, testDir));
+    log.info(sqrl.getDockerRunCommand(cmd));
     log.info(
         "DataSQRL container environment: KAFKA_BOOTSTRAP_SERVERS={}",
         REDPANDA_CONTAINER_NAME + ":" + REDPANDA_PORT);
@@ -83,7 +82,7 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
     var exitCode = cmd.getCurrentContainerInfo().getState().getExitCodeLong();
     var logs = cmd.getLogs();
 
-    if (exitCode != 0) {
+    if (exitCode == null || exitCode != 0) {
       log.error("SQRL compilation failed with exit code {}\n{}", exitCode, logs);
       throw new ContainerError("SQRL compilation failed", exitCode, logs);
     }
@@ -94,7 +93,7 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
     assertThat(logs).contains("ApplicationStatusTest", "BUILD SUCCESS");
 
     // Verify that no internal Kafka processes were started
-    var cliLogs = testDir.resolve("build").resolve("logs").resolve("datasqrl-cli.log");
+    var cliLogs = sqrl.getTestDir().resolve("build").resolve("logs").resolve("datasqrl-cli.log");
     assertThat(cliLogs).isRegularFile();
     assertThat(cliLogs)
         .as("Should not start internal Kafka when external Kafka is configured")
@@ -103,37 +102,37 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
             "Skip starting Redpanda, because KAFKA_BOOTSTRAP_SERVERS=redpanda:9093 is provided");
 
     // Verify log files and build ownership
-    assertLogFiles(logs, testDir);
-    assertBuildNotOwnedByRoot(testDir, logs);
+    sqrl.assertLogFiles(logs);
+    SqrlContainerExtension.assertBuildNotOwnedByRoot(sqrl.getTestDir(), logs);
 
     // Start GraphQL server with external Kafka configuration and test connectivity
     var bootstrapServers = REDPANDA_CONTAINER_NAME + ":" + REDPANDA_PORT;
     log.info("Starting GraphQL server with external Kafka: {}", bootstrapServers);
 
-    startGraphQLServer(
-        testDir,
+    sqrl.startGraphQLServer(
         container ->
             container
                 .withEnv("KAFKA_BOOTSTRAP_SERVERS", bootstrapServers)
-                .withNetwork(sharedNetwork));
+                .withNetwork(sqrl.getNetwork()));
 
     // Verify server is running and can execute GraphQL queries
-    assertThat(serverContainer.isRunning()).isTrue();
+    assertThat(sqrl.getServerContainer().isRunning()).isTrue();
 
     // Execute a GraphQL query to test server functionality with external Kafka
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { ApplicationStatusTest(limit: 5) { total_count total_amount } }\"}");
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { ApplicationStatusTest(limit: 5) { total_count total_amount } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
 
-    var responseBody = EntityUtils.toString(response.getEntity());
-    var jsonResponse = new ObjectMapper().readTree(responseBody);
+      var responseBody = EntityUtils.toString(response.getEntity());
+      var jsonResponse = OBJECT_MAPPER.readTree(responseBody);
 
-    assertThat(jsonResponse.has("data")).isTrue();
-    assertThat(jsonResponse.get("data").has("ApplicationStatusTest")).isTrue();
+      assertThat(jsonResponse.has("data")).isTrue();
+      assertThat(jsonResponse.get("data").has("ApplicationStatusTest")).isTrue();
+    }
 
     // Verify server logs mention Kafka bootstrap servers
-    var serverLogs = serverContainer.getLogs();
+    var serverLogs = sqrl.getServerContainer().getLogs();
     assertThat(serverLogs).contains(bootstrapServers);
 
     log.info(
@@ -145,7 +144,7 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
 
     redpandaContainer =
         new GenericContainer<>(DockerImageName.parse(REDPANDA_IMAGE))
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withNetworkAliases(REDPANDA_CONTAINER_NAME)
             .withExposedPorts(REDPANDA_PORT, 8081) // Kafka port and schema registry
             .withCommand(
@@ -187,19 +186,24 @@ public class ExternalRedpandaContainerIT extends SqrlContainerTestBase {
 
   private GenericContainer<?> createCmdContainerWithExternalKafka() {
     var container =
-        createCmdContainer(testDir, true)
-            .withNetwork(sharedNetwork)
+        sqrl.createCmdContainer(true)
+            .withNetwork(sqrl.getNetwork())
             .withEnv("KAFKA_BOOTSTRAP_SERVERS", REDPANDA_CONTAINER_NAME + ":" + REDPANDA_PORT);
 
     // Add additional mount to resolve the symlink
     // flink-kafka/loan-local -> ../banking/loan-local
-    var bankingDir = testDir.getParent().resolve("banking");
+    var bankingDir = sqrl.getTestDir().getParent().resolve("banking");
 
     if (bankingDir.toFile().exists()) {
       container =
           container.withFileSystemBind(
-              bankingDir.toString(), BUILD_DIR + "/../banking", BindMode.READ_ONLY);
-      log.info("Mounted banking directory: {} -> {}", bankingDir, BUILD_DIR + "/../banking");
+              bankingDir.toString(),
+              SqrlContainerExtension.BUILD_DIR + "/../banking",
+              BindMode.READ_ONLY);
+      log.info(
+          "Mounted banking directory: {} -> {}",
+          bankingDir,
+          SqrlContainerExtension.BUILD_DIR + "/../banking");
     }
 
     return container;

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/HttpLookupConnectorContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/HttpLookupConnectorContainerIT.java
@@ -21,22 +21,31 @@ import static org.awaitility.Awaitility.await;
 import java.time.Duration;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
-public class HttpLookupConnectorContainerIT extends SqrlContainerTestBase {
+public class HttpLookupConnectorContainerIT {
+
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("http-lookup");
 
   private static final String HTTP_LOOKUP_MOCK_ALIAS = "http-lookup-mock";
   private static final int HTTP_LOOKUP_MOCK_PORT = 18080;
 
   private GenericContainer<?> httpLookupMock;
 
-  @Override
-  protected String getTestCaseName() {
-    return "http-lookup";
+  @AfterEach
+  void tearDown() {
+    sqrl.cleanupContainers();
+
+    if (httpLookupMock != null && httpLookupMock.isRunning()) {
+      httpLookupMock.stop();
+      httpLookupMock = null;
+    }
   }
 
   @Test
@@ -44,14 +53,14 @@ public class HttpLookupConnectorContainerIT extends SqrlContainerTestBase {
   void givenSqrlWithHttpLookup_whenRun_thenHttpLookupInvokesMockServer() {
     startHttpLookupMock();
 
-    cmd =
-        createCmdContainer(testDir)
-            .withNetwork(sharedNetwork)
+    var cmd =
+        sqrl.createCmdContainer()
+            .withNetwork(sqrl.getNetwork())
             .withCommand("test", "package.json")
-            .withExposedPorts(HTTP_SERVER_PORT)
+            .withExposedPorts(SqrlContainerExtension.HTTP_SERVER_PORT)
             .waitingFor(
                 Wait.forHttp("/health")
-                    .forPort(HTTP_SERVER_PORT)
+                    .forPort(SqrlContainerExtension.HTTP_SERVER_PORT)
                     .forStatusCode(204)
                     .withStartupTimeout(Duration.ofMinutes(3)));
 
@@ -112,22 +121,12 @@ public class HttpLookupConnectorContainerIT extends SqrlContainerTestBase {
 
     httpLookupMock =
         new GenericContainer<>(DockerImageName.parse("python:3.12-alpine"))
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withNetworkAliases(HTTP_LOOKUP_MOCK_ALIAS)
             .withExposedPorts(HTTP_LOOKUP_MOCK_PORT)
             .withCommand("python", "-u", "-c", python)
             .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30)));
 
     httpLookupMock.start();
-  }
-
-  @Override
-  protected void cleanupContainers() {
-    super.cleanupContainers();
-
-    if (httpLookupMock != null && httpLookupMock.isRunning()) {
-      httpLookupMock.stop();
-      httpLookupMock = null;
-    }
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JBangContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JBangContainerIT.java
@@ -19,22 +19,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-class JBangContainerIT extends SqrlContainerTestBase {
+class JBangContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "jbang";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("jbang");
 
   @Test
   void givenProjectWithJBangJarExport_whenTestCommandExecuted_thenCompileAndTestSuccessful()
       throws Exception {
-    var res = sqrlCmd(testDir, "test", "package.json");
+    var res = sqrl.sqrlCmd("test", "package.json");
 
     assertThat(res.logs()).contains("MyTableTest", "MyAsyncTableTest", "BUILD SUCCESS");
 
-    var fatJar = testDir.resolve("build/deploy/flink/lib/jbang-udfs.jar");
+    var fatJar = sqrl.getTestDir().resolve("build/deploy/flink/lib/jbang-udfs.jar");
     assertThat(fatJar).exists().isRegularFile();
     assertThat(Files.size(fatJar))
         .as("Fat JAR should only contain UDF classes and declared //DEPS, not the entire classpath")

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtContainerIT.java
@@ -44,9 +44,17 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Slf4j
-public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
+public class JwtContainerIT {
+
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("jwt-authorized");
+
+  @RegisterExtension
+  static PostgresContainerExtension postgres =
+      new PostgresContainerExtension(sqrl, JwtContainerIT::executeStatements);
 
   // Response types for REST endpoints
   static class MyTableItem {
@@ -67,13 +75,7 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
     MyTableResponse getAuthMyTableWithAuth(@Param("token") String token, @Param("limit") int limit);
   }
 
-  @Override
-  protected String getTestCaseName() {
-    return "jwt-authorized";
-  }
-
-  @Override
-  protected void executeStatements(Statement stmt) throws SQLException {
+  private static void executeStatements(Statement stmt) throws SQLException {
     // Create and populate tables as defined in jwt-authorized-base.sqrl
 
     // Create MyTable and populate with values 1-10
@@ -91,100 +93,97 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
   @Test
   @SneakyThrows
   void givenJwt_whenUnauthenticatedGraphQL_thenReturns401() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
-    var response = executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}");
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
+    try (var response =
+        sqrl.executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
+    }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenAuthenticatedGraphQL_thenSucceeds() {
-    compileAndStartServerWithDatabase(testDir, "package-base.json");
+    postgres.compileAndStartServerWithDatabase("package-base.json");
 
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", generateJwtToken());
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-    var responseBody = EntityUtils.toString(response.getEntity());
-    assertThat(responseBody).contains("\"data\"");
-    assertThat(responseBody).contains("\"AuthMyTable\"");
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", generateJwtToken())) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      var responseBody = EntityUtils.toString(response.getEntity());
+      assertThat(responseBody).contains("\"data\"");
+      assertThat(responseBody).contains("\"AuthMyTable\"");
+    }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenBadToken_thenReturns401() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     // Generate token with RS256 algorithm while server expects HS256
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", generateRS256JwtToken());
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", generateRS256JwtToken())) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
-
-    // Verify the response contains detailed error information in JSON format
-    var responseBody = EntityUtils.toString(response.getEntity());
-    assertThat(responseBody).contains("\"error\"");
-    assertThat(responseBody).contains("\"JWT auth failed\"");
-    assertThat(responseBody).contains("\"cause\"");
-    assertThat(responseBody).contains("\"NoSuchKeyIdException: algorithm [RS256]: <null>\"");
+      // Verify the response contains detailed error information in JSON format
+      var responseBody = EntityUtils.toString(response.getEntity());
+      assertThat(responseBody).contains("\"error\"");
+      assertThat(responseBody).contains("\"JWT auth failed\"");
+      assertThat(responseBody).contains("\"cause\"");
+      assertThat(responseBody).contains("\"NoSuchKeyIdException: algorithm [RS256]: <null>\"");
+    }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenCorruptedToken_thenReturns401() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     // Generate token with RS256 algorithm while server expects HS256
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", "dummy-invalid-jwt");
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", "dummy-invalid-jwt")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
-
-    // Verify the response contains detailed error information in JSON format
-    var responseBody = EntityUtils.toString(response.getEntity());
-    System.out.println(responseBody);
-    assertThat(responseBody).contains("\"error\"");
-    assertThat(responseBody).contains("\"JWT auth failed\"");
-    assertThat(responseBody).contains("\"cause\"");
-    assertThat(responseBody).contains("\"IllegalArgumentException: Invalid format for JWT\"");
+      // Verify the response contains detailed error information in JSON format
+      var responseBody = EntityUtils.toString(response.getEntity());
+      System.out.println(responseBody);
+      assertThat(responseBody).contains("\"error\"");
+      assertThat(responseBody).contains("\"JWT auth failed\"");
+      assertThat(responseBody).contains("\"cause\"");
+      assertThat(responseBody).contains("\"IllegalArgumentException: Invalid format for JWT\"");
+    }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenMissingRequiredClaims_thenReturns403() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
-    try {
-      // Generate valid JWT token but with empty claims (missing required claims)
-      var response =
-          executeGraphQLQuery(
-              "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}",
-              generateJwtToken(Map.of()));
-
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}",
+            generateJwtToken(Map.of()))) {
       // Valid token but missing required claims should return 403 Forbidden
       var responseBody = EntityUtils.toString(response.getEntity());
       assertThat(response.getStatusLine().getStatusCode()).isEqualTo(403);
       assertThat(responseBody).contains("\"errors\"");
     } finally {
-      var logs = serverContainer.getLogs();
-      log.info("Detailed server logs:");
-      System.out.println(logs);
+      log.info("Detailed server logs:\n{}", sqrl.getServerContainer().getLogs());
     }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenUnauthenticatedMcp_thenFails() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     var mcpUrl =
         String.format(
-            "http://localhost:%d/v1/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+            "http://localhost:%d/v1/mcp",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     log.info("Testing MCP endpoint without JWT: {}", mcpUrl);
 
     // Create MCP client without authentication
@@ -193,7 +192,7 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
 
     // Should fail when trying to initialize due to lack of authentication
     // MCP uses OAuthFailureHandler which returns "authentication_required" error
-    assertThatThrownBy(() -> client.initialize())
+    assertThatThrownBy(client::initialize)
         .satisfies(
             ex -> {
               var fullMessage = getFullExceptionMessage(ex);
@@ -206,11 +205,12 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
   @Test
   @SneakyThrows
   void givenJwt_whenAuthenticatedMcp_thenSucceeds() {
-    compileAndStartServerWithDatabase(testDir, "package-base.json");
+    postgres.compileAndStartServerWithDatabase("package-base.json");
 
     var mcpUrl =
         String.format(
-            "http://localhost:%d/v1/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+            "http://localhost:%d/v1/mcp",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     var jwtToken = generateJwtToken();
     log.info("Testing MCP endpoint with valid JWT: {}", mcpUrl);
 
@@ -221,7 +221,7 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
             .endpoint("/v1/mcp")
             .build();
 
-    try (var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build(); ) {
+    try (var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build()) {
       // Should succeed with proper JWT
       client.initialize();
 
@@ -252,20 +252,20 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
       assertThat(toolResult.isError()).isFalse();
       assertThat(toolResult.content()).isNotNull();
     } finally {
-      var logs = serverContainer.getLogs();
-      log.info("Detailed MCP Validation Results:");
-      System.out.println(logs);
+      var logs = sqrl.getServerContainer().getLogs();
+      log.info("Detailed MCP Validation Results:\n{}", logs);
     }
   }
 
   @Test
   @SneakyThrows
   void givenJwt_whenMissingRequiredClaimsMcp_thenFails() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     var mcpUrl =
         String.format(
-            "http://localhost:%d/v1/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+            "http://localhost:%d/v1/mcp",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     var jwtToken = generateJwtToken(Map.of());
     log.info("Testing MCP endpoint with JWT missing claims: {}", mcpUrl);
 
@@ -276,7 +276,7 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
             .endpoint("/v1/mcp")
             .build();
 
-    try (var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build(); ) {
+    try (var client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(10)).build()) {
       // Should succeed with proper JWT - authentication passes
       client.initialize();
 
@@ -311,10 +311,12 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
   @Test
   @SneakyThrows
   void givenJwt_whenUnauthenticatedRest_thenReturns401() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     var restUrl =
-        String.format("http://localhost:%d", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+        String.format(
+            "http://localhost:%d",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     log.info("Testing REST endpoint without auth: {}", restUrl);
 
     var restClient =
@@ -332,10 +334,12 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
   @Test
   @SneakyThrows
   void givenJwt_whenAuthenticatedRest_thenSucceeds() {
-    compileAndStartServerWithDatabase(testDir, "package-base.json");
+    postgres.compileAndStartServerWithDatabase("package-base.json");
 
     var restUrl =
-        String.format("http://localhost:%d", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+        String.format(
+            "http://localhost:%d",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     var jwtToken = generateJwtToken();
     log.info("Testing REST endpoint with valid JWT: {}", restUrl);
 
@@ -358,10 +362,12 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
   @Test
   @SneakyThrows
   void givenJwt_whenMissingRequiredClaimsRest_thenReturns403() {
-    compileAndStartServer(testDir, "package-base.json");
+    sqrl.compileAndStartServer("package-base.json");
 
     var restUrl =
-        String.format("http://localhost:%d", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+        String.format(
+            "http://localhost:%d",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     var jwtToken = generateJwtToken(Map.of());
     log.info("Testing REST endpoint with JWT missing claims: {}", restUrl);
 
@@ -376,9 +382,8 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
       assertThatThrownBy(() -> restClient.getAuthMyTableWithAuth(jwtToken, 5))
           .isInstanceOf(FeignException.Forbidden.class);
     } finally {
-      var logs = serverContainer.getLogs();
-      log.info("Detailed MCP Validation Results:");
-      System.out.println(logs);
+      var logs = sqrl.getServerContainer().getLogs();
+      log.info("Detailed MCP Validation Results:\n{}", logs);
     }
   }
 
@@ -437,7 +442,7 @@ public class JwtContainerIT extends SqrlWithPostgresContainerTestBase {
     var current = throwable;
     while (current != null) {
       if (current.getMessage() != null) {
-        if (messages.length() > 0) {
+        if (!messages.isEmpty()) {
           messages.append(" -> ");
         }
         messages.append(current.getMessage());

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtOAuthCombinedIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/JwtOAuthCombinedIT.java
@@ -39,6 +39,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -51,7 +52,13 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Testcontainers
 @Slf4j
-class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
+class JwtOAuthCombinedIT {
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("jwt-oauth-combined");
+
+  @RegisterExtension
+  static PostgresContainerExtension postgres =
+      new PostgresContainerExtension(sqrl, JwtOAuthCombinedIT::executeStatements);
 
   private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.0";
   private static final String KEYCLOAK_ADMIN = "admin";
@@ -69,13 +76,7 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Override
-  protected String getTestCaseName() {
-    return "jwt-oauth-combined";
-  }
-
-  @Override
-  protected void executeStatements(Statement stmt) throws SQLException {
+  private static void executeStatements(Statement stmt) throws SQLException {
     stmt.execute("CREATE TABLE IF NOT EXISTS \"MyTable\" (val INTEGER)");
     stmt.execute(
         "INSERT INTO \"MyTable\" (val) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)");
@@ -86,7 +87,7 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
   static void startKeycloak() {
     keycloak =
         new GenericContainer<>(DockerImageName.parse(KEYCLOAK_IMAGE))
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withNetworkAliases("keycloak")
             .withExposedPorts(8080)
             .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", KEYCLOAK_ADMIN)
@@ -146,11 +147,11 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
                 + KEYCLOAK_PASSWORD,
             ContentType.APPLICATION_FORM_URLENCODED));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    var json = new ObjectMapper().readTree(body);
-
-    return json.get("access_token").asText();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var body = EntityUtils.toString(response.getEntity());
+      var json = new ObjectMapper().readTree(body);
+      return json.get("access_token").asText();
+    }
   }
 
   @SneakyThrows
@@ -175,14 +176,14 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(realmConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
-
-    if (statusCode == 409) {
-      log.info("Realm '{}' already exists", REALM_NAME);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create realm: " + statusCode + " - " + body);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode == 409) {
+        log.info("Realm '{}' already exists", REALM_NAME);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create realm: " + statusCode + " - " + body);
+      }
     }
   }
 
@@ -212,17 +213,17 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(clientConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode == 409) {
+        log.info("Client '{}' already exists", CLIENT_ID);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create client: " + statusCode + " - " + body);
+      }
 
-    if (statusCode == 409) {
-      log.info("Client '{}' already exists", CLIENT_ID);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create client: " + statusCode + " - " + body);
+      return getClientUuid(keycloakUrl, adminToken);
     }
-
-    return getClientUuid(keycloakUrl, adminToken);
   }
 
   @SneakyThrows
@@ -232,11 +233,11 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     var request = new HttpGet(clientUrl);
     request.setHeader("Authorization", "Bearer " + adminToken);
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    var json = new ObjectMapper().readTree(body);
-
-    return json.get(0).get("id").asText();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var body = EntityUtils.toString(response.getEntity());
+      var json = new ObjectMapper().readTree(body);
+      return json.get(0).get("id").asText();
+    }
   }
 
   @SneakyThrows
@@ -273,16 +274,17 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(mapperConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
 
-    if (statusCode == 409) {
-      log.info("Claim mapper already exists");
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create claim mapper: " + statusCode + " - " + body);
-    } else {
-      log.info("Added 'val' claim mapper with value {} to client", CLAIM_VAL);
+      if (statusCode == 409) {
+        log.info("Claim mapper already exists");
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create claim mapper: " + statusCode + " - " + body);
+      } else {
+        log.info("Added 'val' claim mapper with value {} to client", CLAIM_VAL);
+      }
     }
   }
 
@@ -314,14 +316,14 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(userConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
-
-    if (statusCode == 409) {
-      log.info("User '{}' already exists", TEST_USER);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create user: " + statusCode + " - " + body);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode == 409) {
+        log.info("User '{}' already exists", TEST_USER);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create user: " + statusCode + " - " + body);
+      }
     }
   }
 
@@ -341,9 +343,11 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
                 CLIENT_ID, CLIENT_SECRET, TEST_USER, TEST_PASSWORD),
             ContentType.APPLICATION_FORM_URLENCODED));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    log.info("Token response status: {}", response.getStatusLine().getStatusCode());
+    String body;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      body = EntityUtils.toString(response.getEntity());
+      log.info("Token response status: {}", response.getStatusLine().getStatusCode());
+    }
 
     var json = objectMapper.readTree(body);
     if (json.has("error")) {
@@ -358,14 +362,14 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
   }
 
   private void compileAndStartServerWithKeycloak() {
-    startPostgreSQLContainer();
+    postgres.startPostgreSQLContainer();
     compileSqrlProjectWithKeycloak();
     startGraphQLServerWithKeycloak();
   }
 
   private void compileSqrlProjectWithKeycloak() {
-    cmd =
-        createCmdContainer(testDir)
+    var cmd =
+        sqrl.createCmdContainer()
             .withCommand("compile", "package.json")
             .withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/")
             .withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
@@ -375,7 +379,7 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
 
     var exitCode = cmd.getCurrentContainerInfo().getState().getExitCodeLong();
     var logs = cmd.getLogs();
-    if (exitCode != 0) {
+    if (exitCode == null || exitCode != 0) {
       log.error("SQRL compilation failed with exit code {}\n{}", exitCode, logs);
       throw new ContainerError("SQRL compilation failed", exitCode, logs);
     }
@@ -384,17 +388,19 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
   }
 
   private void startGraphQLServerWithKeycloak() {
-    serverContainer =
-        createServerContainer(testDir)
+    var serverContainer =
+        sqrl.createServerContainer()
             .withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/")
             .withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/")
             .withEnv("POSTGRES_HOST", "postgresql")
-            .withEnv("POSTGRES_USERNAME", postgresql.getUsername())
-            .withEnv("POSTGRES_PASSWORD", postgresql.getPassword())
-            .withEnv("POSTGRES_DATABASE", postgresql.getDatabaseName())
+            .withEnv("POSTGRES_USERNAME", postgres.getPostgresql().getUsername())
+            .withEnv("POSTGRES_PASSWORD", postgres.getPostgresql().getPassword())
+            .withEnv("POSTGRES_DATABASE", postgres.getPostgresql().getDatabaseName())
             .withEnv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092");
     serverContainer.start();
-    log.info("HTTP server started on port {}", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+    log.info(
+        "HTTP server started on port {}",
+        serverContainer.getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
   }
 
   @Test
@@ -402,9 +408,10 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
   void givenCombinedAuth_whenUnauthenticated_thenReturns401() {
     compileAndStartServerWithKeycloak();
 
-    var response = executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}");
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
+    try (var response =
+        sqrl.executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
+    }
     log.info("Unauthenticated request correctly rejected with 401");
   }
 
@@ -414,15 +421,16 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     compileAndStartServerWithKeycloak();
 
     var jwtToken = generateHmacJwtToken(Map.of("val", CLAIM_VAL));
-    var response =
-        executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", jwtToken);
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-    var responseBody = EntityUtils.toString(response.getEntity());
-    assertThat(responseBody).contains("\"data\"");
-    assertThat(responseBody).contains("\"AuthMyTable\"");
-    assertThat(responseBody).contains("\"val\":" + CLAIM_VAL);
-    log.info("JWT with claim succeeded, response: {}", responseBody);
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", jwtToken)) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      var responseBody = EntityUtils.toString(response.getEntity());
+      assertThat(responseBody).contains("\"data\"");
+      assertThat(responseBody).contains("\"AuthMyTable\"");
+      assertThat(responseBody).contains("\"val\":" + CLAIM_VAL);
+      log.info("JWT with claim succeeded, response: {}", responseBody);
+    }
   }
 
   @Test
@@ -433,20 +441,18 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
     var keycloakToken = getKeycloakToken();
     log.info("Obtained Keycloak token with 'val' claim");
 
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", keycloakToken);
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", keycloakToken)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      var responseBody = EntityUtils.toString(response.getEntity());
+      log.info("OAuth response status: {}, body: {}", statusCode, responseBody);
 
-    var responseBody = EntityUtils.toString(response.getEntity());
-    log.info(
-        "OAuth response status: {}, body: {}",
-        response.getStatusLine().getStatusCode(),
-        responseBody);
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-    assertThat(responseBody).contains("\"data\"");
-    assertThat(responseBody).contains("\"AuthMyTable\"");
-    assertThat(responseBody).contains("\"val\":" + CLAIM_VAL);
+      assertThat(statusCode).isEqualTo(200);
+      assertThat(responseBody).contains("\"data\"");
+      assertThat(responseBody).contains("\"AuthMyTable\"");
+      assertThat(responseBody).contains("\"val\":" + CLAIM_VAL);
+    }
     log.info("OAuth with claim succeeded");
   }
 
@@ -457,21 +463,24 @@ class JwtOAuthCombinedIT extends SqrlWithPostgresContainerTestBase {
 
     // Test JWT with claim
     var jwtToken = generateHmacJwtToken(Map.of("val", CLAIM_VAL));
-    var jwtResponse =
-        executeGraphQLQuery("{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", jwtToken);
-    assertThat(jwtResponse.getStatusLine().getStatusCode()).isEqualTo(200);
-    var jwtBody = EntityUtils.toString(jwtResponse.getEntity());
-    assertThat(jwtBody).contains("\"val\":" + CLAIM_VAL);
+    try (var jwtResponse =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", jwtToken)) {
+      assertThat(jwtResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+      var jwtBody = EntityUtils.toString(jwtResponse.getEntity());
+      assertThat(jwtBody).contains("\"val\":" + CLAIM_VAL);
+    }
     log.info("JWT token with claim accepted");
 
     // Test OAuth with claim
     var keycloakToken = getKeycloakToken();
-    var oauthResponse =
-        executeGraphQLQuery(
-            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", keycloakToken);
-    assertThat(oauthResponse.getStatusLine().getStatusCode()).isEqualTo(200);
-    var oauthBody = EntityUtils.toString(oauthResponse.getEntity());
-    assertThat(oauthBody).contains("\"val\":" + CLAIM_VAL);
+    try (var oauthResponse =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { AuthMyTable(limit: 5) { val } }\"}", keycloakToken)) {
+      assertThat(oauthResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+      var oauthBody = EntityUtils.toString(oauthResponse.getEntity());
+      assertThat(oauthBody).contains("\"val\":" + CLAIM_VAL);
+    }
     log.info("OAuth token with claim accepted");
 
     log.info("Both JWT and OAuth tokens with claims work correctly");

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/KafkaStartupFailureContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/KafkaStartupFailureContainerIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.output.ToStringConsumer;
 
@@ -28,34 +29,31 @@ import org.testcontainers.containers.output.ToStringConsumer;
  * missing, instead of continuing to run in a broken state.
  */
 @Slf4j
-public class KafkaStartupFailureContainerIT extends SqrlContainerTestBase {
+public class KafkaStartupFailureContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "sensors-mutation";
-  }
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("sensors-mutation");
 
   @Test
   void givenMissingKafkaEnvVar_whenServerStarts_thenServiceTerminatesCleanly() {
     // First compile the SQRL script that uses Kafka
-    compileSqrlProject(testDir);
+    sqrl.compileSqrlProject();
 
     // Create a server container but don't set the KAFKA_BOOTSTRAP_SERVERS env var
     // which should cause the service to fail and terminate
-    var deployPlanPath = testDir.resolve("build/deploy/plan");
+    var deployPlanPath = sqrl.getTestDir().resolve("build/deploy/plan");
     assertThat(deployPlanPath).exists().isDirectory();
 
     // Use ToStringConsumer to capture logs even if container fails
     var logConsumer = new ToStringConsumer();
 
-    serverContainer =
-        createServerContainer(testDir)
-            .withEnv("SQRL_DEBUG", "1")
-            // Set an invalid bootstrap server URL
-            .withEnv("KAFKA_BOOTSTRAP_SERVERS", "${KAFKA_BOOTSTRAP_SERVERS}")
-            .withLogConsumer(logConsumer);
+    sqrl.createServerContainer()
+        .withEnv("SQRL_DEBUG", "1")
+        // Set an invalid bootstrap server URL
+        .withEnv("KAFKA_BOOTSTRAP_SERVERS", "${KAFKA_BOOTSTRAP_SERVERS}")
+        .withLogConsumer(logConsumer);
 
-    assertThatThrownBy(() -> serverContainer.start())
+    assertThatThrownBy(() -> sqrl.getServerContainer().start())
         .isInstanceOfAny(ContainerLaunchException.class, IllegalStateException.class)
         .hasMessageContaining("failed");
 
@@ -64,7 +62,7 @@ public class KafkaStartupFailureContainerIT extends SqrlContainerTestBase {
     log.info("Container logs:\n{}", logs);
 
     // Verify the container is not running
-    assertThat(serverContainer.isRunning()).isFalse();
+    assertThat(sqrl.getServerContainer().isRunning()).isFalse();
 
     // Verify the expected error messages are present
     assertThat(logs).contains("Invalid url in bootstrap.servers: ${KAFKA_BOOTSTRAP_SERVERS}");
@@ -75,23 +73,22 @@ public class KafkaStartupFailureContainerIT extends SqrlContainerTestBase {
   @Test
   void givenInvalidKafkaBootstrapServers_whenServerStarts_thenServiceTerminatesCleanly() {
     // First compile the SQRL script that uses Kafka
-    compileSqrlProject(testDir);
+    sqrl.compileSqrlProject();
 
     // Create a server container with an invalid Kafka bootstrap server address
-    var deployPlanPath = testDir.resolve("build/deploy/plan");
+    var deployPlanPath = sqrl.getTestDir().resolve("build/deploy/plan");
     assertThat(deployPlanPath).exists().isDirectory();
 
     // Use ToStringConsumer to capture logs even if container fails
     var logConsumer = new ToStringConsumer();
 
-    serverContainer =
-        createServerContainer(testDir)
-            .withEnv("SQRL_DEBUG", "1")
-            // Set an invalid bootstrap server URL
-            .withEnv("KAFKA_BOOTSTRAP_SERVERS", "not-a-valid-url:definitely-not-a-port")
-            .withLogConsumer(logConsumer);
+    sqrl.createServerContainer()
+        .withEnv("SQRL_DEBUG", "1")
+        // Set an invalid bootstrap server URL
+        .withEnv("KAFKA_BOOTSTRAP_SERVERS", "not-a-valid-url:definitely-not-a-port")
+        .withLogConsumer(logConsumer);
 
-    assertThatThrownBy(() -> serverContainer.start())
+    assertThatThrownBy(() -> sqrl.getServerContainer().start())
         .isInstanceOfAny(ContainerLaunchException.class, IllegalStateException.class)
         .hasMessageContaining("failed");
 
@@ -100,7 +97,7 @@ public class KafkaStartupFailureContainerIT extends SqrlContainerTestBase {
     log.info("Container logs:\n{}", logs);
 
     // Verify the container is not running
-    assertThat(serverContainer.isRunning()).isFalse();
+    assertThat(sqrl.getServerContainer().isRunning()).isFalse();
 
     // Verify error messages
     assertThat(logs).contains("Invalid url in bootstrap.servers");

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpAuth0IT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpAuth0IT.java
@@ -16,12 +16,9 @@
 package com.datasqrl.container.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.file.Path;
-import java.time.Duration;
 import java.util.function.Consumer;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +30,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -56,7 +54,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Disabled("Intended for manual usage")
 @Testcontainers
 @Slf4j
-class McpAuth0IT extends SqrlContainerTestBase {
+class McpAuth0IT {
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("oauth-authorized-compile");
 
   private static final String AUTH0_DOMAIN = ""; // Set Auth0 domain to test
   private static final String AUTH0_ISSUER_URL = "https://" + AUTH0_DOMAIN + "/";
@@ -68,11 +68,6 @@ class McpAuth0IT extends SqrlContainerTestBase {
   private static final String AUDIENCE = System.getenv("AUTH0_AUDIENCE");
 
   private final ObjectMapper objectMapper = new ObjectMapper();
-
-  @Override
-  protected String getTestCaseName() {
-    return "oauth-authorized-compile";
-  }
 
   @BeforeEach
   void requireAuth0Credentials() {
@@ -106,9 +101,12 @@ class McpAuth0IT extends SqrlContainerTestBase {
     var request = new HttpPost(AUTH0_TOKEN_URL);
     request.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    var statusCode = response.getStatusLine().getStatusCode();
+    String body;
+    int statusCode;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      body = EntityUtils.toString(response.getEntity());
+      statusCode = response.getStatusLine().getStatusCode();
+    }
 
     if (statusCode != 200) {
       throw new RuntimeException("Failed to obtain Auth0 token: HTTP " + statusCode + " — " + body);
@@ -127,24 +125,6 @@ class McpAuth0IT extends SqrlContainerTestBase {
     return json.get("access_token").asText();
   }
 
-  private void compileSqrlProjectWithAuth0(
-      Path workingDir, Consumer<GenericContainer<?>> customizer) {
-    cmd = createCmdContainer(workingDir).withCommand("compile", "package.json");
-    customizer.accept(cmd);
-    cmd.start();
-
-    await().atMost(Duration.ofMinutes(5)).until(() -> !cmd.isRunning());
-
-    var exitCode = cmd.getCurrentContainerInfo().getState().getExitCodeLong();
-    var logs = cmd.getLogs();
-    if (exitCode != 0) {
-      log.error("SQRL compilation failed with exit code {}\n{}", exitCode, logs);
-      throw new ContainerError("SQRL compilation failed", exitCode, logs);
-    }
-
-    log.info("SQRL script compiled successfully with Auth0 config");
-  }
-
   private void compileAndStartServerWithAuth0() {
     Consumer<GenericContainer<?>> auth0Env =
         c -> {
@@ -154,8 +134,8 @@ class McpAuth0IT extends SqrlContainerTestBase {
           c.withEnv("KEYCLOAK_EXTERNAL_URL", AUTH0_ISSUER_URL);
         };
 
-    compileSqrlProjectWithAuth0(testDir, auth0Env);
-    startGraphQLServer(testDir, auth0Env);
+    sqrl.compileSqrlProject(null, auth0Env);
+    sqrl.startGraphQLServer(auth0Env);
   }
 
   @Test
@@ -163,14 +143,15 @@ class McpAuth0IT extends SqrlContainerTestBase {
   void givenAuth0Config_whenFetchDiscoveryEndpoint_thenReturnsProtectedResourceMetadata() {
     compileAndStartServerWithAuth0();
 
-    var discoveryUrl = getBaseUrl() + "/.well-known/oauth-protected-resource";
+    var discoveryUrl = sqrl.getBaseUrl() + "/.well-known/oauth-protected-resource";
     log.info("Testing OAuth discovery endpoint: {}", discoveryUrl);
 
-    var response = sharedHttpClient.execute(new HttpGet(discoveryUrl));
+    String body;
+    try (var response = sqrl.getHttpClient().execute(new HttpGet(discoveryUrl))) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      body = EntityUtils.toString(response.getEntity());
+    }
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-
-    var body = EntityUtils.toString(response.getEntity());
     log.info("Discovery response: {}", body);
 
     var json = objectMapper.readTree(body);
@@ -193,7 +174,7 @@ class McpAuth0IT extends SqrlContainerTestBase {
   void givenAuth0Config_whenMcpRequestWithoutToken_thenReturns401WithWWWAuthenticate() {
     compileAndStartServerWithAuth0();
 
-    var mcpUrl = getBaseUrl() + "/v1/mcp";
+    var mcpUrl = sqrl.getBaseUrl() + "/v1/mcp";
     log.info("Testing MCP endpoint without token: {}", mcpUrl);
 
     var request = new HttpPost(mcpUrl);
@@ -202,14 +183,14 @@ class McpAuth0IT extends SqrlContainerTestBase {
             "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}",
             ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
-
-    var wwwAuth = response.getFirstHeader("WWW-Authenticate");
-    assertThat(wwwAuth).isNotNull();
-    assertThat(wwwAuth.getValue()).contains("resource_metadata=");
-    assertThat(wwwAuth.getValue()).contains(".well-known/oauth-protected-resource");
+      var wwwAuth = response.getFirstHeader("WWW-Authenticate");
+      assertThat(wwwAuth).isNotNull();
+      assertThat(wwwAuth.getValue()).contains("resource_metadata=");
+      assertThat(wwwAuth.getValue()).contains(".well-known/oauth-protected-resource");
+    }
   }
 
   @Test
@@ -219,7 +200,7 @@ class McpAuth0IT extends SqrlContainerTestBase {
 
     var token = getAuth0Token();
 
-    var mcpUrl = getBaseUrl() + "/v1/mcp";
+    var mcpUrl = sqrl.getBaseUrl() + "/v1/mcp";
     log.info("Testing MCP endpoint with valid Auth0 token: {}", mcpUrl);
 
     var request = new HttpPost(mcpUrl);
@@ -229,11 +210,12 @@ class McpAuth0IT extends SqrlContainerTestBase {
             "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}",
             ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    log.info("MCP response status: {}, body: {}", response.getStatusLine().getStatusCode(), body);
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+    String body;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      body = EntityUtils.toString(response.getEntity());
+      log.info("MCP response status: {}, body: {}", response.getStatusLine().getStatusCode(), body);
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+    }
 
     var json = objectMapper.readTree(body);
     assertThat(json.has("result")).isTrue();

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpOAuthIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpOAuthIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.function.Consumer;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.methods.HttpGet;
@@ -29,6 +30,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -41,7 +43,9 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Testcontainers
 @Slf4j
-class McpOAuthIT extends SqrlContainerTestBase {
+class McpOAuthIT {
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("oauth-authorized-compile");
 
   private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.0";
   private static final String KEYCLOAK_ADMIN = "admin";
@@ -58,16 +62,18 @@ class McpOAuthIT extends SqrlContainerTestBase {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Override
-  protected String getTestCaseName() {
-    return "oauth-authorized-compile";
+  private static Consumer<GenericContainer<?>> keycloakEnv() {
+    return c -> {
+      c.withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/");
+      c.withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
+    };
   }
 
   @BeforeAll
   static void startKeycloak() {
     keycloak =
         new GenericContainer<>(DockerImageName.parse(KEYCLOAK_IMAGE))
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withNetworkAliases("keycloak")
             .withExposedPorts(8080)
             .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", KEYCLOAK_ADMIN)
@@ -126,11 +132,11 @@ class McpOAuthIT extends SqrlContainerTestBase {
                 + KEYCLOAK_PASSWORD,
             ContentType.APPLICATION_FORM_URLENCODED));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    var json = new ObjectMapper().readTree(body);
-
-    return json.get("access_token").asText();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var body = EntityUtils.toString(response.getEntity());
+      var json = new ObjectMapper().readTree(body);
+      return json.get("access_token").asText();
+    }
   }
 
   @SneakyThrows
@@ -152,14 +158,15 @@ class McpOAuthIT extends SqrlContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(realmConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
 
-    if (statusCode == 409) {
-      log.info("Realm '{}' already exists", REALM_NAME);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create realm: " + statusCode + " - " + body);
+      if (statusCode == 409) {
+        log.info("Realm '{}' already exists", REALM_NAME);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create realm: " + statusCode + " - " + body);
+      }
     }
   }
 
@@ -189,14 +196,14 @@ class McpOAuthIT extends SqrlContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(clientConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
-
-    if (statusCode == 409) {
-      log.info("Client '{}' already exists", CLIENT_ID);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create client: " + statusCode + " - " + body);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode == 409) {
+        log.info("Client '{}' already exists", CLIENT_ID);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create client: " + statusCode + " - " + body);
+      }
     }
   }
 
@@ -223,14 +230,14 @@ class McpOAuthIT extends SqrlContainerTestBase {
     request.setHeader("Authorization", "Bearer " + adminToken);
     request.setEntity(new StringEntity(userConfig, ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-    var statusCode = response.getStatusLine().getStatusCode();
-
-    if (statusCode == 409) {
-      log.info("User '{}' already exists", TEST_USER);
-    } else if (statusCode != 201) {
-      var body = EntityUtils.toString(response.getEntity());
-      throw new RuntimeException("Failed to create user: " + statusCode + " - " + body);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode == 409) {
+        log.info("User '{}' already exists", TEST_USER);
+      } else if (statusCode != 201) {
+        var body = EntityUtils.toString(response.getEntity());
+        throw new RuntimeException("Failed to create user: " + statusCode + " - " + body);
+      }
     }
   }
 
@@ -248,41 +255,30 @@ class McpOAuthIT extends SqrlContainerTestBase {
                 CLIENT_ID, CLIENT_SECRET, TEST_USER, TEST_PASSWORD),
             ContentType.APPLICATION_FORM_URLENCODED));
 
-    var response = sharedHttpClient.execute(request);
-    var body = EntityUtils.toString(response.getEntity());
-    var json = objectMapper.readTree(body);
-
-    return json.get("access_token").asText();
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      var body = EntityUtils.toString(response.getEntity());
+      var json = objectMapper.readTree(body);
+      return json.get("access_token").asText();
+    }
   }
 
   @Test
   @SneakyThrows
   void givenOAuthConfig_whenFetchDiscoveryEndpoint_thenReturnsProtectedResourceMetadata() {
-    compileSqrlProject(
-        testDir,
-        c -> {
-          c.withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/");
-          c.withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
-        });
+    var env = keycloakEnv();
+    sqrl.compileSqrlProject(null, env);
+    sqrl.startGraphQLServer(env);
 
-    startGraphQLServer(
-        testDir,
-        c -> {
-          c.withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/");
-          c.withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
-        });
-
-    var discoveryUrl = getBaseUrl() + "/.well-known/oauth-protected-resource";
+    var discoveryUrl = sqrl.getBaseUrl() + "/.well-known/oauth-protected-resource";
     log.info("Testing OAuth discovery endpoint: {}", discoveryUrl);
 
-    var request = new HttpGet(discoveryUrl);
-    var response = sharedHttpClient.execute(request);
+    String body;
+    try (var response = sqrl.getHttpClient().execute(new HttpGet(discoveryUrl))) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      body = EntityUtils.toString(response.getEntity());
+    }
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-
-    var body = EntityUtils.toString(response.getEntity());
     log.info("Discovery response: {}", body);
-
     var json = objectMapper.readTree(body);
 
     assertThat(json.has("authorization_servers")).isTrue();
@@ -303,21 +299,11 @@ class McpOAuthIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenOAuthConfig_whenMcpRequestWithoutToken_thenReturns401WithWWWAuthenticate() {
-    compileSqrlProject(
-        testDir,
-        c -> {
-          c.withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/");
-          c.withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
-        });
+    var env = keycloakEnv();
+    sqrl.compileSqrlProject(null, env);
+    sqrl.startGraphQLServer(env);
 
-    startGraphQLServer(
-        testDir,
-        c -> {
-          c.withEnv("KEYCLOAK_ISSUER", keycloakInternalUrl + "/realms/" + REALM_NAME + "/");
-          c.withEnv("KEYCLOAK_EXTERNAL_URL", keycloakExternalUrl + "/realms/" + REALM_NAME + "/");
-        });
-
-    var mcpUrl = getBaseUrl() + "/v1/mcp";
+    var mcpUrl = sqrl.getBaseUrl() + "/v1/mcp";
     log.info("Testing MCP endpoint without token: {}", mcpUrl);
 
     var request = new HttpPost(mcpUrl);
@@ -326,41 +312,12 @@ class McpOAuthIT extends SqrlContainerTestBase {
             "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}",
             ContentType.APPLICATION_JSON));
 
-    var response = sharedHttpClient.execute(request);
-
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
-
-    var wwwAuth = response.getFirstHeader("WWW-Authenticate");
-    assertThat(wwwAuth).isNotNull();
-    assertThat(wwwAuth.getValue()).contains("resource_metadata=");
-    assertThat(wwwAuth.getValue()).contains(".well-known/oauth-protected-resource");
-  }
-
-  /** Compiles the SQRL project with environment variable support. */
-  protected void compileSqrlProject(
-      java.nio.file.Path workingDir, java.util.function.Consumer<GenericContainer<?>> customizer) {
-    cmd = createCmdContainer(workingDir).withCommand("compile", "package.json");
-    customizer.accept(cmd);
-    cmd.start();
-
-    org.awaitility.Awaitility.await().atMost(Duration.ofMinutes(5)).until(() -> !cmd.isRunning());
-
-    var exitCode = cmd.getCurrentContainerInfo().getState().getExitCodeLong();
-    var logs = cmd.getLogs();
-    if (exitCode != 0) {
-      log.error("SQRL compilation failed with exit code {}\n{}", exitCode, logs);
-      throw new ContainerError("SQRL compilation failed", exitCode, logs);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(401);
+      var wwwAuth = response.getFirstHeader("WWW-Authenticate");
+      assertThat(wwwAuth).isNotNull();
+      assertThat(wwwAuth.getValue()).contains("resource_metadata=");
+      assertThat(wwwAuth.getValue()).contains(".well-known/oauth-protected-resource");
     }
-
-    log.info("SQRL script compiled successfully");
-  }
-
-  /** Starts the GraphQL server with custom environment variables. */
-  protected void startGraphQLServer(
-      java.nio.file.Path workingDir, java.util.function.Consumer<GenericContainer<?>> customizer) {
-    serverContainer = createServerContainer(workingDir);
-    customizer.accept(serverContainer);
-    serverContainer.start();
-    log.info("HTTP server started on port {}", serverContainer.getMappedPort(HTTP_SERVER_PORT));
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpValidationIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/McpValidationIT.java
@@ -26,23 +26,19 @@ import java.util.Map;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers
 @Slf4j
-class McpValidationIT extends SqrlContainerTestBase {
+class McpValidationIT {
+
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("udf");
 
   private final ObjectMapper objectMapper = new ObjectMapper();
-
-  @Override
-  protected String getTestCaseName() {
-    return "udf";
-  }
 
   private String getMcpInspectorImage() {
     var mcpVersion = System.getProperty("mcp.inspector.version");
@@ -67,21 +63,23 @@ class McpValidationIT extends SqrlContainerTestBase {
   void givenUdfTestCase_whenMcpServerStarted_thenMcpInspectorValidatesSuccessfully()
       throws Exception {
     // Compile first
-    compileSqrlProject(testDir);
+    sqrl.compileSqrlProject();
 
     // Create server container with network alias
     var serverAlias = "sqrl-server";
-    serverContainer = createServerContainer(testDir);
-    serverContainer.withNetworkAliases(serverAlias);
-    serverContainer.start();
-    log.info("HTTP server started on port {}", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+    sqrl.createServerContainer();
+    sqrl.getServerContainer().withNetworkAliases(serverAlias);
+    sqrl.getServerContainer().start();
+    log.info(
+        "HTTP server started on port {}",
+        sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
 
     var mcpUrl = String.format("http://%s:8888/v1/mcp", serverAlias);
     log.info("Testing MCP endpoint: {}", mcpUrl);
 
     var mcpInspector =
         createMcpInspectorContainer(getMcpInspectorImage())
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withCommand(
                 "sh",
                 "-c",
@@ -131,20 +129,20 @@ class McpValidationIT extends SqrlContainerTestBase {
   void givenUdfTestCase_whenMcpServerStarted_thenDetailedProtocolValidationPasses()
       throws Exception {
     // Compile first
-    compileSqrlProject(testDir);
+    sqrl.compileSqrlProject();
 
     // Create server container with network alias
     var serverAlias = "sqrl-server";
-    serverContainer = createServerContainer(testDir);
-    serverContainer.withNetworkAliases(serverAlias);
-    serverContainer.start();
-    log.info("HTTP server started on port {}", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+    sqrl.createServerContainer().withNetworkAliases(serverAlias).start();
+    log.info(
+        "HTTP server started on port {}",
+        sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
 
     var mcpUrl = String.format("http://%s:8888/v1/mcp", serverAlias);
 
     var validatorContainer =
         createMcpInspectorContainer(getMcpInspectorImage())
-            .withNetwork(sharedNetwork)
+            .withNetwork(sqrl.getNetwork())
             .withCommand(
                 "sh",
                 "-c",
@@ -195,12 +193,13 @@ class McpValidationIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenUdfTestCase_whenUnauthenticatedMcp_thenSucceeds() {
-    compileSqrlProject(testDir);
-    startGraphQLServer(testDir);
+    sqrl.compileSqrlProject();
+    sqrl.startGraphQLServer();
 
     var mcpUrl =
         String.format(
-            "http://localhost:%d/v1/mcp", serverContainer.getMappedPort(HTTP_SERVER_PORT));
+            "http://localhost:%d/v1/mcp",
+            sqrl.getServerContainer().getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT));
     log.info("Testing MCP endpoint without JWT: {}", mcpUrl);
 
     // Create MCP client without authentication
@@ -260,7 +259,7 @@ class McpValidationIT extends SqrlContainerTestBase {
       client.close();
     } finally {
       // Print server logs when test fails to help debug
-      var serverLogs = serverContainer.getLogs();
+      var serverLogs = sqrl.getServerContainer().getLogs();
       log.error("=== SERVER LOGS ON MCP CLIENT ERROR ===");
       System.out.println(serverLogs);
       log.error("=== END SERVER LOGS ===");

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/MetricsContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/MetricsContainerIT.java
@@ -17,17 +17,18 @@ package com.datasqrl.container.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class MetricsContainerIT extends SqrlContainerTestBase {
+public class MetricsContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "udf";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("udf");
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Test
   void givenRunningServer_whenAccessingMetricsEndpoint_thenReturnsMetrics() {
@@ -71,44 +72,40 @@ public class MetricsContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenRunningServer_whenAccessingHealthEndpoint_thenReturnsHealthStatus() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var response = sharedHttpClient.execute(new HttpGet(getHealthEndpoint()));
+    try (var response = sqrl.getHttpClient().execute(new HttpGet(sqrl.getHealthEndpoint()))) {
+      var statusCode = response.getStatusLine().getStatusCode();
 
-    var statusCode = response.getStatusLine().getStatusCode();
+      // Health endpoint can return either 200 (with JSON) or 204 (no content) - both indicate
+      // healthy
+      assertThat(statusCode)
+          .as("Health endpoint should return either 200 (with JSON) or 204 (no content)")
+          .isIn(200, 204);
 
-    // Health endpoint can return either 200 (with JSON) or 204 (no content) - both indicate healthy
-    assertThat(statusCode)
-        .as("Health endpoint should return either 200 (with JSON) or 204 (no content)")
-        .isIn(200, 204);
+      if (statusCode == 200) {
+        var responseBody = EntityUtils.toString(response.getEntity());
+        var jsonResponse = OBJECT_MAPPER.readTree(responseBody);
 
-    if (statusCode == 200) {
-      var responseBody = EntityUtils.toString(response.getEntity());
-      var jsonResponse = objectMapper.readTree(responseBody);
-
-      assertThat(jsonResponse.has("status")).isTrue();
-      assertThat(jsonResponse.get("status").asText()).isEqualTo("UP");
+        assertThat(jsonResponse.has("status")).isTrue();
+        assertThat(jsonResponse.get("status").asText()).isEqualTo("UP");
+      }
+      // 204 No Content indicates healthy server with no registered health checks
     }
-    // 204 No Content indicates healthy server with no registered health checks
   }
 
   @SneakyThrows
   private String getMetricsResult() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var response = sharedHttpClient.execute(new HttpGet(getMetricsEndpoint()));
+    try (var response = sqrl.getHttpClient().execute(new HttpGet(sqrl.getMetricsEndpoint()))) {
+      assertThat(response.getStatusLine().getStatusCode())
+          .as(
+              "Status code check for /metrics endpoint: %s"
+                  .formatted(sqrl.getServerContainer().getLogs()))
+          .isEqualTo(200);
 
-    var statusCode = response.getStatusLine().getStatusCode();
-
-    if (statusCode == 200) {
-      // Metrics endpoint is available
       return EntityUtils.toString(response.getEntity());
-
-    } else {
-      throw new AssertionError(
-          "Unexpected status code for /metrics endpoint: "
-              + statusCode
-              + serverContainer.getLogs());
     }
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/PostgresAccessContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/PostgresAccessContainerIT.java
@@ -20,18 +20,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 @Slf4j
-public class PostgresAccessContainerIT extends SqrlContainerTestBase {
+public class PostgresAccessContainerIT {
+
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("avro-schema");
 
   private GenericContainer<?> runContainer;
 
-  @Override
-  protected String getTestCaseName() {
-    return "avro-schema";
+  @AfterEach
+  void tearDown() {
+    if (runContainer != null && runContainer.isRunning()) {
+      runContainer.stop();
+      runContainer = null;
+    }
   }
 
   @Test
@@ -39,12 +46,12 @@ public class PostgresAccessContainerIT extends SqrlContainerTestBase {
   void givenRunningContainer_whenExecutePostgresVersionQuery_thenReturnsPostgresVersion() {
     // Start the run container which compiles and runs the server
     runContainer =
-        createCmdContainer(testDir)
+        sqrl.createCmdContainer()
             .withCommand("run")
-            .withExposedPorts(HTTP_SERVER_PORT)
+            .withExposedPorts(SqrlContainerExtension.HTTP_SERVER_PORT)
             .waitingFor(
                 Wait.forHttp("/health")
-                    .forPort(HTTP_SERVER_PORT)
+                    .forPort(SqrlContainerExtension.HTTP_SERVER_PORT)
                     .forStatusCode(204)
                     .withStartupTimeout(Duration.ofSeconds(30)));
 
@@ -76,14 +83,5 @@ public class PostgresAccessContainerIT extends SqrlContainerTestBase {
         .containsPattern("PostgreSQL\\s+\\d+\\.\\d+");
 
     log.info("PostgreSQL version verification completed successfully");
-  }
-
-  @Override
-  protected void cleanupContainers() {
-    super.cleanupContainers();
-    if (runContainer != null && runContainer.isRunning()) {
-      runContainer.stop();
-      runContainer = null;
-    }
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/PostgresContainerExtension.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/PostgresContainerExtension.java
@@ -21,66 +21,74 @@ import static com.datasqrl.env.EnvVariableNames.POSTGRES_HOST;
 import static com.datasqrl.env.EnvVariableNames.POSTGRES_PASSWORD;
 import static com.datasqrl.env.EnvVariableNames.POSTGRES_USERNAME;
 
-import java.nio.file.Path;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Objects;
 import javax.annotation.Nullable;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
-/**
- * Abstract base class for container tests that require a PostgreSQL database. Extends {@link
- * SqrlContainerTestBase} and adds PostgreSQL container management.
- */
 @Slf4j
-public abstract class SqrlWithPostgresContainerTestBase extends SqrlContainerTestBase {
+public class PostgresContainerExtension implements AfterEachCallback {
 
-  protected PostgreSQLContainer postgresql;
+  private final SqrlContainerExtension sqrl;
+  private final StatementConsumer schemaInitializer;
 
-  /**
-   * Abstract method that subclasses must implement to create and populate their specific test
-   * tables in the PostgreSQL database.
-   */
-  protected abstract void executeStatements(Statement stmt) throws SQLException;
+  @Getter private PostgreSQLContainer postgresql;
 
-  /**
-   * Starts the PostgreSQL container if not already running.
-   *
-   * <p>After starting the container, calls {@link #executeStatements(Statement)} to initialize the
-   * database schema.
-   */
+  @FunctionalInterface
+  public interface StatementConsumer {
+    void accept(Statement stmt) throws SQLException;
+  }
+
+  public PostgresContainerExtension(
+      SqrlContainerExtension sqrl, StatementConsumer schemaInitializer) {
+    this.sqrl = Objects.requireNonNull(sqrl);
+    this.schemaInitializer = Objects.requireNonNull(schemaInitializer);
+  }
+
   @SneakyThrows
-  protected void startPostgreSQLContainer() {
+  public void startPostgreSQLContainer() {
     if (postgresql == null) {
+      var network = sqrl.getNetwork();
+      if (network == null) {
+        throw new IllegalStateException(
+            "SqrlContainerExtension must be declared before PostgresContainerExtension "
+                + "so that the shared Docker network is initialized before Postgres starts.");
+      }
       postgresql =
-          new PostgreSQLContainer("postgres:17")
+          new PostgreSQLContainer(DockerImageName.parse("postgres:17"))
               .withDatabaseName("datasqrl")
               .withUsername("datasqrl")
               .withPassword("password")
-              .withNetwork(sharedNetwork)
+              .withNetwork(network)
               .withNetworkAliases("postgresql");
       postgresql.start();
       log.info("PostgreSQL container started on port {}", postgresql.getMappedPort(5432));
 
       try (var connection = postgresql.createConnection("")) {
         try (var stmt = connection.createStatement()) {
-          executeStatements(stmt);
+          schemaInitializer.accept(stmt);
         }
       }
+      log.info("Schema initialized");
     }
   }
 
-  protected void compileAndStartServerWithDatabase(Path workingDir) {
-    compileAndStartServerWithDatabase(workingDir, null);
+  public void compileAndStartServerWithDatabase() {
+    compileAndStartServerWithDatabase(null);
   }
 
-  protected void compileAndStartServerWithDatabase(Path workingDir, @Nullable String packageFile) {
+  public void compileAndStartServerWithDatabase(@Nullable String packageFile) {
     startPostgreSQLContainer();
-    compileSqrlProject(workingDir, packageFile);
+    sqrl.compileSqrlProject(packageFile);
 
-    startGraphQLServer(
-        workingDir,
+    sqrl.startGraphQLServer(
         container ->
             container
                 .withEnv(POSTGRES_HOST, "postgresql")
@@ -91,8 +99,7 @@ public abstract class SqrlWithPostgresContainerTestBase extends SqrlContainerTes
   }
 
   @Override
-  protected void commonTearDown() {
-    super.commonTearDown();
+  public void afterEach(ExtensionContext context) {
     if (postgresql != null) {
       postgresql.stop();
       postgresql = null;

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/S3ContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/S3ContainerIT.java
@@ -24,18 +24,23 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.MinIOContainer;
 
-public class S3ContainerIT extends SqrlContainerTestBase {
+public class S3ContainerIT {
+
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("seedshop-tutorial");
 
   private static final String BUCKET_NAME = "test";
   private static final String CRED = "minioadmin";
 
   private final MinIOContainer minioContainer =
       new MinIOContainer("minio/minio:RELEASE.2023-12-20T01-00-02Z")
-          .withNetwork(sharedNetwork)
+          .withNetwork(sqrl.getNetwork())
           .withNetworkAliases("minio")
           .withUserName(CRED)
           .withPassword(CRED)
@@ -64,9 +69,9 @@ public class S3ContainerIT extends SqrlContainerTestBase {
     s3Client.createBucket(BUCKET_NAME);
   }
 
-  @Override
-  protected void cleanupContainers() {
-    super.cleanupContainers();
+  @AfterEach
+  void tearDown() {
+    sqrl.cleanupContainers();
 
     if (s3Client != null) {
       s3Client.shutdown();
@@ -77,20 +82,14 @@ public class S3ContainerIT extends SqrlContainerTestBase {
     }
   }
 
-  @Override
-  protected String getTestCaseName() {
-    return "seedshop-tutorial";
-  }
-
   @Test
   void test() {
-    cmd =
-        createCmdContainer(testDir)
-            .withNetwork(sharedNetwork)
+    var cmd =
+        sqrl.createCmdContainer()
+            .withNetwork(sqrl.getNetwork())
             .withEnv("AWS_ACCESS_KEY_ID", CRED)
             .withEnv("AWS_SECRET_KEY", CRED)
             .withCommand("test", "package-s3.json");
-
     cmd.start();
 
     await().atMost(Duration.ofSeconds(90)).until(() -> !cmd.isRunning());

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ServerFunctionContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/ServerFunctionContainerIT.java
@@ -22,16 +22,18 @@ import java.sql.Statement;
 import lombok.SneakyThrows;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ServerFunctionContainerIT extends SqrlWithPostgresContainerTestBase {
+public class ServerFunctionContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "server-functions";
-  }
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("server-functions");
 
-  @Override
-  protected void executeStatements(Statement stmt) throws SQLException {
+  @RegisterExtension
+  static PostgresContainerExtension postgres =
+      new PostgresContainerExtension(sqrl, ServerFunctionContainerIT::executeStatements);
+
+  private static void executeStatements(Statement stmt) throws SQLException {
     // Create MyTable and populate with values 1-10
     stmt.execute(
         "CREATE TABLE IF NOT EXISTS \"Customers\" ("
@@ -49,14 +51,14 @@ public class ServerFunctionContainerIT extends SqrlWithPostgresContainerTestBase
   @Test
   @SneakyThrows
   void givenScript_whenCompiledAndServerStarted_thenApiRespondsCorrectly() {
-    compileAndStartServerWithDatabase(testDir);
-    var response =
-        executeGraphQLQuery(
-            "{\"query\":\"query { CustomersByName(inputName: \\\"Bobasd\\\") { customerid, name } }\"}");
+    postgres.compileAndStartServerWithDatabase();
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query { CustomersByName(inputName: \\\"Bobasd\\\") { customerid, name } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
 
-    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-
-    var responseBody = EntityUtils.toString(response.getEntity());
-    assertThat(responseBody).contains("Bob Jones");
+      var responseBody = EntityUtils.toString(response.getEntity());
+      assertThat(responseBody).contains("Bob Jones");
+    }
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlContainerExtension.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlContainerExtension.java
@@ -21,95 +21,86 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers
 @Slf4j
-public abstract class SqrlContainerTestBase {
+public class SqrlContainerExtension
+    implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
 
-  protected Path testDir;
+  public static final String SQRL_CMD_IMAGE = "datasqrl/cmd";
+  public static final String SQRL_SERVER_IMAGE = "datasqrl/sqrl-server";
+  public static final String BUILD_DIR = "/build";
+  public static final int HTTP_SERVER_PORT = 8888;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final String testCaseName;
+
+  @Getter private Network network;
+  @Getter private CloseableHttpClient httpClient;
+  @Getter private Path testDir;
+  @Getter private GenericContainer<?> serverContainer;
+
+  private List<GenericContainer<?>> commandContainers = new ArrayList<>();
   private long testStartTime;
   private String currentTestName;
 
-  protected abstract String getTestCaseName();
-
-  @BeforeEach
-  void setupBeforeEach(TestInfo testInfo) {
-    currentTestName = testInfo.getDisplayName();
-    testStartTime = System.currentTimeMillis();
-    log.info(">>> Starting: {}", currentTestName);
-    testDir = itPath(getTestCaseName());
+  public SqrlContainerExtension(String testCaseName) {
+    this.testCaseName = testCaseName;
   }
 
-  @AfterEach
-  protected void commonTearDown() {
-    cleanupContainers();
-    var elapsed = System.currentTimeMillis() - testStartTime;
-    log.info("<<< Finished: {} ({}ms)", currentTestName, elapsed);
-  }
-
-  protected static final String SQRL_CMD_IMAGE = "datasqrl/cmd";
-  protected static final String SQRL_SERVER_IMAGE = "datasqrl/sqrl-server";
-  protected static final String BUILD_DIR = "/build";
-  protected static final int HTTP_SERVER_PORT = 8888;
-
-  protected static Network sharedNetwork;
-  protected static CloseableHttpClient sharedHttpClient;
-  protected static final ObjectMapper objectMapper = new ObjectMapper();
-
-  protected GenericContainer<?> cmd;
-  protected GenericContainer<?> serverContainer;
-
-  @BeforeAll
-  static void setUpSharedResources() {
-    sharedNetwork = Network.newNetwork();
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    network = Network.newNetwork();
     var requestConfig =
         RequestConfig.custom()
             .setConnectTimeout(10_000)
             .setSocketTimeout(30_000)
             .setConnectionRequestTimeout(5_000)
             .build();
-    sharedHttpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+    httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
     log.info("Shared test resources initialized");
   }
 
-  @AfterAll
-  static void tearDownSharedResources() {
+  @Override
+  public void afterAll(ExtensionContext context) {
     try {
-      if (sharedHttpClient != null) {
-        sharedHttpClient.close();
+      if (httpClient != null) {
+        httpClient.close();
       }
-      if (sharedNetwork != null) {
-        sharedNetwork.close();
+      if (network != null) {
+        network.close();
       }
       log.info("Shared test resources cleaned up");
     } catch (Exception e) {
@@ -117,59 +108,94 @@ public abstract class SqrlContainerTestBase {
     }
   }
 
-  protected GenericContainer<?> createCmdContainer(Path workingDir) {
-    return createCmdContainer(workingDir, true);
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    currentTestName = context.getDisplayName();
+    testStartTime = System.currentTimeMillis();
+    log.info(">>> Starting: {}", currentTestName);
+    testDir = itPath(testCaseName);
   }
 
-  protected GenericContainer<?> createCmdContainer(Path workingDir, boolean debug) {
-    assertThat(workingDir).exists().isDirectory();
+  @Override
+  public void afterEach(ExtensionContext context) {
+    cleanupContainers();
+    var elapsed = System.currentTimeMillis() - testStartTime;
+    log.info("<<< Finished: {} ({}ms)", currentTestName, elapsed);
+  }
 
-    var container =
+  public GenericContainer<?> createCmdContainer() {
+    return createCmdContainer(true);
+  }
+
+  public GenericContainer<?> createCmdContainer(boolean debug) {
+    assertThat(testDir).exists().isDirectory();
+
+    var cmd =
         new GenericContainer<>(DockerImageName.parse(SQRL_CMD_IMAGE + ":" + getImageTag()))
             .withWorkingDirectory(BUILD_DIR)
-            .withFileSystemBind(workingDir.toString(), BUILD_DIR, BindMode.READ_WRITE)
+            .withFileSystemBind(testDir.toString(), BUILD_DIR, BindMode.READ_WRITE)
             .withEnv("TZ", "America/Los_Angeles");
-
     if (debug) {
-      container = container.withEnv("SQRL_DEBUG", "1");
+      cmd = cmd.withEnv("SQRL_DEBUG", "1");
     }
 
-    return container;
+    commandContainers.add(cmd);
+    return cmd;
   }
 
   @SuppressWarnings("resource")
-  protected GenericContainer<?> createServerContainer(Path workingDir) {
-    var deployPlanPath = workingDir.resolve("build/deploy/plan");
+  public GenericContainer<?> createServerContainer() {
+    var deployPlanPath = testDir.resolve("build/deploy/plan");
     assertThat(deployPlanPath).exists().isDirectory();
 
-    return new GenericContainer<>(DockerImageName.parse(SQRL_SERVER_IMAGE + ":" + getImageTag()))
-        .withNetwork(sharedNetwork)
-        .withExposedPorts(HTTP_SERVER_PORT)
-        .withFileSystemBind(deployPlanPath.toString(), "/opt/sqrl/config", BindMode.READ_ONLY)
-        .withEnv("SQRL_DEBUG", "1")
-        .waitingFor(
-            Wait.forLogMessage(".*HTTP server listening on port 8888.*", 1)
-                .withStartupTimeout(Duration.ofSeconds(30)));
+    assertThat(serverContainer).as("serverContainer is already set.").isNull();
+    serverContainer =
+        new GenericContainer<>(DockerImageName.parse(SQRL_SERVER_IMAGE + ":" + getImageTag()))
+            .withNetwork(network)
+            .withExposedPorts(HTTP_SERVER_PORT)
+            .withFileSystemBind(deployPlanPath.toString(), "/opt/sqrl/config", BindMode.READ_ONLY)
+            .withEnv("SQRL_DEBUG", "1")
+            .waitingFor(
+                Wait.forLogMessage(".*HTTP server listening on port 8888.*", 1)
+                    .withStartupTimeout(Duration.ofSeconds(30)));
+
+    return serverContainer;
   }
 
-  protected void compileSqrlProject(Path workingDir) {
-    compileSqrlProject(workingDir, null);
+  public void compileSqrlProject() {
+    compileSqrlProject(null);
   }
 
-  protected void compileSqrlProject(Path workingDir, @Nullable String packageFile) {
-    sqrlCmd(workingDir, "compile", packageFile != null ? packageFile : "package.json");
+  public void compileSqrlProject(@Nullable String packageFile) {
+    var result = sqrlCmd("compile", packageFile != null ? packageFile : "package.json");
+    validatePlan(result.logs());
+    assertBuildNotOwnedByRoot(testDir, result.logs());
   }
 
-  protected ContainerResult sqrlCmd(Path workingDir, String... command) {
-    return sqrlCmd(workingDir, true, command);
+  public void compileSqrlProject(
+      @Nullable String packageFile, Consumer<GenericContainer<?>> customizer) {
+    var result =
+        sqrlCmd(customizer, true, "compile", packageFile != null ? packageFile : "package.json");
+    validatePlan(result.logs());
+    assertBuildNotOwnedByRoot(testDir, result.logs());
   }
 
-  protected ContainerResult sqrlCmd(Path workingDir, boolean debug, String... command) {
-    cmd = createCmdContainer(workingDir, debug).withCommand(command);
+  public ContainerResult sqrlCmd(String... command) {
+    return sqrlCmd(true, command);
+  }
 
-    log.info("Docker run command to reproduce:");
-    log.info(getDockerRunCommand(cmd, workingDir));
+  public ContainerResult sqrlCmd(boolean debug, String... command) {
+    return sqrlCmd(c -> {}, debug, command);
+  }
 
+  public ContainerResult sqrlCmd(
+      Consumer<GenericContainer<?>> customizer, boolean debug, String... command) {
+    var cmd = createCmdContainer(debug).withCommand(command);
+    customizer.accept(cmd);
+
+    log.info("Docker run command to reproduce cmd:\n{}", getDockerRunCommand(cmd));
+
+    commandContainers.add(cmd);
     cmd.start();
 
     // Wait for the container to finish running
@@ -177,43 +203,18 @@ public abstract class SqrlContainerTestBase {
 
     var exitCode = cmd.getCurrentContainerInfo().getState().getExitCodeLong();
     var logs = cmd.getLogs();
-    if (exitCode != 0) {
+    if (exitCode == null || exitCode != 0) {
       log.error("SQRL compilation failed with exit code {}\n{}", exitCode, logs);
       throw new ContainerError("SQRL compilation failed", exitCode, logs);
     }
 
-    log.info("SQRL script {} compiled successfully", Arrays.toString(command));
-    validatePlan(workingDir, logs);
-    assertBuildNotOwnedByRoot(testDir, logs);
+    log.info("SQRL command {} completed successfully", Arrays.toString(command));
 
     return new ContainerResult(cmd, exitCode, logs);
   }
 
-  protected record ContainerResult(GenericContainer<?> cmd, Long exitCode, String logs) {}
-
-  @Getter
-  public static class ContainerError extends RuntimeException {
-
-    private static final long serialVersionUID = -2159257606710389109L;
-
-    private final Long exitCode;
-    private final String logs;
-
-    public ContainerError(String message, Long exitCode, String logs, Throwable cause) {
-      super(message, cause);
-      this.exitCode = exitCode;
-      this.logs = logs;
-    }
-
-    public ContainerError(String message, Long exitCode, String logs) {
-      super(message);
-      this.exitCode = exitCode;
-      this.logs = logs;
-    }
-  }
-
-  private void validatePlan(Path workingDir, String logs) {
-    var planDir = workingDir.resolve("build/deploy/plan");
+  private void validatePlan(String logs) {
+    var planDir = testDir.resolve("build/deploy/plan");
     assertThat(planDir).as("Compiler output:\n%s", logs).exists().isDirectory();
 
     assertSoftly(
@@ -226,18 +227,16 @@ public abstract class SqrlContainerTestBase {
         });
   }
 
-  protected void startGraphQLServer(Path workingDir) {
-    startGraphQLServer(workingDir, c -> {});
+  public void startGraphQLServer() {
+    startGraphQLServer(c -> {});
   }
 
-  protected void startGraphQLServer(
-      Path workingDir, Consumer<GenericContainer<?>> containerCustomizer) {
-    serverContainer = createServerContainer(workingDir);
+  public void startGraphQLServer(Consumer<GenericContainer<?>> containerCustomizer) {
+    serverContainer = createServerContainer();
 
     containerCustomizer.accept(serverContainer);
 
-    log.info("Docker run command to reproduce:");
-    log.info(getDockerRunCommand(serverContainer, workingDir));
+    log.info("Docker run command to reproduce server:\n{}", getDockerRunCommand(serverContainer));
 
     try {
       serverContainer.start();
@@ -265,51 +264,33 @@ public abstract class SqrlContainerTestBase {
     }
   }
 
-  protected String getBaseUrl() {
+  public String getBaseUrl() {
     if (serverContainer == null || !serverContainer.isRunning()) {
       throw new IllegalStateException("Server container is not running");
     }
     return "http://localhost:" + serverContainer.getMappedPort(HTTP_SERVER_PORT);
   }
 
-  protected String getGraphQLEndpoint() {
+  public String getGraphQLEndpoint() {
     return getBaseUrl() + "/v1/graphql";
   }
 
-  protected String getMetricsEndpoint() {
+  public String getMetricsEndpoint() {
     return getBaseUrl() + "/metrics";
   }
 
-  protected String getHealthEndpoint() {
+  public String getHealthEndpoint() {
     return getBaseUrl() + "/health";
-  }
-
-  protected void verifyNoSlfWarnings(GenericContainer<?> container) {
-    var logs = container.getLogs();
-    var slf4jWarningPattern = Pattern.compile("(log4j:WARN|SLF4J\\(W\\)|SLF4J:WARN)");
-
-    if (slf4jWarningPattern.matcher(logs).find()) {
-      throw new AssertionError("SLF4J / log4j warnings detected in container logs: " + logs);
-    }
-  }
-
-  protected void verifyLogContains(GenericContainer<?> container, String expectedPattern) {
-    var logs = container.getLogs();
-    if (!logs.contains(expectedPattern)) {
-      throw new AssertionError(
-          "Expected log entry '" + expectedPattern + "' not found in: " + logs);
-    }
   }
 
   private String getImageTag() {
     return System.getProperty("docker.image.tag", "local");
   }
 
-  protected String getDockerRunCommand(GenericContainer<?> container, Path workingDir) {
+  public String getDockerRunCommand(GenericContainer<?> container) {
     var sb = new StringBuilder();
     sb.append("docker run -it --rm");
 
-    // Extract ports
     var exposedPorts = container.getExposedPorts();
     if (exposedPorts != null && !exposedPorts.isEmpty()) {
       for (var port : exposedPorts) {
@@ -317,12 +298,9 @@ public abstract class SqrlContainerTestBase {
       }
     }
 
-    // Extract volume binds
     var binds = container.getBinds();
     if (binds != null && !binds.isEmpty()) {
       for (var bind : binds) {
-        // Parse the bind string which should be in format "hostPath:containerPath" or
-        // "hostPath:containerPath:mode"
         var bindString = bind.getPath();
         var parts = bindString.split(":");
         if (parts.length >= 2) {
@@ -337,7 +315,6 @@ public abstract class SqrlContainerTestBase {
       }
     }
 
-    // Extract environment variables
     var env = container.getEnvMap();
     if (env != null && !env.isEmpty()) {
       for (var entry : env.entrySet()) {
@@ -345,17 +322,14 @@ public abstract class SqrlContainerTestBase {
       }
     }
 
-    // Extract network
-    var network = container.getNetwork();
-    if (network != null) {
-      sb.append(" --network ").append(network.getId());
+    var containerNetwork = container.getNetwork();
+    if (containerNetwork != null) {
+      sb.append(" --network ").append(containerNetwork.getId());
     }
 
-    // Extract image name
     var dockerImageName = container.getDockerImageName();
     sb.append(" ").append(dockerImageName);
 
-    // Extract command
     var command = container.getCommandParts();
     if (command != null) {
       for (String part : command) {
@@ -367,7 +341,7 @@ public abstract class SqrlContainerTestBase {
   }
 
   @SneakyThrows
-  protected static Path itPath(String relativePath) {
+  public static Path itPath(String relativePath) {
     var directLocalPath = Paths.get("src/test/resources", relativePath).toAbsolutePath();
     if (Files.exists(directLocalPath) && Files.isDirectory(directLocalPath)) {
       return directLocalPath.toRealPath();
@@ -385,50 +359,50 @@ public abstract class SqrlContainerTestBase {
     return integrationPath.toRealPath();
   }
 
-  protected static void assertBuildNotOwnedByRoot(Path testDir, String logs) {
+  public static void assertBuildNotOwnedByRoot(Path testDir, String logs) {
     var buildPath = testDir.resolve("build");
     assertThat(buildPath).exists();
 
     assertOwner(buildPath, logs);
   }
 
-  protected static void assertOwner(Path path, String logs) {
+  public static void assertOwner(Path path, String logs) {
     try {
       var owner = Files.getOwner(path);
       assertThat(owner.getName())
           .as("Build directory should not be owned by root user: %s\n%s", path, logs)
           .isNotEqualTo("root");
       log.debug("Build directory {} is owned by: {}", path, owner.getName());
-    } catch (Exception e) {
+    } catch (IOException e) {
       fail("Failed to check build directory ownership: " + e.getMessage(), e);
     }
   }
 
-  protected void validateBasicGraphQLResponse(HttpResponse response) throws Exception {
+  public void validateBasicGraphQLResponse(HttpResponse response) throws Exception {
     assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
 
     var responseBody = EntityUtils.toString(response.getEntity());
-    var jsonResponse = objectMapper.readTree(responseBody);
+    var jsonResponse = OBJECT_MAPPER.readTree(responseBody);
 
     assertThat(jsonResponse.has("data")).isTrue();
     assertThat(jsonResponse.get("data").has("__typename")).isTrue();
     assertThat(jsonResponse.get("data").get("__typename").asText()).isEqualTo("Query");
   }
 
-  protected void compileAndStartServer(Path testDir) {
-    compileAndStartServer(testDir, null);
+  public void compileAndStartServer() {
+    compileAndStartServer(null);
   }
 
-  protected void compileAndStartServer(Path testDir, @Nullable String packageFile) {
-    compileSqrlProject(testDir, packageFile);
-    startGraphQLServer(testDir);
+  public void compileAndStartServer(@Nullable String packageFile) {
+    compileSqrlProject(packageFile);
+    startGraphQLServer();
   }
 
-  protected HttpResponse executeGraphQLQuery(String query) throws Exception {
+  public CloseableHttpResponse executeGraphQLQuery(String query) throws Exception {
     return executeGraphQLQuery(query, null);
   }
 
-  protected HttpResponse executeGraphQLQuery(String query, String jwtToken) throws Exception {
+  public CloseableHttpResponse executeGraphQLQuery(String query, String jwtToken) throws Exception {
     var request = new HttpPost(getGraphQLEndpoint());
     request.setEntity(new StringEntity(query, ContentType.APPLICATION_JSON));
 
@@ -436,10 +410,10 @@ public abstract class SqrlContainerTestBase {
       request.setHeader("Authorization", "Bearer " + jwtToken);
     }
 
-    return sharedHttpClient.execute(request);
+    return httpClient.execute(request);
   }
 
-  protected void assertLogFiles(String logs, Path testDir) {
+  public void assertLogFiles(String logs) {
     var logsDir = testDir.resolve("build/logs");
     assertThat(logsDir).as("Logs directory should exist\n%s", logs).exists().isDirectory();
 
@@ -462,14 +436,12 @@ public abstract class SqrlContainerTestBase {
                     ? cliLogContent.substring(0, 500) + "..."
                     : cliLogContent);
 
-            // Validate that log files are not owned by root
             var cliLogOwner = Files.getOwner(cliLogFile);
             softAssertions
                 .assertThat(cliLogOwner.getName())
                 .as("CLI log file should not be owned by root\n%s", logs)
                 .isNotEqualTo("root");
 
-            // Check for service log files if they exist
             var redpandaLogFile = logsDir.resolve("redpanda.log");
             if (Files.exists(redpandaLogFile)) {
               var redpandaLogContent = Files.readString(redpandaLogFile);
@@ -502,20 +474,18 @@ public abstract class SqrlContainerTestBase {
                   .isNotEqualTo("root");
             }
 
-          } catch (Exception e) {
+          } catch (IOException e) {
             softAssertions.fail("Failed to read log files: " + e.getMessage() + "\n" + logs);
           }
         });
   }
 
-  protected void cleanupContainers() {
-    if (serverContainer != null && serverContainer.isRunning()) {
+  public void cleanupContainers() {
+    if (serverContainer != null) {
       serverContainer.stop();
       serverContainer = null;
     }
-    if (cmd != null && cmd.isRunning()) {
-      cmd.stop();
-      cmd = null;
-    }
+    commandContainers.forEach(Startable::close);
+    commandContainers = new ArrayList<>();
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlRunContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlRunContainerIT.java
@@ -20,23 +20,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 @Slf4j
-public class SqrlRunContainerIT extends SqrlContainerTestBase {
+public class SqrlRunContainerIT {
+
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("avro-schema");
 
   private GenericContainer<?> runContainer;
 
-  @Override
-  protected String getTestCaseName() {
-    return "avro-schema";
+  @AfterEach
+  void tearDown() {
+    if (runContainer != null && runContainer.isRunning()) {
+      runContainer.stop();
+      runContainer = null;
+    }
   }
 
   @Test
@@ -44,12 +51,12 @@ public class SqrlRunContainerIT extends SqrlContainerTestBase {
   void givenAvroSchemaScript_whenRunCommandExecuted_thenServerStartsAndRespondsToGraphQL() {
     // Start the run container which compiles and runs the server all in one
     runContainer =
-        createCmdContainer(testDir)
+        sqrl.createCmdContainer()
             .withCommand("run")
-            .withExposedPorts(HTTP_SERVER_PORT)
+            .withExposedPorts(SqrlContainerExtension.HTTP_SERVER_PORT)
             .waitingFor(
                 Wait.forHttp("/health")
-                    .forPort(HTTP_SERVER_PORT)
+                    .forPort(SqrlContainerExtension.HTTP_SERVER_PORT)
                     .forStatusCode(204)
                     .withStartupTimeout(Duration.ofSeconds(30)));
 
@@ -63,39 +70,34 @@ public class SqrlRunContainerIT extends SqrlContainerTestBase {
     assertThat(logs).contains("GraphQL verticle deployed successfully");
 
     // Test GraphQL endpoint
-    var baseUrl = "http://localhost:" + runContainer.getMappedPort(HTTP_SERVER_PORT);
+    var baseUrl =
+        "http://localhost:" + runContainer.getMappedPort(SqrlContainerExtension.HTTP_SERVER_PORT);
     var graphqlEndpoint = baseUrl + "/v1/graphql";
 
-    var response =
-        executeGraphQLQueryToRunContainer(graphqlEndpoint, "{\"query\":\"query { __typename }\"}");
-    validateBasicGraphQLResponse(response);
+    try (var response =
+        executeGraphQLQueryToRunContainer(
+            graphqlEndpoint, "{\"query\":\"query { __typename }\"}")) {
+      sqrl.validateBasicGraphQLResponse(response);
+    }
 
     // Verify health endpoint
     var healthEndpoint = baseUrl + "/health";
-    var healthResponse = executeHealthCheck(healthEndpoint);
-    assertThat(healthResponse.getStatusLine().getStatusCode()).isEqualTo(204);
+    try (var healthResponse = executeHealthCheck(healthEndpoint)) {
+      assertThat(healthResponse.getStatusLine().getStatusCode()).isEqualTo(204);
+    }
 
     log.info("All endpoint validations passed successfully");
   }
 
-  @Override
-  protected void cleanupContainers() {
-    super.cleanupContainers();
-    if (runContainer != null && runContainer.isRunning()) {
-      runContainer.stop();
-      runContainer = null;
-    }
-  }
-
-  private HttpResponse executeGraphQLQueryToRunContainer(String endpoint, String query)
+  private CloseableHttpResponse executeGraphQLQueryToRunContainer(String endpoint, String query)
       throws Exception {
     var request = new HttpPost(endpoint);
     request.setEntity(new StringEntity(query, ContentType.APPLICATION_JSON));
-    return sharedHttpClient.execute(request);
+    return sqrl.getHttpClient().execute(request);
   }
 
-  private HttpResponse executeHealthCheck(String endpoint) throws Exception {
+  private CloseableHttpResponse executeHealthCheck(String endpoint) throws Exception {
     var request = new HttpGet(endpoint);
-    return sharedHttpClient.execute(request);
+    return sqrl.getHttpClient().execute(request);
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlTestContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SqrlTestContainerIT.java
@@ -22,19 +22,17 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Slf4j
-public class SqrlTestContainerIT extends SqrlContainerTestBase {
+public class SqrlTestContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "avro-schema";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("avro-schema");
 
   @Test
   @SneakyThrows
   void givenAvroSchemaScript_whenTestCommandExecuted_thenSnapshotsValidateSuccessfully() {
-    var result = sqrlCmd(testDir, "test package.json".split(" "));
+    var result = sqrl.sqrlCmd("test package.json".split(" "));
 
     var logs = result.logs();
     log.info("SQRL test command executed successfully");
@@ -54,7 +52,7 @@ public class SqrlTestContainerIT extends SqrlContainerTestBase {
         .doesNotContain("SLF4J: See http://www.slf4j.org/codes.html");
 
     // Validate log files are present and have content
-    assertLogFiles(logs, testDir);
+    sqrl.assertLogFiles(logs);
 
     log.info("All snapshot validations passed successfully");
   }
@@ -62,13 +60,13 @@ public class SqrlTestContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenAvroPackage_whenTestCommandExecuted_thenSnapshotsValidateSuccessfully() {
-    var snapshots = testDir.resolve("snapshots-tmp");
+    var snapshots = sqrl.getTestDir().resolve("snapshots-tmp");
     FileUtils.deleteDirectory(snapshots.toFile());
 
     // Assert that the test command throws a RuntimeException and capture the exception
     ContainerError exception =
         (ContainerError)
-            assertThatThrownBy(() -> sqrlCmd(testDir, "test package-no-snapshots.json".split(" ")))
+            assertThatThrownBy(() -> sqrl.sqrlCmd("test package-no-snapshots.json".split(" ")))
                 .isInstanceOf(ContainerError.class)
                 .hasMessageContaining("SQRL compilation failed")
                 .actual();
@@ -79,14 +77,14 @@ public class SqrlTestContainerIT extends SqrlContainerTestBase {
     // Assert that the logs contain the expected error messages
     assertThat(logs).contains("Snapshot created for test:");
 
-    assertOwner(snapshots, logs);
+    SqrlContainerExtension.assertOwner(snapshots, logs);
     FileUtils.deleteDirectory(snapshots.toFile());
   }
 
   @Test
   @SneakyThrows
   void givenAvroSchemaScript_whenTestCommandExecutedWithoutDebug_thenNoBashDebugLogsPresent() {
-    var result = sqrlCmd(testDir, false, "test package.json".split(" "));
+    var result = sqrl.sqrlCmd(false, "test package.json".split(" "));
 
     var logs = result.logs();
     log.info("SQRL test command executed without DEBUG=1");
@@ -107,7 +105,7 @@ public class SqrlTestContainerIT extends SqrlContainerTestBase {
         .doesNotContain("set +x");
 
     // Validate log files are present and have content
-    assertLogFiles(logs, testDir);
+    sqrl.assertLogFiles(logs);
 
     log.info("Test completed successfully without bash debug logs");
   }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SwaggerContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/SwaggerContainerIT.java
@@ -25,19 +25,19 @@ import lombok.SneakyThrows;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class SwaggerContainerIT extends SqrlContainerTestBase {
+public class SwaggerContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "avro-schema";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("avro-schema");
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Test
   @SneakyThrows
   void givenSwaggerTest_whenCompiledAndServerStarted_thenSwaggerEndpointsAvailable() {
     // Compile and start the server
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     // Test Swagger JSON endpoint
     testSwaggerJsonEndpoint();
@@ -48,23 +48,25 @@ public class SwaggerContainerIT extends SqrlContainerTestBase {
 
   @SneakyThrows
   private void testSwaggerJsonEndpoint() {
-    var swaggerJsonUrl = getBaseUrl() + "/v1/swagger";
+    var swaggerJsonUrl = sqrl.getBaseUrl() + "/v1/swagger";
     var request = new HttpGet(swaggerJsonUrl);
-    var response = sharedHttpClient.execute(request);
+    String responseBody;
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      // Verify response status
+      assertThat(response.getStatusLine().getStatusCode())
+          .as("Swagger JSON endpoint should return 200")
+          .isEqualTo(200);
 
-    // Verify response status
-    assertThat(response.getStatusLine().getStatusCode())
-        .as("Swagger JSON endpoint should return 200")
-        .isEqualTo(200);
+      // Verify content type
+      assertThat(response.getEntity().getContentType().getValue())
+          .as("Swagger JSON should have correct content type")
+          .isEqualTo("application/json");
 
-    // Verify content type
-    assertThat(response.getEntity().getContentType().getValue())
-        .as("Swagger JSON should have correct content type")
-        .isEqualTo("application/json");
+      responseBody = EntityUtils.toString(response.getEntity());
+    }
 
     // Parse and validate JSON structure
-    var responseBody = EntityUtils.toString(response.getEntity());
-    var jsonResponse = objectMapper.readTree(responseBody);
+    var jsonResponse = new ObjectMapper().readTree(responseBody);
 
     // Verify OpenAPI structure
     assertThat(jsonResponse.has("openapi")).as("Response should contain OpenAPI version").isTrue();
@@ -91,40 +93,40 @@ public class SwaggerContainerIT extends SqrlContainerTestBase {
 
   @SneakyThrows
   private void testSwaggerUIEndpoint() {
-    var swaggerUIUrl = getBaseUrl() + "/v1/swagger-ui";
+    var swaggerUIUrl = sqrl.getBaseUrl() + "/v1/swagger-ui";
     var request = new HttpGet(swaggerUIUrl);
-    var response = sharedHttpClient.execute(request);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      // Verify response status
+      assertThat(response.getStatusLine().getStatusCode())
+          .as("Swagger UI endpoint should return 200")
+          .isEqualTo(200);
 
-    // Verify response status
-    assertThat(response.getStatusLine().getStatusCode())
-        .as("Swagger UI endpoint should return 200")
-        .isEqualTo(200);
+      // Verify content type
+      assertThat(response.getEntity().getContentType().getValue())
+          .as("Swagger UI should have HTML content type")
+          .isEqualTo("text/html");
 
-    // Verify content type
-    assertThat(response.getEntity().getContentType().getValue())
-        .as("Swagger UI should have HTML content type")
-        .isEqualTo("text/html");
-
-    // Verify HTML content contains Swagger UI
-    var responseBody = EntityUtils.toString(response.getEntity());
-    assertThat(responseBody)
-        .as("Response should contain Swagger UI HTML")
-        .contains("swagger-ui")
-        .contains("SwaggerUIBundle")
-        .contains("DataSQRL REST API");
+      // Verify HTML content contains Swagger UI
+      var responseBody = EntityUtils.toString(response.getEntity());
+      assertThat(responseBody)
+          .as("Response should contain Swagger UI HTML")
+          .contains("swagger-ui")
+          .contains("SwaggerUIBundle")
+          .contains("DataSQRL REST API");
+    }
   }
 
   @Test
   @SneakyThrows
   void givenDisabledSwaggerConfig_whenCompiledAndServerStarted_thenSwaggerEndpointsNotAvailable() {
     // Compile the script first
-    compileSqrlProject(testDir);
+    sqrl.compileSqrlProject();
 
     // Modify the server configuration to disable Swagger
-    disableSwaggerInConfiguration(testDir);
+    disableSwaggerInConfiguration(sqrl.getTestDir());
 
     // Start the server with modified configuration
-    startGraphQLServer(testDir);
+    sqrl.startGraphQLServer();
 
     // Test that Swagger JSON endpoint returns 404
     testSwaggerEndpointNotAvailable("/swagger");
@@ -139,11 +141,10 @@ public class SwaggerContainerIT extends SqrlContainerTestBase {
 
     // Read the existing configuration
     var configContent = Files.readString(vertxConfigPath);
-    var mapper = new ObjectMapper();
-    var configNode = (ObjectNode) mapper.readTree(configContent);
+    var configNode = (ObjectNode) OBJECT_MAPPER.readTree(configContent);
 
     // Add disabled Swagger configuration
-    var swaggerConfig = mapper.createObjectNode();
+    var swaggerConfig = OBJECT_MAPPER.createObjectNode();
     swaggerConfig.put("enabled", false);
     swaggerConfig.put("endpoint", "/swagger");
     swaggerConfig.put("uiEndpoint", "/swagger-ui");
@@ -151,18 +152,19 @@ public class SwaggerContainerIT extends SqrlContainerTestBase {
 
     // Write back the modified configuration
     Files.writeString(
-        vertxConfigPath, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(configNode));
+        vertxConfigPath,
+        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(configNode));
   }
 
   @SneakyThrows
   private void testSwaggerEndpointNotAvailable(String endpoint) {
-    var url = getBaseUrl() + endpoint;
+    var url = sqrl.getBaseUrl() + endpoint;
     var request = new HttpGet(url);
-    var response = sharedHttpClient.execute(request);
-
-    // Verify response status is 404 (not found)
-    assertThat(response.getStatusLine().getStatusCode())
-        .as("Swagger endpoint %s should return 404 when disabled", endpoint)
-        .isEqualTo(404);
+    try (var response = sqrl.getHttpClient().execute(request)) {
+      // Verify response status is 404 (not found)
+      assertThat(response.getStatusLine().getStatusCode())
+          .as("Swagger endpoint %s should return 404 when disabled", endpoint)
+          .isEqualTo(404);
+    }
   }
 }

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/TesterConsoleOutputIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/TesterConsoleOutputIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Integration test that verifies warnings and errors during test execution are properly surfaced in
@@ -30,19 +31,17 @@ import org.junit.jupiter.api.Test;
  * test reports, failure details) is visible to help users debug issues.
  */
 @Slf4j
-public class TesterConsoleOutputIT extends SqrlContainerTestBase {
+public class TesterConsoleOutputIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "null-timestamp";
-  }
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("null-timestamp");
 
   @Test
   @SneakyThrows
   void givenNullTimestampAndPrintLogger_whenTestExecuted_thenErrorIsCapturedAndDisplayed() {
     ContainerError exception =
         (ContainerError)
-            assertThatThrownBy(() -> sqrlCmd(testDir, "test package.json".split(" ")))
+            assertThatThrownBy(() -> sqrl.sqrlCmd("test package.json".split(" ")))
                 .isInstanceOf(ContainerError.class)
                 .hasMessageContaining("SQRL compilation failed")
                 .actual();

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/VertxContainerIT.java
@@ -27,31 +27,31 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class VertxContainerIT extends SqrlContainerTestBase {
+public class VertxContainerIT {
 
-  @Override
-  protected String getTestCaseName() {
-    return "udf";
-  }
+  @RegisterExtension static SqrlContainerExtension sqrl = new SqrlContainerExtension("udf");
 
   @Test
   @SneakyThrows
   void givenUdfScript_whenCompiledAndServerStarted_thenApiRespondsCorrectly() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
-    var response = executeGraphQLQuery("{\"query\":\"query { __typename }\"}");
-    validateBasicGraphQLResponse(response);
+    try (var response = sqrl.executeGraphQLQuery("{\"query\":\"query { __typename }\"}")) {
+      sqrl.validateBasicGraphQLResponse(response);
+    }
   }
 
   @Test
   @SneakyThrows
   void givenTraceRequestsEnabled_whenGraphQLRequestSent_thenRequestBodyLoggedInServerLogs() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     var testQuery = "{\"query\":\"query { __typename }\"}";
-    var response = executeGraphQLQuery(testQuery);
-    validateBasicGraphQLResponse(response);
+    try (var response = sqrl.executeGraphQLQuery(testQuery)) {
+      sqrl.validateBasicGraphQLResponse(response);
+    }
 
     assertTraceLogContains("ReqBody:");
   }
@@ -59,31 +59,34 @@ public class VertxContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenTraceRequestsEnabled_whenHttpRequestsMade_thenLogPathAndBody() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     var testQuery = "{\"query\":\"query { __typename }\"}";
-    var response = executeGraphQLQuery(testQuery);
-    validateBasicGraphQLResponse(response);
+    try (var response = sqrl.executeGraphQLQuery(testQuery)) {
+      sqrl.validateBasicGraphQLResponse(response);
+    }
 
     assertTraceLogContains("ReqBody:", testQuery, "/v1/graphql");
 
     var randomPath = "/random/test/path/12345";
     var testBody = "{\"test\":\"data\",\"random\":\"content\"}";
 
-    var randomRequest = new HttpPost(getBaseUrl() + randomPath);
+    var randomRequest = new HttpPost(sqrl.getBaseUrl() + randomPath);
     randomRequest.setEntity(new StringEntity(testBody, ContentType.APPLICATION_JSON));
 
-    var randomResponse = sharedHttpClient.execute(randomRequest);
-    EntityUtils.consume(randomResponse.getEntity());
+    try (var randomResponse = sqrl.getHttpClient().execute(randomRequest)) {
+      EntityUtils.consume(randomResponse.getEntity());
+    }
 
     assertTraceLogContains("ReqBody:", testBody, randomPath);
 
-    var graphiqlResponse = sharedHttpClient.execute(new HttpGet(getBaseUrl() + "/v1/graphiql/"));
-
-    assertThat(graphiqlResponse.getStatusLine().getStatusCode()).isEqualTo(200);
-    assertThat(graphiqlResponse.getFirstHeader("Content-Type").getValue()).contains("text/html");
-
-    var graphiql = EntityUtils.toString(graphiqlResponse.getEntity());
+    String graphiql;
+    try (var graphiqlResponse =
+        sqrl.getHttpClient().execute(new HttpGet(sqrl.getBaseUrl() + "/v1/graphiql/"))) {
+      assertThat(graphiqlResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+      assertThat(graphiqlResponse.getFirstHeader("Content-Type").getValue()).contains("text/html");
+      graphiql = EntityUtils.toString(graphiqlResponse.getEntity());
+    }
 
     assertThat(graphiql)
         .contains("<!doctype html>")
@@ -104,11 +107,12 @@ public class VertxContainerIT extends SqrlContainerTestBase {
   @Test
   @SneakyThrows
   void givenTraceRequestsEnabled_whenRequestsMade_thenLogsContainRequestPrefix() {
-    compileAndStartServer(testDir);
+    sqrl.compileAndStartServer();
 
     var testQuery = "{\"query\":\"query { __typename }\"}";
-    var response = executeGraphQLQuery(testQuery);
-    validateBasicGraphQLResponse(response);
+    try (var response = sqrl.executeGraphQLQuery(testQuery)) {
+      sqrl.validateBasicGraphQLResponse(response);
+    }
 
     // Verify that log entries contain request ID prefix and all key elements in single line
     assertTraceLogMatchesPattern("\\[REQ-\\d+-\\d+\\] POST /v1/graphql \\| Status: \\d+");
@@ -150,7 +154,7 @@ public class VertxContainerIT extends SqrlContainerTestBase {
     var logPath = "/opt/sqrl/logs/request-trace.log";
 
     // Copy log file from container to temp location and read it
-    var result = serverContainer.execInContainer("cat", logPath);
+    var result = sqrl.getServerContainer().execInContainer("cat", logPath);
     if (result.getExitCode() != 0) {
       throw new RuntimeException("Failed to read request trace log: " + result.getStderr());
     }


### PR DESCRIPTION
- Refactor container integration tests to use reusable JUnit 5 extensions instead of inheritance-based classes
- Centralize shared container lifecycle, command execution, and PostgreSQL setup in SqrlContainerExtension and PostgresContainerExtension
- Improve test reliability and diagnostics with better resource cleanup, explicit container result/error handling

Closes #1980 