### PR TITLE
fix: Write mutation records with keys properly to Kafka

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
@@ -106,7 +106,6 @@ public class GraphqlModelGenerator extends GraphqlSchemaWalker {
       FieldDefinition atField, TypeDefinitionRegistry registry, MutationTable mutation) {
 
     var computedCols = mutation.getComputedColumns();
-    var keysCols = mutation.getTableBuilder().getPrimaryKey().orElse(List.of());
     var returnList = GraphqlSchemaUtil.isListType(atField.getType());
 
     if (mutation.getCreateTable() instanceof KafkaLogEngine.Table mutationTopic) {
@@ -115,7 +114,7 @@ public class GraphqlModelGenerator extends GraphqlSchemaWalker {
               atField.getName(),
               returnList,
               mutationTopic.topicName(),
-              Set.copyOf(keysCols),
+              mutationTopic.messageKeys(),
               computedCols,
               mutation.getInsertType() == MutationInsertType.TRANSACTION,
               Map.of()));

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/GraphqlModelGenerator.java
@@ -104,15 +104,19 @@ public class GraphqlModelGenerator extends GraphqlSchemaWalker {
   @Override
   protected void visitMutation(
       FieldDefinition atField, TypeDefinitionRegistry registry, MutationTable mutation) {
-    var computedColumns = mutation.getComputedColumns();
+
+    var computedCols = mutation.getComputedColumns();
+    var keysCols = mutation.getTableBuilder().getPrimaryKey().orElse(List.of());
     var returnList = GraphqlSchemaUtil.isListType(atField.getType());
+
     if (mutation.getCreateTable() instanceof KafkaLogEngine.Table mutationTopic) {
       mutations.add(
           new KafkaMutationCoords(
               atField.getName(),
               returnList,
               mutationTopic.topicName(),
-              computedColumns,
+              Set.copyOf(keysCols),
+              computedCols,
               mutation.getInsertType() == MutationInsertType.TRANSACTION,
               Map.of()));
     } else {

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/RootGraphqlModel.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/RootGraphqlModel.java
@@ -133,7 +133,7 @@ public class RootGraphqlModel {
     protected String fieldName;
     protected boolean returnList;
     protected String topic;
-    protected Set<String> keyColumns;
+    protected List<String> keyColumns;
     protected Map<String, ResolvedMetadata> computedColumns;
     protected boolean transactional;
     protected Map<String, String> sinkConfig;

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/RootGraphqlModel.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/graphql/server/RootGraphqlModel.java
@@ -124,6 +124,7 @@ public class RootGraphqlModel {
   }
 
   @Getter
+  @AllArgsConstructor
   @NoArgsConstructor
   public static class KafkaMutationCoords extends MutationCoords {
 
@@ -132,24 +133,10 @@ public class RootGraphqlModel {
     protected String fieldName;
     protected boolean returnList;
     protected String topic;
+    protected Set<String> keyColumns;
     protected Map<String, ResolvedMetadata> computedColumns;
     protected boolean transactional;
     protected Map<String, String> sinkConfig;
-
-    public KafkaMutationCoords(
-        String fieldName,
-        boolean returnList,
-        String topic,
-        Map<String, ResolvedMetadata> computedColumns,
-        boolean transactional,
-        Map<String, String> sinkConfig) {
-      this.fieldName = fieldName;
-      this.returnList = returnList;
-      this.topic = topic;
-      this.computedColumns = computedColumns;
-      this.transactional = transactional;
-      this.sinkConfig = sinkConfig;
-    }
 
     @Override
     public <R, C> R accept(MutationCoordsVisitor<R, C> visitor, C context) {

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
@@ -40,7 +40,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -66,9 +65,9 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
           KafkaProducer.create(
               vertx, config.getKafkaMutationConfig().asMap(coords.isTransactional()));
 
-      SinkProducer emitter = new KafkaSinkProducer<>(coords.getTopic(), producer);
-      Set<String> keyColumns = coords.getKeyColumns();
-      final Map<String, ComputeInputColumns> computedInputColumns = new HashMap<>();
+      var emitter = new KafkaSinkProducer<>(coords.getTopic(), producer);
+      var keyColumns = coords.getKeyColumns();
+      final var computedInputColumns = new HashMap<String, ComputeInputColumns>();
 
       coords
           .getComputedColumns()
@@ -123,7 +122,7 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
 
   private List<SinkProducer.Record> getRecords(
       DataFetchingEnvironment env,
-      Set<String> keyColumns,
+      List<String> keyColumns,
       Map<String, ComputeInputColumns> computedColumns) {
     // Rules:
     // - Only one argument is allowed, it doesn't matter the name

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/MutationConfigurationImpl.java
@@ -34,10 +34,13 @@ import io.vertx.core.Vertx;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -62,8 +65,11 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
       KafkaProducer<String, String> producer =
           KafkaProducer.create(
               vertx, config.getKafkaMutationConfig().asMap(coords.isTransactional()));
+
       SinkProducer emitter = new KafkaSinkProducer<>(coords.getTopic(), producer);
+      Set<String> keyColumns = coords.getKeyColumns();
       final Map<String, ComputeInputColumns> computedInputColumns = new HashMap<>();
+
       coords
           .getComputedColumns()
           .forEach(
@@ -81,6 +87,7 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
                     };
                 if (fct != null) computedInputColumns.put(colName, fct);
               });
+
       final List<String> timestampColumns =
           coords.getComputedColumns().entrySet().stream()
               .filter(e -> e.getValue().metadataType() == MetadataType.TIMESTAMP)
@@ -88,15 +95,16 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
               .collect(Collectors.toList());
 
       checkNotNull(emitter, "Could not find sink for field: %s", coords.getFieldName());
+
       return env -> {
-        var entries = getEntries(env, computedInputColumns);
-        var cf = new CompletableFuture<Object>();
+        var records = getRecords(env, keyColumns, computedInputColumns);
+        var cf = new CompletableFuture<>();
 
         Future<List<Object>> sendFuture =
             coords.isTransactional()
-                ? sendMessagesTransactionally(producer, entries, emitter, timestampColumns)
+                ? sendMessagesTransactionally(producer, emitter, records, timestampColumns)
                 : sendMessagesNonTransactionally(
-                    createSendFutures(entries, emitter, timestampColumns));
+                    createSendFutures(emitter, records, timestampColumns));
 
         sendFuture
             .onSuccess(results -> completeWithResults(cf, results, coords.isReturnList()))
@@ -113,8 +121,10 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
     Object compute(DataFetchingEnvironment env);
   }
 
-  private List<Map> getEntries(
-      DataFetchingEnvironment env, Map<String, ComputeInputColumns> computedColumns) {
+  private List<SinkProducer.Record> getRecords(
+      DataFetchingEnvironment env,
+      Set<String> keyColumns,
+      Map<String, ComputeInputColumns> computedColumns) {
     // Rules:
     // - Only one argument is allowed, it doesn't matter the name
     // - input argument cannot be null.
@@ -129,6 +139,20 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
       entries = List.of((Map) argument);
     }
 
+    // Construct keys if necessary (null if no key cols)
+    var keys = new Map[entries.size()];
+    if (!keyColumns.isEmpty()) {
+      for (int i = 0; i < entries.size(); i++) {
+        var filtered = new LinkedHashMap();
+        for (var key : keyColumns) {
+          if (entries.get(i).containsKey(key)) {
+            filtered.put(key, entries.get(i).get(key));
+          }
+        }
+        keys[i] = filtered;
+      }
+    }
+
     if (!computedColumns.isEmpty()) {
       // Add UUID for event for the computed uuid columns
       entries.forEach(
@@ -140,26 +164,13 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
                 });
           });
     }
-    return entries;
-  }
 
-  private List<Future<Map>> createSendFutures(
-      List<Map> entries, SinkProducer emitter, List<String> timestampColumns) {
-    return entries.stream()
-        .map(
-            entry ->
-                emitter
-                    .send(entry)
-                    .map(
-                        sinkResult -> {
-                          // Add timestamp from sink to result
-                          var dateTime =
-                              ZonedDateTime.ofInstant(sinkResult.sourceTime(), ZoneOffset.UTC);
-                          timestampColumns.forEach(
-                              colName -> entry.put(colName, dateTime.toOffsetDateTime()));
-                          return entry;
-                        }))
-        .collect(Collectors.toList());
+    var records = new ArrayList<SinkProducer.Record>();
+    for (int i = 0; i < entries.size(); i++) {
+      records.add(new SinkProducer.Record(keys[i], entries.get(i)));
+    }
+
+    return records;
   }
 
   private void completeWithResults(
@@ -173,16 +184,17 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
 
   private Future<List<Object>> sendMessagesTransactionally(
       KafkaProducer<String, String> producer,
-      List<Map> entries,
       SinkProducer emitter,
+      List<SinkProducer.Record> records,
       List<String> timestampColumns) {
+
     return producer
         .initTransactions()
         .compose(v -> producer.beginTransaction())
         .compose(
             v -> {
               // Create send futures only after transaction is initialized and begun
-              var futures = createSendFutures(entries, emitter, timestampColumns);
+              var futures = createSendFutures(emitter, records, timestampColumns);
               return Future.join(futures);
             })
         .compose(compositeFuture -> producer.commitTransaction().map(v -> compositeFuture.list()))
@@ -192,5 +204,24 @@ public class MutationConfigurationImpl implements MutationConfiguration<DataFetc
 
   private Future<List<Object>> sendMessagesNonTransactionally(List<Future<Map>> futures) {
     return Future.join(futures).map(CompositeFuture::list);
+  }
+
+  private List<Future<Map>> createSendFutures(
+      SinkProducer emitter, List<SinkProducer.Record> records, List<String> timestampColumns) {
+    return records.stream()
+        .map(
+            rec ->
+                emitter
+                    .send(rec)
+                    .map(
+                        sinkResult -> {
+                          // Add timestamp from sink to result
+                          var dateTime =
+                              ZonedDateTime.ofInstant(sinkResult.sourceTime(), ZoneOffset.UTC);
+                          timestampColumns.forEach(
+                              colName -> rec.value().put(colName, dateTime.toOffsetDateTime()));
+                          return rec.value();
+                        }))
+        .collect(Collectors.toList());
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/io/SinkProducer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/io/SinkProducer.java
@@ -20,5 +20,8 @@ import java.util.Map;
 
 /** Sending records to a sink (such as a Kafka topic) */
 public interface SinkProducer {
-  public Future<SinkResult> send(Map entry);
+
+  Future<SinkResult> send(Record record);
+
+  record Record(Map key, Map value) {}
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/kafka/KafkaSinkProducer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/kafka/KafkaSinkProducer.java
@@ -22,7 +22,6 @@ import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
 import java.time.Instant;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -32,11 +31,11 @@ public class KafkaSinkProducer<OUT> implements SinkProducer {
   private final KafkaProducer<String, OUT> kafkaProducer;
 
   @Override
-  public Future<SinkResult> send(Map entry) {
+  public Future<SinkResult> send(Record record) {
     final KafkaProducerRecord producerRecord;
 
     try {
-      producerRecord = KafkaProducerRecord.create(topic, entry);
+      producerRecord = KafkaProducerRecord.create(topic, record.key(), record.value());
     } catch (Exception e) {
       return Future.failedFuture(e);
     }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -177,7 +176,7 @@ class WriteIT {
                 .build())
         .mutation(
             new KafkaMutationCoords(
-                "addCustomer", false, topicName, Set.of(), Map.of(), false, Map.of()))
+                "addCustomer", false, topicName, List.of(), Map.of(), false, Map.of()))
         .build();
   }
 

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/graphql/WriteIT.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -175,7 +176,8 @@ class WriteIT {
                         .build())
                 .build())
         .mutation(
-            new KafkaMutationCoords("addCustomer", false, topicName, Map.of(), false, Map.of()))
+            new KafkaMutationCoords(
+                "addCustomer", false, topicName, Set.of(), Map.of(), false, Map.of()))
         .build();
   }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
@@ -2601,6 +2601,9 @@ INSERT INTO `default_catalog`.`default_database`.`Customer_2`
           "fieldName" : "Orders",
           "returnList" : false,
           "topic" : "kafka-mutation-Orders",
+          "keyColumns" : [
+            "orderid"
+          ],
           "computedColumns" : { },
           "transactional" : false,
           "sinkConfig" : { }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
@@ -429,6 +429,7 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "_SensorReading",
           "returnList" : false,
           "topic" : "kafka-mutation-_SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_id" : {
               "metadataType" : "UUID",
@@ -449,6 +450,9 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "_Sensors",
           "returnList" : false,
           "topic" : "kafka-mutation-_Sensors",
+          "keyColumns" : [
+            "sensorid"
+          ],
           "computedColumns" : {
             "updatedTime" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
@@ -366,6 +366,7 @@ INSERT INTO `default_catalog`.`default_database`.`_Input_2`
           "fieldName" : "SimpleInput",
           "returnList" : false,
           "topic" : "kafka-mutation-SimpleInput",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "_uuid" : {
               "metadataType" : "UUID",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
@@ -879,6 +879,7 @@ INSERT INTO `default_catalog`.`default_database`.`CustomerExport`
           "fieldName" : "CustomerExport",
           "returnList" : false,
           "topic" : "kafka-mutation-CustomerExport",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "timestamp" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
@@ -410,6 +410,7 @@ INSERT INTO `default_catalog`.`default_database`.`CustomerMessage_2`
           "fieldName" : "_InputData",
           "returnList" : false,
           "topic" : "kafka-mutation-_InputData",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_id" : {
               "metadataType" : "UUID",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
@@ -486,6 +486,7 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "_SensorReading",
           "returnList" : false,
           "topic" : "kafka-mutation-_SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_id" : {
               "metadataType" : "UUID",
@@ -506,6 +507,9 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "_Sensors",
           "returnList" : false,
           "topic" : "kafka-mutation-_Sensors",
+          "keyColumns" : [
+            "sensorid"
+          ],
           "computedColumns" : {
             "updatedTime" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
@@ -525,6 +525,9 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "Sensors",
           "returnList" : true,
           "topic" : "kafka-mutation-Sensors",
+          "keyColumns" : [
+            "sensorid"
+          ],
           "computedColumns" : {
             "updatedTime" : {
               "metadataType" : "TIMESTAMP",
@@ -540,6 +543,7 @@ INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
           "fieldName" : "_SensorReading",
           "returnList" : true,
           "topic" : "kafka-mutation-_SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_id" : {
               "metadataType" : "UUID",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
@@ -473,6 +473,9 @@ INSERT INTO `default_catalog`.`default_database`.`NestedCustomers_2`
           "fieldName" : "NestedCustomers",
           "returnList" : false,
           "topic" : "kafka-mutation-NestedCustomers",
+          "keyColumns" : [
+            "customerid"
+          ],
           "computedColumns" : {
             "updatedTime" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
@@ -1243,6 +1243,7 @@ INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
           "fieldName" : "SimpleOrders",
           "returnList" : false,
           "topic" : "kafka-mutation-SimpleOrders",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "orderTime" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
@@ -2084,6 +2084,9 @@ FROM "ExternalOrders" AS "ExternalOrders0"
           "fieldName" : "Orders",
           "returnList" : false,
           "topic" : "Orders",
+          "keyColumns" : [
+            "orderid"
+          ],
           "computedColumns" : { },
           "transactional" : false,
           "sinkConfig" : { }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -1199,6 +1199,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
           "fieldName" : "AddChatMessage",
           "returnList" : false,
           "topic" : "AddChatMessage",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "_uuid" : {
               "metadataType" : "UUID",
@@ -1219,6 +1220,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
           "fieldName" : "ApplicationUpdates",
           "returnList" : true,
           "topic" : "ApplicationUpdates",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "_uuid" : {
               "metadataType" : "UUID",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
           "fieldName" : "InputTable",
           "returnList" : false,
           "topic" : "InputTable",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_time" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -463,6 +463,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
           "fieldName" : "AuthInputData",
           "returnList" : false,
           "topic" : "AuthInputData",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "val" : {
               "metadataType" : "AUTH",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -360,6 +360,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
           "fieldName" : "SensorReading",
           "returnList" : false,
           "topic" : "SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "uuid" : {
               "metadataType" : "UUID",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -359,6 +359,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
           "fieldName" : "SensorReading",
           "returnList" : true,
           "topic" : "SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_time" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -13,8 +13,8 @@ Schema:
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
 Inputs:
- - default_catalog.default_database.SensorDistinct
  - default_catalog.default_database.SensorReading
+ - default_catalog.default_database._SensorDistinct
 Annotations:
  - sort: [3 ASC-nulls-first]
 
@@ -28,20 +28,6 @@ Inputs:
 Annotations:
  - parameters: placement
  - base-table: EnrichedSensorReading
-
-=== SensorDistinct
-ID:          default_catalog.default_database.SensorDistinct
-Type:        state
-Stage:       flink
-Primary key: sensorid
-Timestamp:   lastUpdated
----
-Schema:
- - sensorid: INTEGER NOT NULL
- - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
- - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Inputs:
- - default_catalog.default_database.SensorUpdates
 
 === SensorReading
 ID:          default_catalog.default_database.SensorReading
@@ -71,6 +57,20 @@ Schema:
  - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
 Inputs:
  - default_catalog.default_database.SensorUpdates__base
+
+=== _SensorDistinct
+ID:          default_catalog.default_database._SensorDistinct
+Type:        state
+Stage:       flink
+Primary key: sensorid
+Timestamp:   lastUpdated
+---
+Schema:
+ - sensorid: INTEGER NOT NULL
+ - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.SensorUpdates
 
 === Result
 ID:          logger.Result
@@ -129,7 +129,7 @@ WITH (
   'value.fields-include' = 'ALL',
   'value.format' = 'flexible-json'
 );
-CREATE VIEW `SensorDistinct`
+CREATE VIEW `_SensorDistinct`
 AS
 SELECT `sensorid`, `sensor_name`, `lastUpdated`
 FROM (SELECT `sensorid`, `sensor_name`, `lastUpdated`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
@@ -139,7 +139,7 @@ CREATE VIEW `EnrichedSensorReading`
 AS
 SELECT `r`.`sensorid`, `r`.`temperature`, `r`.`placement`, `r`.`event_time`, `u`.`sensor_name`
 FROM `SensorReading` AS `r`
- LEFT JOIN `SensorDistinct` FOR SYSTEM_TIME AS OF `r`.`event_time` AS `u` ON `r`.`sensorid` = `u`.`sensorid`;
+ LEFT JOIN `_SensorDistinct` FOR SYSTEM_TIME AS OF `r`.`event_time` AS `u` ON `r`.`sensorid` = `u`.`sensorid`;
 CREATE TABLE `Result_1` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
@@ -168,21 +168,7 @@ WITH (
   'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
   'username' = '${POSTGRES_USERNAME}'
 );
-CREATE TABLE `SensorDistinct_3` (
-  `sensorid` INTEGER NOT NULL,
-  `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  PRIMARY KEY (`sensorid`) NOT ENFORCED
-)
-WITH (
-  'connector' = 'jdbc-sqrl',
-  'driver' = 'org.postgresql.Driver',
-  'password' = '${POSTGRES_PASSWORD}',
-  'table-name' = 'SensorDistinct',
-  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
-  'username' = '${POSTGRES_USERNAME}'
-);
-CREATE TABLE `SensorReading_4` (
+CREATE TABLE `SensorReading_3` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
   `placement` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
@@ -192,7 +178,7 @@ WITH (
   'connector' = 'print',
   'print-identifier' = 'SensorReading'
 );
-CREATE TABLE `SensorReading_5` (
+CREATE TABLE `SensorReading_4` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
   `placement` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
@@ -208,7 +194,7 @@ WITH (
   'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
   'username' = '${POSTGRES_USERNAME}'
 );
-CREATE TABLE `SensorUpdates_6` (
+CREATE TABLE `SensorUpdates_5` (
   `sensorid` INTEGER NOT NULL,
   `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
   `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
@@ -218,7 +204,7 @@ WITH (
   'connector' = 'print',
   'print-identifier' = 'SensorUpdates'
 );
-CREATE TABLE `SensorUpdates_7` (
+CREATE TABLE `SensorUpdates_6` (
   `sensorid` INTEGER NOT NULL,
   `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
   `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
@@ -241,27 +227,23 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
  SELECT `sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`) AS `__pk_hash`
   FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
  ;
- INSERT INTO `default_catalog`.`default_database`.`SensorDistinct_3`
+ INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
   SELECT *
-   FROM `default_catalog`.`default_database`.`SensorDistinct`
+   FROM `default_catalog`.`default_database`.`SensorReading`
   ;
   INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
-   SELECT *
+   SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
     FROM `default_catalog`.`default_database`.`SensorReading`
    ;
-   INSERT INTO `default_catalog`.`default_database`.`SensorReading_5`
-    SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
-     FROM `default_catalog`.`default_database`.`SensorReading`
+   INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_5`
+    SELECT *
+     FROM `default_catalog`.`default_database`.`SensorUpdates`
     ;
     INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_6`
      SELECT *
       FROM `default_catalog`.`default_database`.`SensorUpdates`
      ;
-     INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_7`
-      SELECT *
-       FROM `default_catalog`.`default_database`.`SensorUpdates`
-      ;
-      END
+     END
 >>>kafka.json
 {
   "topics" : [
@@ -294,7 +276,6 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
 }
 >>>postgres-schema.sql
 CREATE TABLE IF NOT EXISTS "EnrichedSensorReading" ("sensorid" INTEGER NOT NULL, "temperature" FLOAT NOT NULL, "placement" TEXT NOT NULL, "event_time" TIMESTAMP WITH TIME ZONE NOT NULL, "sensor_name" TEXT, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
-CREATE TABLE IF NOT EXISTS "SensorDistinct" ("sensorid" INTEGER NOT NULL, "sensor_name" TEXT NOT NULL, "lastUpdated" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("sensorid"));
 CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temperature" FLOAT NOT NULL, "placement" TEXT NOT NULL, "event_time" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
 CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor_name" TEXT NOT NULL, "lastUpdated" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("sensorid"))
 >>>postgres-views.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -104,13 +104,17 @@ CREATE TABLE `SensorReading` (
   `event_time` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
   WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
 )
+PARTITIONED BY (`placement`, `temperature`)
 WITH (
   'connector' = 'kafka',
-  'format' = 'flexible-json',
+  'key.fields' = 'placement;temperature',
+  'key.format' = 'flexible-json',
   'properties.auto.offset.reset' = 'earliest',
   'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
   'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorReading'
+  'topic' = 'SensorReading',
+  'value.fields-include' = 'ALL',
+  'value.format' = 'flexible-json'
 );
 CREATE TABLE `SensorUpdates` (
   `sensorid` INTEGER NOT NULL,
@@ -254,7 +258,10 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
       "numPartitions" : 1,
       "replicationFactor" : 3,
       "type" : "MUTATION",
-      "messageKeys" : [ ],
+      "messageKeys" : [
+        "placement",
+        "temperature"
+      ],
       "messageSchema" : "",
       "config" : { }
     },
@@ -401,7 +408,10 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
           "fieldName" : "SensorReading",
           "returnList" : false,
           "topic" : "SensorReading",
-          "keyColumns" : [ ],
+          "keyColumns" : [
+            "placement",
+            "temperature"
+          ],
           "computedColumns" : {
             "event_time" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -13,8 +13,8 @@ Schema:
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
 Inputs:
+ - default_catalog.default_database.SensorDistinct
  - default_catalog.default_database.SensorReading
- - default_catalog.default_database._SensorDistinct
 Annotations:
  - sort: [3 ASC-nulls-first]
 
@@ -28,6 +28,20 @@ Inputs:
 Annotations:
  - parameters: placement
  - base-table: EnrichedSensorReading
+
+=== SensorDistinct
+ID:          default_catalog.default_database.SensorDistinct
+Type:        state
+Stage:       flink
+Primary key: sensorid
+Timestamp:   lastUpdated
+---
+Schema:
+ - sensorid: INTEGER NOT NULL
+ - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.SensorUpdates
 
 === SensorReading
 ID:          default_catalog.default_database.SensorReading
@@ -46,20 +60,6 @@ Inputs:
 
 === SensorUpdates
 ID:          default_catalog.default_database.SensorUpdates
-Type:        stream
-Stage:       flink
-Primary key: -
-Timestamp:   lastUpdated
----
-Schema:
- - sensorid: INTEGER NOT NULL
- - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
- - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
-Inputs:
- - default_catalog.default_database.SensorUpdates__base
-
-=== _SensorDistinct
-ID:          default_catalog.default_database._SensorDistinct
 Type:        state
 Stage:       flink
 Primary key: sensorid
@@ -70,9 +70,7 @@ Schema:
  - sensor_name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
 Inputs:
- - default_catalog.default_database.SensorUpdates
-Annotations:
- - mostRecentDistinct: true
+ - default_catalog.default_database.SensorUpdates__base
 
 === Result
 ID:          logger.Result
@@ -118,17 +116,20 @@ CREATE TABLE `SensorUpdates` (
   `sensorid` INTEGER NOT NULL,
   `sensor_name` STRING NOT NULL,
   `lastUpdated` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
+  PRIMARY KEY (`sensorid`) NOT ENFORCED,
   WATERMARK FOR `lastUpdated` AS `lastUpdated` - INTERVAL '0.0' SECOND
 )
 WITH (
-  'connector' = 'kafka',
-  'format' = 'flexible-json',
+  'connector' = 'upsert-kafka',
+  'key.format' = 'flexible-json',
   'properties.auto.offset.reset' = 'earliest',
   'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
   'properties.group.id' = '${KAFKA_GROUP_ID}',
-  'topic' = 'SensorUpdates'
+  'topic' = 'SensorUpdates',
+  'value.fields-include' = 'ALL',
+  'value.format' = 'flexible-json'
 );
-CREATE VIEW `_SensorDistinct`
+CREATE VIEW `SensorDistinct`
 AS
 SELECT `sensorid`, `sensor_name`, `lastUpdated`
 FROM (SELECT `sensorid`, `sensor_name`, `lastUpdated`, ROW_NUMBER() OVER (PARTITION BY `sensorid` ORDER BY `lastUpdated` DESC NULLS LAST) AS `__sqrlinternal_rownum`
@@ -138,7 +139,7 @@ CREATE VIEW `EnrichedSensorReading`
 AS
 SELECT `r`.`sensorid`, `r`.`temperature`, `r`.`placement`, `r`.`event_time`, `u`.`sensor_name`
 FROM `SensorReading` AS `r`
- LEFT JOIN `_SensorDistinct` FOR SYSTEM_TIME AS OF `r`.`event_time` AS `u` ON `r`.`sensorid` = `u`.`sensorid`;
+ LEFT JOIN `SensorDistinct` FOR SYSTEM_TIME AS OF `r`.`event_time` AS `u` ON `r`.`sensorid` = `u`.`sensorid`;
 CREATE TABLE `Result_1` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
@@ -167,7 +168,21 @@ WITH (
   'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
   'username' = '${POSTGRES_USERNAME}'
 );
-CREATE TABLE `SensorReading_3` (
+CREATE TABLE `SensorDistinct_3` (
+  `sensorid` INTEGER NOT NULL,
+  `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`sensorid`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'SensorDistinct',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `SensorReading_4` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
   `placement` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
@@ -177,7 +192,7 @@ WITH (
   'connector' = 'print',
   'print-identifier' = 'SensorReading'
 );
-CREATE TABLE `SensorReading_4` (
+CREATE TABLE `SensorReading_5` (
   `sensorid` INTEGER NOT NULL,
   `temperature` FLOAT NOT NULL,
   `placement` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
@@ -193,21 +208,21 @@ WITH (
   'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
   'username' = '${POSTGRES_USERNAME}'
 );
-CREATE TABLE `SensorUpdates_5` (
+CREATE TABLE `SensorUpdates_6` (
   `sensorid` INTEGER NOT NULL,
   `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
-  `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
+  `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`sensorid`) NOT ENFORCED
 )
 WITH (
   'connector' = 'print',
   'print-identifier' = 'SensorUpdates'
 );
-CREATE TABLE `SensorUpdates_6` (
+CREATE TABLE `SensorUpdates_7` (
   `sensorid` INTEGER NOT NULL,
   `sensor_name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
   `lastUpdated` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
-  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
-  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+  PRIMARY KEY (`sensorid`) NOT ENFORCED
 )
 WITH (
   'connector' = 'jdbc-sqrl',
@@ -226,23 +241,27 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
  SELECT `sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`) AS `__pk_hash`
   FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
  ;
- INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
+ INSERT INTO `default_catalog`.`default_database`.`SensorDistinct_3`
   SELECT *
-   FROM `default_catalog`.`default_database`.`SensorReading`
+   FROM `default_catalog`.`default_database`.`SensorDistinct`
   ;
   INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
-   SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
+   SELECT *
     FROM `default_catalog`.`default_database`.`SensorReading`
    ;
-   INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_5`
-    SELECT *
-     FROM `default_catalog`.`default_database`.`SensorUpdates`
+   INSERT INTO `default_catalog`.`default_database`.`SensorReading_5`
+    SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
+     FROM `default_catalog`.`default_database`.`SensorReading`
     ;
     INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_6`
-     SELECT `sensorid`, `sensor_name`, `lastUpdated`, `hash_columns`(`sensorid`, `sensor_name`, `lastUpdated`) AS `__pk_hash`
+     SELECT *
       FROM `default_catalog`.`default_database`.`SensorUpdates`
      ;
-     END
+     INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_7`
+      SELECT *
+       FROM `default_catalog`.`default_database`.`SensorUpdates`
+      ;
+      END
 >>>kafka.json
 {
   "topics" : [
@@ -264,7 +283,9 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
       "numPartitions" : 1,
       "replicationFactor" : 3,
       "type" : "MUTATION",
-      "messageKeys" : [ ],
+      "messageKeys" : [
+        "sensorid"
+      ],
       "messageSchema" : "",
       "config" : { }
     }
@@ -273,8 +294,9 @@ INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
 }
 >>>postgres-schema.sql
 CREATE TABLE IF NOT EXISTS "EnrichedSensorReading" ("sensorid" INTEGER NOT NULL, "temperature" FLOAT NOT NULL, "placement" TEXT NOT NULL, "event_time" TIMESTAMP WITH TIME ZONE NOT NULL, "sensor_name" TEXT, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "SensorDistinct" ("sensorid" INTEGER NOT NULL, "sensor_name" TEXT NOT NULL, "lastUpdated" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("sensorid"));
 CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temperature" FLOAT NOT NULL, "placement" TEXT NOT NULL, "event_time" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
-CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor_name" TEXT NOT NULL, "lastUpdated" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"))
+CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor_name" TEXT NOT NULL, "lastUpdated" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("sensorid"))
 >>>postgres-views.sql
 
 >>>vertx.json
@@ -349,7 +371,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"sensorid\", \"sensor_name\", \"lastUpdated\"\nFROM \"SensorUpdates\"",
+              "sql" : "SELECT *\nFROM \"SensorUpdates\"",
               "parameters" : [ ],
               "pagination" : "LIMIT_AND_OFFSET",
               "cacheDurationMs" : 0,
@@ -398,6 +420,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
           "fieldName" : "SensorReading",
           "returnList" : false,
           "topic" : "SensorReading",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "event_time" : {
               "metadataType" : "TIMESTAMP",
@@ -413,6 +436,9 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
           "fieldName" : "SensorUpdates",
           "returnList" : false,
           "topic" : "SensorUpdates",
+          "keyColumns" : [
+            "sensorid"
+          ],
           "computedColumns" : {
             "lastUpdated" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
@@ -368,6 +368,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
           "fieldName" : "UserTokens",
           "returnList" : false,
           "topic" : "UserTokens",
+          "keyColumns" : [ ],
           "computedColumns" : {
             "request_time" : {
               "metadataType" : "TIMESTAMP",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
@@ -17,10 +17,10 @@ CREATE TABLE SensorUpdates (
 EXPORT SensorReading TO logger.SensorReading;
 EXPORT SensorUpdates TO logger.SensorUpdates;
 
-SensorDistinct := DISTINCT SensorUpdates ON sensorid ORDER BY lastUpdated DESC;
+_SensorDistinct := DISTINCT SensorUpdates ON sensorid ORDER BY lastUpdated DESC;
 
 EnrichedSensorReading := SELECT r.sensorid, r.temperature, r.placement, r.event_time, u.sensor_name
-                         FROM SensorReading r LEFT JOIN SensorDistinct FOR SYSTEM_TIME AS OF r.event_time u on r.sensorid = u.sensorid
+                         FROM SensorReading r LEFT JOIN _SensorDistinct FOR SYSTEM_TIME AS OF r.event_time u on r.sensorid = u.sensorid
                          ORDER BY r.event_time ASC;
 
 EnrichedSensorReadingByPlacement(placement STRING NOT NULL) :=

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
@@ -4,7 +4,7 @@ CREATE TABLE SensorReading (
    temperature FLOAT NOT NULL,
    placement STRING NOT NULL,
    event_time TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp'
-);
+) PARTITIONED BY (placement, temperature);
 
 /*+engine(kafka) */
 CREATE TABLE SensorUpdates (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/temporal-join.sqrl
@@ -10,16 +10,17 @@ CREATE TABLE SensorReading (
 CREATE TABLE SensorUpdates (
     sensorid INT NOT NULL,
     sensor_name STRING NOT NULL,
-    lastUpdated TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp'
+    lastUpdated TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
+    PRIMARY KEY (sensorid) NOT ENFORCED
 );
 
 EXPORT SensorReading TO logger.SensorReading;
 EXPORT SensorUpdates TO logger.SensorUpdates;
 
-_SensorDistinct := DISTINCT SensorUpdates ON sensorid ORDER BY lastUpdated DESC;
+SensorDistinct := DISTINCT SensorUpdates ON sensorid ORDER BY lastUpdated DESC;
 
 EnrichedSensorReading := SELECT r.sensorid, r.temperature, r.placement, r.event_time, u.sensor_name
-                         FROM SensorReading r LEFT JOIN _SensorDistinct FOR SYSTEM_TIME AS OF r.event_time u on r.sensorid = u.sensorid
+                         FROM SensorReading r LEFT JOIN SensorDistinct FOR SYSTEM_TIME AS OF r.event_time u on r.sensorid = u.sensorid
                          ORDER BY r.event_time ASC;
 
 EnrichedSensorReadingByPlacement(placement STRING NOT NULL) :=


### PR DESCRIPTION
## Key Changes
- Wire in the `Flink` primary key col names to `KafkaMutationCoords`
- In `MutationConfigurationImpl`, when we put together the Kafka record to be sent, we take the key columns into account, and also send it with the value if it exists