### PR TITLE
fix: Mutation engine hint error location is wrong when table has doc comment

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -72,6 +72,7 @@ import com.datasqrl.planner.hint.TestHint;
 import com.datasqrl.planner.hint.TtlHint;
 import com.datasqrl.planner.parser.AccessModifier;
 import com.datasqrl.planner.parser.FlinkSQLStatement;
+import com.datasqrl.planner.parser.NoLocationStatementParserException;
 import com.datasqrl.planner.parser.ParsePosUtil;
 import com.datasqrl.planner.parser.ParsedObject;
 import com.datasqrl.planner.parser.ParsedStatement;
@@ -219,15 +220,29 @@ public class SqlScriptPlanner {
   public void planMain(MainScript mainScript, Sqrl2FlinkSQLTranslator sqrlEnv) {
     var scriptErrors = errorCollector.withScript(mainScript.getPath(), mainScript.getContent());
     var statements = sqrlParser.parseScript(mainScript.getContent(), scriptErrors);
-    List<StackableStatement> statementStack = new ArrayList<>();
+    var statementStack = new ArrayList<StackableStatement>();
+
     for (ParsedStatement sourceStmt : statements) {
       var statement = sourceStmt.statement();
       var lineErrors = scriptErrors.atFile(statement.getFileLocation());
       var sqlStatement = statement.get();
+
       try {
         planStatement(sqlStatement, statementStack, sqrlEnv, lineErrors);
+
       } catch (CollectedException e) {
         throw e;
+
+      } catch (NoLocationStatementParserException e) {
+        FileLocation location;
+        if (sqlStatement instanceof SqrlStatement sqrlStmt) {
+          location = sqrlStmt.getDefaultLocation();
+        } else {
+          location = statement.getFileLocation();
+        }
+
+        throw lineErrors.handle(new StatementParserException(location, e));
+
       } catch (Throwable e) {
         // Map errors from the Flink parser/planner by adjusting the line numbers
         var converted = ParsePosUtil.convertFlinkParserException(e);
@@ -256,9 +271,11 @@ public class SqlScriptPlanner {
         // Use registered error handlers
         throw lineErrors.handle(e);
       }
+
       if (!(sqlStatement instanceof SqrlImportStatement)) {
         completeScript.append(sourceStmt.source());
       }
+
       /*Some SQRL statements extend previous statements, so we stack them to keep
       of the lineage as needed for planning
        */
@@ -826,6 +843,7 @@ public class SqlScriptPlanner {
     NamePath aliasPath = null;
     if (importStmt.getAlias().isPresent()) {
       aliasPath = importStmt.getAlias().get();
+      ;
       checkFatal(
           aliasPath.size() == 1,
           ErrorCode.INVALID_IMPORT,

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -42,6 +42,7 @@ import com.datasqrl.planner.analyzer.TableAnalysis;
 import com.datasqrl.planner.analyzer.TableOrFunctionAnalysis;
 import com.datasqrl.planner.dag.plan.MutationTable.MutationTableBuilder;
 import com.datasqrl.planner.hint.PlannerHints;
+import com.datasqrl.planner.parser.NoLocationStatementParserException;
 import com.datasqrl.planner.parser.ParsePosUtil;
 import com.datasqrl.planner.parser.ParsePosUtil.MessageLocation;
 import com.datasqrl.planner.parser.ParsedObject;
@@ -1143,7 +1144,7 @@ public class Sqrl2FlinkSQLTranslator {
 
     // TODO: Collect supported engines dynamically in a sane way
     if (!tableName.endsWith("_schema") && options.isEmpty() && mutationBuilder.isEmpty()) {
-      throw new StatementParserException(
+      throw new NoLocationStatementParserException(
           "Mutation engine hint \"/*+ engine(...) */\" is required for internal CREATE TABLE statements."
               + " Supported engines: \"kafka\", \"iceberg\".");
     }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/NoLocationStatementParserException.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/NoLocationStatementParserException.java
@@ -15,27 +15,9 @@
  */
 package com.datasqrl.planner.parser;
 
-import com.datasqrl.error.ErrorLocation.FileLocation;
-import lombok.Value;
+public class NoLocationStatementParserException extends RuntimeException {
 
-/** Reprensets a CREATE TABLE statement */
-@Value
-public class SqrlCreateTableStatement implements SqrlDdlStatement {
-
-  ParsedObject<String> createTable;
-  SqrlComments comments;
-
-  public String toSql() {
-    return createTable.get();
-  }
-
-  @Override
-  public FileLocation mapSqlLocation(FileLocation location) {
-    return createTable.getFileLocation().add(location);
-  }
-
-  @Override
-  public FileLocation getDefaultLocation() {
-    return createTable.getFileLocation();
+  public NoLocationStatementParserException(String message) {
+    super(message);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlDefinition.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlDefinition.java
@@ -77,4 +77,9 @@ public abstract class SqrlDefinition implements SqrlStatement {
         .getFileLocation()
         .add(SQLStatement.removeFirstRowOffset(location, getPrefix().length()));
   }
+
+  @Override
+  public FileLocation getDefaultLocation() {
+    return tableName.getFileLocation();
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlExportStatement.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlExportStatement.java
@@ -16,6 +16,7 @@
 package com.datasqrl.planner.parser;
 
 import com.datasqrl.canonicalizer.NamePath;
+import com.datasqrl.error.ErrorLocation;
 import lombok.Value;
 
 /** Represents an EXPORT statement */
@@ -25,4 +26,9 @@ public class SqrlExportStatement implements SqrlDdlStatement {
   ParsedObject<NamePath> tableIdentifier;
   ParsedObject<NamePath> packageIdentifier;
   SqrlComments comments;
+
+  @Override
+  public ErrorLocation.FileLocation getDefaultLocation() {
+    return packageIdentifier.getFileLocation();
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlImportStatement.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlImportStatement.java
@@ -16,6 +16,7 @@
 package com.datasqrl.planner.parser;
 
 import com.datasqrl.canonicalizer.NamePath;
+import com.datasqrl.error.ErrorLocation;
 import lombok.Value;
 
 /** Represents an EXPORT statement */
@@ -25,4 +26,9 @@ public class SqrlImportStatement implements SqrlDdlStatement {
   ParsedObject<NamePath> packageIdentifier;
   ParsedObject<NamePath> alias;
   SqrlComments comments;
+
+  @Override
+  public ErrorLocation.FileLocation getDefaultLocation() {
+    return packageIdentifier.getFileLocation();
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlNextBatch.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlNextBatch.java
@@ -15,11 +15,12 @@
  */
 package com.datasqrl.planner.parser;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import com.datasqrl.error.ErrorLocation;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class SqrlNextBatch implements SqrlStatement {
+public record SqrlNextBatch(ParsedObject<String> sql) implements SqrlStatement {
 
-  public static final SqrlNextBatch INSTANCE = new SqrlNextBatch();
+  @Override
+  public ErrorLocation.FileLocation getDefaultLocation() {
+    return sql.getFileLocation();
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlStatement.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlStatement.java
@@ -15,10 +15,14 @@
  */
 package com.datasqrl.planner.parser;
 
+import com.datasqrl.error.ErrorLocation.FileLocation;
+
 /** A SQRL specific statement */
 public interface SqrlStatement extends SQLStatement {
 
   default SqrlComments getComments() {
     return SqrlComments.EMPTY;
   }
+
+  FileLocation getDefaultLocation();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlStatementParser.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqrlStatementParser.java
@@ -304,7 +304,7 @@ public class SqrlStatementParser {
     // #4: Next Batch
     var nextBatch = NEXT_BATCH_PARSER.matcher(statement);
     if (nextBatch.find()) {
-      return SqrlNextBatch.INSTANCE;
+      return new SqrlNextBatch(new ParsedObject<>(statement, FileLocation.START));
     }
 
     // #5: If none of the regex match, we assume it's a Flink SQL statement

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/mutationHintMissing-fail.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/mutationHintMissing-fail.sqrl
@@ -6,6 +6,9 @@ CREATE TABLE _SensorsValid (
     PRIMARY KEY (sensorid) NOT ENFORCED
 );
 
+/**
+  Multi-line doc comment
+  */
 CREATE TABLE _SensorsInvalid (
     sensorid INT,
     machineid INT,
@@ -13,4 +16,4 @@ CREATE TABLE _SensorsInvalid (
     PRIMARY KEY (sensorid) NOT ENFORCED
 );
 
-Sensors := SELECT * FROM _Sensors;
+Sensors := SELECT * FROM _SensorsValid;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationHintMissing-fail.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationHintMissing-fail.txt
@@ -1,7 +1,7 @@
 [FATAL] Mutation engine hint "/*+ engine(...) */" is required for internal CREATE TABLE statements. Supported engines: "kafka", "iceberg".
-in script:mutationHintMissing-fail.sqrl [9:1]:
-);
-
+in script:mutationHintMissing-fail.sqrl [12:1]:
+  Multi-line doc comment
+  */
 CREATE TABLE _SensorsInvalid (
 ^
 


### PR DESCRIPTION
## Key Changes
- Introduce `NoLocationStatementParserException` with optional custom logic on getting file location
- Add `getDefaultLocation` to `SqrlStatement` where we can specify the proper location per statement type
- Catch the exception on the script planner level, and retrieve the proper file location via `getDefaultLocation`