### PR TITLE
chore: Refactor AbstractITSupport with JUnit extension

### DIFF
--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/flinkrunner/FlinkSqlRunnerExtension.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/flinkrunner/FlinkSqlRunnerExtension.java
@@ -32,7 +32,7 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class FlinkContainerExtension implements BeforeEachCallback, AfterEachCallback {
+public class FlinkSqlRunnerExtension implements BeforeEachCallback, AfterEachCallback {
 
   private static final int FLINK_REST_PORT = 8081;
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/flinkrunner/FlinkSqlRunnerIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/flinkrunner/FlinkSqlRunnerIT.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @Slf4j
 class FlinkSqlRunnerIT {
 
-  @RegisterExtension final FlinkContainerExtension flink = new FlinkContainerExtension();
+  @RegisterExtension final FlinkSqlRunnerExtension flink = new FlinkSqlRunnerExtension();
 
   @Test
   void givenPlan_whenInvokingFormatFunction_thenSuccess() throws Exception {


### PR DESCRIPTION
- Removed `AbstractITSupport`
- Added `FlinkContainerExtension` as a JUnit extension that can help spinning up Flink containers with the `flink-sql-runner` image
- Improved assertions where I could