### PR TITLE
fix: Defined operations are ignored if GraphQL schema is inferred

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -26,7 +26,6 @@ import com.datasqrl.engine.stream.flink.FlinkStreamEngine;
 import com.datasqrl.error.ErrorCode;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.graphql.GenerateServerModel;
-import com.datasqrl.graphql.GraphqlSchemaHandler;
 import com.datasqrl.plan.MainScript;
 import com.datasqrl.plan.global.PhysicalPlanRewriter;
 import com.datasqrl.plan.validate.ExecutionGoal;
@@ -53,7 +52,6 @@ public class CompilationProcess {
   private final MainScript mainScript;
   private final PackageJson config;
   private final GenerateServerModel generateServerModel;
-  private final GraphqlSchemaHandler graphqlSchemaHandler;
   private final DagWriter writeDeploymentArtifactsHook;
   private final GraphqlSourceLoader graphqlSourceLoader;
   private final ExecutionGoal executionGoal;
@@ -87,19 +85,10 @@ public class CompilationProcess {
           serverPlan.getFunctions().size(),
           serverPlan.getMutations().size());
 
-      var apiVersions = graphqlSourceLoader.getApiVersions();
-      if (apiVersions.isEmpty()
-          || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema())) {
+      var loadResult = graphqlSourceLoader.load(serverPlan);
+      var apiVersions = loadResult.apiVersions();
 
-        var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
-        apiVersions = List.of(graphqlSourceLoader.createInferredApiSources(inferredSchema));
-
-        // Write out the inferred API schema to the build dir
-        writeDeploymentArtifactsHook.writeInferredSchema(inferredSchema);
-      } else {
-        apiVersions.forEach(
-            apiVersion -> graphqlSchemaHandler.validateSchema(apiVersion, serverPlan));
-      }
+      loadResult.inferredSchema().ifPresent(writeDeploymentArtifactsHook::writeInferredSchema);
 
       apiVersions.forEach(
           api -> {

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -25,7 +25,6 @@ import com.datasqrl.engine.server.ServerPhysicalPlan;
 import com.datasqrl.engine.stream.flink.FlinkStreamEngine;
 import com.datasqrl.error.ErrorCode;
 import com.datasqrl.error.ErrorCollector;
-import com.datasqrl.graphql.ApiSources;
 import com.datasqrl.graphql.GenerateServerModel;
 import com.datasqrl.graphql.GraphqlSchemaHandler;
 import com.datasqrl.plan.MainScript;
@@ -93,7 +92,7 @@ public class CompilationProcess {
           || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema())) {
 
         var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
-        apiVersions = List.of(new ApiSources(inferredSchema));
+        apiVersions = List.of(graphqlSourceLoader.createInferredApiSources(inferredSchema));
 
         // Write out the inferred API schema to the build dir
         writeDeploymentArtifactsHook.writeInferredSchema(inferredSchema);

--- a/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
@@ -39,6 +39,7 @@ public class GraphqlSourceLoader {
 
   Map<String, ApiSources> apiByVersion;
   List<ApiSources> apiVersions;
+  List<ApiSource> defaultOperations;
 
   public GraphqlSourceLoader(ScriptFiles scriptFiles, ResourceResolver resolver) {
     if (!scriptFiles.getApiConfigs().isEmpty()) {
@@ -55,12 +56,15 @@ public class GraphqlSourceLoader {
 
       apiVersions = apis.build();
       apiByVersion = builder.build();
+      defaultOperations = List.of();
       return;
     }
 
     if (scriptFiles.getGraphql().isEmpty()) {
       apiVersions = List.of();
       apiByVersion = Map.of();
+      defaultOperations =
+          scriptFiles.getOperations().stream().map(file -> resolvePath(file, resolver)).toList();
       return;
     }
 
@@ -73,6 +77,7 @@ public class GraphqlSourceLoader {
 
     apiVersions = List.of(sources);
     apiByVersion = Map.of(DEFAULT_API_VERSION, sources);
+    defaultOperations = List.of();
   }
 
   private static ApiSources createApiSources(
@@ -82,6 +87,14 @@ public class GraphqlSourceLoader {
     var opSrc = operations.stream().map(file -> resolvePath(file, resolver)).toList();
 
     return new ApiSources(version, schemaSrc, opSrc);
+  }
+
+  public ApiSources createInferredApiSources(String inferredSchema) {
+    var operations =
+        apiVersions.isEmpty()
+            ? defaultOperations
+            : apiVersions.stream().flatMap(a -> a.operations().stream()).toList();
+    return new ApiSources(inferredSchema, operations);
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
@@ -17,67 +17,80 @@ package com.datasqrl.config;
 
 import static com.datasqrl.graphql.ApiSources.DEFAULT_API_VERSION;
 
+import com.datasqrl.engine.server.ServerPhysicalPlan;
 import com.datasqrl.graphql.ApiSource;
 import com.datasqrl.graphql.ApiSources;
+import com.datasqrl.graphql.GraphqlSchemaHandler;
 import com.datasqrl.graphql.ScriptFiles;
 import com.datasqrl.loaders.resolver.ResourceResolver;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.datasqrl.plan.validate.ExecutionGoal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
 @Lazy
-@Value
+@RequiredArgsConstructor
 public class GraphqlSourceLoader {
 
-  Map<String, ApiSources> apiByVersion;
-  List<ApiSources> apiVersions;
-  List<ApiSource> defaultOperations;
+  private final ScriptFiles scriptFiles;
+  private final ResourceResolver resolver;
+  private final GraphqlSchemaHandler graphqlSchemaHandler;
+  private final PackageJson config;
+  private final ExecutionGoal executionGoal;
 
-  public GraphqlSourceLoader(ScriptFiles scriptFiles, ResourceResolver resolver) {
+  public record LoadResult(List<ApiSources> apiVersions, Optional<String> inferredSchema) {}
+
+  public LoadResult load(ServerPhysicalPlan serverPlan) {
+    List<ApiSources> apiVersions;
+
     if (!scriptFiles.getApiConfigs().isEmpty()) {
+      apiVersions =
+          scriptFiles.getApiConfigs().stream()
+              .map(
+                  apiConf ->
+                      createApiSources(
+                          apiConf.getVersion(),
+                          apiConf.getSchema(),
+                          apiConf.getOperations(),
+                          resolver))
+              .toList();
 
-      var apis = ImmutableList.<ApiSources>builder();
-      var builder = ImmutableMap.<String, ApiSources>builder();
-      for (var apiConf : scriptFiles.getApiConfigs()) {
-        var sources =
-            createApiSources(
-                apiConf.getVersion(), apiConf.getSchema(), apiConf.getOperations(), resolver);
-        builder.put(apiConf.getVersion(), sources);
-        apis.add(sources);
-      }
-
-      apiVersions = apis.build();
-      apiByVersion = builder.build();
-      defaultOperations = List.of();
-      return;
-    }
-
-    if (scriptFiles.getGraphql().isEmpty()) {
+    } else if (scriptFiles.getGraphql().isEmpty()) {
       apiVersions = List.of();
-      apiByVersion = Map.of();
-      defaultOperations =
-          scriptFiles.getOperations().stream().map(file -> resolvePath(file, resolver)).toList();
-      return;
+
+    } else {
+      var sources =
+          createApiSources(
+              DEFAULT_API_VERSION,
+              scriptFiles.getGraphql().get(),
+              scriptFiles.getOperations(),
+              resolver);
+      apiVersions = List.of(sources);
     }
 
-    var sources =
-        createApiSources(
-            DEFAULT_API_VERSION,
-            scriptFiles.getGraphql().get(),
-            scriptFiles.getOperations(),
-            resolver);
+    if (apiVersions.isEmpty()
+        || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema())) {
 
-    apiVersions = List.of(sources);
-    apiByVersion = Map.of(DEFAULT_API_VERSION, sources);
-    defaultOperations = List.of();
+      var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
+      List<ApiSource> operations;
+      if (apiVersions.isEmpty()) {
+        operations =
+            scriptFiles.getOperations().stream().map(file -> resolvePath(file, resolver)).toList();
+      } else {
+        operations = apiVersions.stream().flatMap(a -> a.operations().stream()).toList();
+      }
+      apiVersions = List.of(new ApiSources(inferredSchema, operations));
+      return new LoadResult(apiVersions, Optional.of(inferredSchema));
+    }
+
+    apiVersions.forEach(apiVersion -> graphqlSchemaHandler.validateSchema(apiVersion, serverPlan));
+    return new LoadResult(apiVersions, Optional.empty());
   }
 
   private static ApiSources createApiSources(
@@ -87,14 +100,6 @@ public class GraphqlSourceLoader {
     var opSrc = operations.stream().map(file -> resolvePath(file, resolver)).toList();
 
     return new ApiSources(version, schemaSrc, opSrc);
-  }
-
-  public ApiSources createInferredApiSources(String inferredSchema) {
-    var operations =
-        apiVersions.isEmpty()
-            ? defaultOperations
-            : apiVersions.stream().flatMap(a -> a.operations().stream()).toList();
-    return new ApiSources(inferredSchema, operations);
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/GraphqlSourceLoader.java
@@ -74,23 +74,28 @@ public class GraphqlSourceLoader {
       apiVersions = List.of(sources);
     }
 
-    if (apiVersions.isEmpty()
-        || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema())) {
-
-      var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
-      List<ApiSource> operations;
-      if (apiVersions.isEmpty()) {
-        operations =
-            scriptFiles.getOperations().stream().map(file -> resolvePath(file, resolver)).toList();
-      } else {
-        operations = apiVersions.stream().flatMap(a -> a.operations().stream()).toList();
-      }
-      apiVersions = List.of(new ApiSources(inferredSchema, operations));
-      return new LoadResult(apiVersions, Optional.of(inferredSchema));
+    if (!shouldUseInferredSchema(apiVersions)) {
+      apiVersions.forEach(
+          apiVersion -> graphqlSchemaHandler.validateSchema(apiVersion, serverPlan));
+      return new LoadResult(apiVersions, Optional.empty());
     }
 
-    apiVersions.forEach(apiVersion -> graphqlSchemaHandler.validateSchema(apiVersion, serverPlan));
-    return new LoadResult(apiVersions, Optional.empty());
+    List<ApiSource> operations;
+    if (apiVersions.isEmpty()) {
+      operations =
+          scriptFiles.getOperations().stream().map(file -> resolvePath(file, resolver)).toList();
+    } else {
+      operations = apiVersions.stream().flatMap(a -> a.operations().stream()).toList();
+    }
+
+    var inferredSchema = graphqlSchemaHandler.inferGraphQLSchema(serverPlan);
+    return new LoadResult(
+        List.of(new ApiSources(inferredSchema, operations)), Optional.of(inferredSchema));
+  }
+
+  private boolean shouldUseInferredSchema(List<ApiSources> apiVersions) {
+    return apiVersions.isEmpty()
+        || (executionGoal == ExecutionGoal.TEST && config.getTestConfig().useInferredSchema());
   }
 
   private static ApiSources createApiSources(

--- a/sqrl-planner/src/main/java/com/datasqrl/graphql/ApiSources.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/graphql/ApiSources.java
@@ -21,7 +21,7 @@ public record ApiSources(String version, ApiSource schema, List<ApiSource> opera
 
   public static final String DEFAULT_API_VERSION = "v1";
 
-  public ApiSources(String inferredSchema) {
-    this(DEFAULT_API_VERSION, new ApiSource(inferredSchema), List.of());
+  public ApiSources(String inferredSchema, List<ApiSource> operations) {
+    this(DEFAULT_API_VERSION, new ApiSource(inferredSchema), operations);
   }
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/config/GraphqlSourceLoaderTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/GraphqlSourceLoaderTest.java
@@ -17,230 +17,198 @@ package com.datasqrl.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.datasqrl.config.PackageJson.ScriptApiConfig;
-import com.datasqrl.config.PackageJson.ScriptConfig;
+import com.datasqrl.engine.server.ServerPhysicalPlan;
 import com.datasqrl.graphql.ApiSource;
+import com.datasqrl.graphql.GraphqlSchemaHandler;
 import com.datasqrl.graphql.ScriptFiles;
-import com.datasqrl.loaders.resolver.FileResourceResolver;
 import com.datasqrl.loaders.resolver.ResourceResolver;
+import com.datasqrl.plan.validate.ExecutionGoal;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class GraphqlSourceLoaderTest {
 
   @TempDir Path tempDir;
 
-  private ResourceResolver resolver;
+  @Mock ScriptFiles scriptFiles;
+  @Mock ResourceResolver resolver;
+  @Mock GraphqlSchemaHandler graphqlSchemaHandler;
+  @Mock ServerPhysicalPlan serverPlan;
 
-  @BeforeEach
-  void setUp() {
-    resolver = new FileResourceResolver(tempDir);
+  private final PackageJson config = createConfig(true);
+
+  private static PackageJson createConfig(boolean useInferredSchema) {
+    var sqrlConfig = SqrlConfig.createCurrentVersion();
+    sqrlConfig.setProperty("test-runner.use-inferred-schema", useInferredSchema);
+    return new PackageJsonImpl(sqrlConfig);
   }
 
   @Test
-  void givenGraphqlAndOperations_whenConstruct_thenDefaultOperationsEmpty() throws IOException {
-    Files.writeString(tempDir.resolve("schema.graphqls"), "type Query { foo: String }");
-    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
-    var scriptFiles = scriptFiles("schema.graphqls", List.of("op.graphql"), List.of());
-
-    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
-
-    assertThat(loader.getApiVersions()).hasSize(1);
-    assertThat(loader.getApiVersions().get(0).operations())
-        .extracting(ApiSource::getDefinition)
-        .containsExactly("query Foo { foo }");
-    assertThat(loader.getDefaultOperations()).isEmpty();
-  }
-
-  @Test
-  void givenApiConfigs_whenConstruct_thenDefaultOperationsEmpty() throws IOException {
-    Files.writeString(tempDir.resolve("v1-schema.graphqls"), "type Query { foo: String }");
-    var apiConfig = apiConfig(List.of());
-    var scriptFiles = scriptFiles(null, List.of("ignored.graphql"), List.of(apiConfig));
-
-    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
-
-    assertThat(loader.getApiVersions()).hasSize(1);
-    assertThat(loader.getApiByVersion()).containsOnlyKeys("v1");
-    assertThat(loader.getDefaultOperations()).isEmpty();
-  }
-
-  @Test
-  void givenOperationsWithoutGraphql_whenCreateInferred_thenUsesDefaultOperations()
+  void givenExplicitSchemaAndOperations_whenLoad_thenValidatesAndReturnsExplicitVersions()
       throws IOException {
-    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
-    var scriptFiles = scriptFiles(null, List.of("op.graphql"), List.of());
-    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+    var schemaPath = writeFile("schema.graphqls", "type Query { foo: String }");
+    var opPath = writeFile("op.graphql", "query Foo { foo }");
+    when(scriptFiles.getApiConfigs()).thenReturn(List.of());
+    when(scriptFiles.getGraphql()).thenReturn(Optional.of("schema.graphqls"));
+    when(scriptFiles.getOperations()).thenReturn(List.of("op.graphql"));
+    when(resolver.resolveFile(Path.of("schema.graphqls"))).thenReturn(Optional.of(schemaPath));
+    when(resolver.resolveFile(Path.of("op.graphql"))).thenReturn(Optional.of(opPath));
 
-    var result = loader.createInferredApiSources("type Query { foo: String }");
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.COMPILE);
+    var result = loader.load(serverPlan);
 
-    assertThat(result.schema().getDefinition()).isEqualTo("type Query { foo: String }");
-    assertThat(result.operations())
+    assertThat(result.apiVersions()).hasSize(1);
+    assertThat(result.apiVersions().get(0).schema().getDefinition())
+        .isEqualTo("type Query { foo: String }");
+    assertThat(result.apiVersions().get(0).operations())
         .extracting(ApiSource::getDefinition)
         .containsExactly("query Foo { foo }");
+    assertThat(result.inferredSchema()).isEmpty();
+    verify(graphqlSchemaHandler).validateSchema(result.apiVersions().get(0), serverPlan);
+    verify(graphqlSchemaHandler, never()).inferGraphQLSchema(any());
   }
 
   @Test
-  void givenGraphqlAndOperations_whenCreateInferred_thenPreservesExistingOperations()
+  void givenApiConfigs_whenLoad_thenValidatesConfiguredVersions() throws IOException {
+    var schemaPath = writeFile("v1-schema.graphqls", "type Query { foo: String }");
+    when(scriptFiles.getApiConfigs())
+        .thenReturn(
+            List.of(
+                new ScriptApiConfig() {
+                  @Override
+                  public String getVersion() {
+                    return "v1";
+                  }
+
+                  @Override
+                  public String getSchema() {
+                    return "v1-schema.graphqls";
+                  }
+
+                  @Override
+                  public List<String> getOperations() {
+                    return List.of();
+                  }
+                }));
+    when(resolver.resolveFile(Path.of("v1-schema.graphqls"))).thenReturn(Optional.of(schemaPath));
+
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.COMPILE);
+    var result = loader.load(serverPlan);
+
+    assertThat(result.apiVersions()).hasSize(1);
+    assertThat(result.apiVersions().get(0).version()).isEqualTo("v1");
+    assertThat(result.inferredSchema()).isEmpty();
+    verify(graphqlSchemaHandler).validateSchema(result.apiVersions().get(0), serverPlan);
+  }
+
+  @Test
+  void givenNoSchemaWithOperations_whenLoad_thenInfersSchemaAndIncludesOperations()
       throws IOException {
-    Files.writeString(tempDir.resolve("schema.graphqls"), "type Query { foo: String }");
-    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
-    var scriptFiles = scriptFiles("schema.graphqls", List.of("op.graphql"), List.of());
-    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+    var opPath = writeFile("op.graphql", "query Foo { foo }");
+    when(scriptFiles.getApiConfigs()).thenReturn(List.of());
+    when(scriptFiles.getGraphql()).thenReturn(Optional.empty());
+    when(scriptFiles.getOperations()).thenReturn(List.of("op.graphql"));
+    when(resolver.resolveFile(Path.of("op.graphql"))).thenReturn(Optional.of(opPath));
+    when(graphqlSchemaHandler.inferGraphQLSchema(serverPlan))
+        .thenReturn("type Query { foo: String }");
 
-    var result = loader.createInferredApiSources("type Query { bar: String }");
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.COMPILE);
+    var result = loader.load(serverPlan);
 
-    assertThat(result.schema().getDefinition()).isEqualTo("type Query { bar: String }");
-    assertThat(result.operations())
+    assertThat(result.inferredSchema()).contains("type Query { foo: String }");
+    assertThat(result.apiVersions()).hasSize(1);
+    assertThat(result.apiVersions().get(0).operations())
         .extracting(ApiSource::getDefinition)
         .containsExactly("query Foo { foo }");
+    verify(graphqlSchemaHandler, never()).validateSchema(any(), any());
   }
 
   @Test
-  void givenNoOperations_whenCreateInferred_thenOperationsEmpty() {
-    var scriptFiles = scriptFiles(null, List.of(), List.of());
-    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+  void givenNoSchemaNoOperations_whenLoad_thenInfersSchemaWithEmptyOperations() {
+    when(scriptFiles.getApiConfigs()).thenReturn(List.of());
+    when(scriptFiles.getGraphql()).thenReturn(Optional.empty());
+    when(scriptFiles.getOperations()).thenReturn(List.of());
+    when(graphqlSchemaHandler.inferGraphQLSchema(serverPlan))
+        .thenReturn("type Query { foo: String }");
 
-    var result = loader.createInferredApiSources("type Query { foo: String }");
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.COMPILE);
+    var result = loader.load(serverPlan);
 
-    assertThat(result.schema().getDefinition()).isEqualTo("type Query { foo: String }");
-    assertThat(result.operations()).isEmpty();
+    assertThat(result.inferredSchema()).contains("type Query { foo: String }");
+    assertThat(result.apiVersions()).hasSize(1);
+    assertThat(result.apiVersions().get(0).operations()).isEmpty();
   }
 
   @Test
-  void givenMissingOperationFile_whenConstruct_thenThrowsIllegalArgument() {
-    var scriptFiles = scriptFiles(null, List.of("does-not-exist.graphql"), List.of());
+  void givenExplicitSchemaInTestMode_whenUseInferredSchema_thenOverridesWithInferred()
+      throws IOException {
+    var schemaPath = writeFile("schema.graphqls", "type Query { foo: String }");
+    var opPath = writeFile("op.graphql", "query Foo { foo }");
+    when(scriptFiles.getApiConfigs()).thenReturn(List.of());
+    when(scriptFiles.getGraphql()).thenReturn(Optional.of("schema.graphqls"));
+    when(scriptFiles.getOperations()).thenReturn(List.of("op.graphql"));
+    when(resolver.resolveFile(Path.of("schema.graphqls"))).thenReturn(Optional.of(schemaPath));
+    when(resolver.resolveFile(Path.of("op.graphql"))).thenReturn(Optional.of(opPath));
+    when(graphqlSchemaHandler.inferGraphQLSchema(serverPlan))
+        .thenReturn("type Query { bar: String }");
 
-    assertThatThrownBy(() -> new GraphqlSourceLoader(scriptFiles, resolver))
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.TEST);
+    var result = loader.load(serverPlan);
+
+    assertThat(result.inferredSchema()).contains("type Query { bar: String }");
+    assertThat(result.apiVersions()).hasSize(1);
+    assertThat(result.apiVersions().get(0).schema().getDefinition())
+        .isEqualTo("type Query { bar: String }");
+    assertThat(result.apiVersions().get(0).operations())
+        .extracting(ApiSource::getDefinition)
+        .containsExactly("query Foo { foo }");
+    verify(graphqlSchemaHandler, never()).validateSchema(any(), any());
+  }
+
+  @Test
+  void givenMissingFile_whenLoad_thenThrowsIllegalArgument() {
+    when(scriptFiles.getApiConfigs()).thenReturn(List.of());
+    when(scriptFiles.getGraphql()).thenReturn(Optional.empty());
+    when(scriptFiles.getOperations()).thenReturn(List.of("does-not-exist.graphql"));
+    when(resolver.resolveFile(Path.of("does-not-exist.graphql"))).thenReturn(Optional.empty());
+
+    var loader =
+        new GraphqlSourceLoader(
+            scriptFiles, resolver, graphqlSchemaHandler, config, ExecutionGoal.COMPILE);
+
+    assertThatThrownBy(() -> loader.load(serverPlan))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("does-not-exist.graphql");
   }
 
-  private static ScriptFiles scriptFiles(
-      @Nullable String graphql, List<String> operations, List<ScriptApiConfig> apiConfigs) {
-    return new ScriptFiles(stubPackageJson(graphql, operations, apiConfigs));
-  }
-
-  private static PackageJson stubPackageJson(
-      @Nullable String graphql, List<String> operations, List<ScriptApiConfig> apiConfigs) {
-    var scriptConfig =
-        new ScriptConfig() {
-          @Override
-          public Optional<String> getMainScript() {
-            return Optional.empty();
-          }
-
-          @Override
-          public List<ScriptApiConfig> getScriptApiConfigs() {
-            return apiConfigs;
-          }
-
-          @Override
-          public Optional<String> getGraphql() {
-            return Optional.ofNullable(graphql);
-          }
-
-          @Override
-          public List<String> getOperations() {
-            return operations;
-          }
-
-          @Override
-          public Map<String, Object> getConfig() {
-            return Map.of();
-          }
-
-          @Override
-          public Optional<String> getDatabase() {
-            return Optional.empty();
-          }
-
-          @Override
-          public void setMainScript(String script) {}
-
-          @Override
-          public void setGraphql(String g) {}
-        };
-
-    return new PackageJson() {
-      @Override
-      public List<String> getEnabledEngines() {
-        return List.of();
-      }
-
-      @Override
-      public void setEnabledEngines(List<String> enabledEngines) {}
-
-      @Override
-      public EnginesConfig getEngines() {
-        return null;
-      }
-
-      @Override
-      public ConnectorsConfig getConnectors() {
-        return null;
-      }
-
-      @Override
-      public DiscoveryConfig getDiscovery() {
-        return null;
-      }
-
-      @Override
-      public void toFile(Path path, boolean pretty) {}
-
-      @Override
-      public ScriptConfig getScriptConfig() {
-        return scriptConfig;
-      }
-
-      @Override
-      public CompilerConfig getCompilerConfig() {
-        return null;
-      }
-
-      @Override
-      public int getVersion() {
-        return 1;
-      }
-
-      @Override
-      public boolean hasScriptKey() {
-        return true;
-      }
-
-      @Override
-      public TestRunnerConfiguration getTestConfig() {
-        return null;
-      }
-    };
-  }
-
-  private static ScriptApiConfig apiConfig(List<String> operations) {
-    return new ScriptApiConfig() {
-      @Override
-      public String getVersion() {
-        return "v1";
-      }
-
-      @Override
-      public String getSchema() {
-        return "v1-schema.graphqls";
-      }
-
-      @Override
-      public List<String> getOperations() {
-        return operations;
-      }
-    };
+  private Path writeFile(String name, String content) throws IOException {
+    var path = tempDir.resolve(name);
+    Files.writeString(path, content);
+    return path;
   }
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/config/GraphqlSourceLoaderTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/GraphqlSourceLoaderTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datasqrl.config.PackageJson.ScriptApiConfig;
+import com.datasqrl.config.PackageJson.ScriptConfig;
+import com.datasqrl.graphql.ApiSource;
+import com.datasqrl.graphql.ScriptFiles;
+import com.datasqrl.loaders.resolver.FileResourceResolver;
+import com.datasqrl.loaders.resolver.ResourceResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GraphqlSourceLoaderTest {
+
+  @TempDir Path tempDir;
+
+  private ResourceResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new FileResourceResolver(tempDir);
+  }
+
+  @Test
+  void givenGraphqlAndOperations_whenConstruct_thenDefaultOperationsEmpty() throws IOException {
+    Files.writeString(tempDir.resolve("schema.graphqls"), "type Query { foo: String }");
+    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
+    var scriptFiles = scriptFiles("schema.graphqls", List.of("op.graphql"), List.of());
+
+    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+
+    assertThat(loader.getApiVersions()).hasSize(1);
+    assertThat(loader.getApiVersions().get(0).operations())
+        .extracting(ApiSource::getDefinition)
+        .containsExactly("query Foo { foo }");
+    assertThat(loader.getDefaultOperations()).isEmpty();
+  }
+
+  @Test
+  void givenApiConfigs_whenConstruct_thenDefaultOperationsEmpty() throws IOException {
+    Files.writeString(tempDir.resolve("v1-schema.graphqls"), "type Query { foo: String }");
+    var apiConfig = apiConfig(List.of());
+    var scriptFiles = scriptFiles(null, List.of("ignored.graphql"), List.of(apiConfig));
+
+    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+
+    assertThat(loader.getApiVersions()).hasSize(1);
+    assertThat(loader.getApiByVersion()).containsOnlyKeys("v1");
+    assertThat(loader.getDefaultOperations()).isEmpty();
+  }
+
+  @Test
+  void givenOperationsWithoutGraphql_whenCreateInferred_thenUsesDefaultOperations()
+      throws IOException {
+    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
+    var scriptFiles = scriptFiles(null, List.of("op.graphql"), List.of());
+    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+
+    var result = loader.createInferredApiSources("type Query { foo: String }");
+
+    assertThat(result.schema().getDefinition()).isEqualTo("type Query { foo: String }");
+    assertThat(result.operations())
+        .extracting(ApiSource::getDefinition)
+        .containsExactly("query Foo { foo }");
+  }
+
+  @Test
+  void givenGraphqlAndOperations_whenCreateInferred_thenPreservesExistingOperations()
+      throws IOException {
+    Files.writeString(tempDir.resolve("schema.graphqls"), "type Query { foo: String }");
+    Files.writeString(tempDir.resolve("op.graphql"), "query Foo { foo }");
+    var scriptFiles = scriptFiles("schema.graphqls", List.of("op.graphql"), List.of());
+    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+
+    var result = loader.createInferredApiSources("type Query { bar: String }");
+
+    assertThat(result.schema().getDefinition()).isEqualTo("type Query { bar: String }");
+    assertThat(result.operations())
+        .extracting(ApiSource::getDefinition)
+        .containsExactly("query Foo { foo }");
+  }
+
+  @Test
+  void givenNoOperations_whenCreateInferred_thenOperationsEmpty() {
+    var scriptFiles = scriptFiles(null, List.of(), List.of());
+    var loader = new GraphqlSourceLoader(scriptFiles, resolver);
+
+    var result = loader.createInferredApiSources("type Query { foo: String }");
+
+    assertThat(result.schema().getDefinition()).isEqualTo("type Query { foo: String }");
+    assertThat(result.operations()).isEmpty();
+  }
+
+  @Test
+  void givenMissingOperationFile_whenConstruct_thenThrowsIllegalArgument() {
+    var scriptFiles = scriptFiles(null, List.of("does-not-exist.graphql"), List.of());
+
+    assertThatThrownBy(() -> new GraphqlSourceLoader(scriptFiles, resolver))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does-not-exist.graphql");
+  }
+
+  private static ScriptFiles scriptFiles(
+      @Nullable String graphql, List<String> operations, List<ScriptApiConfig> apiConfigs) {
+    return new ScriptFiles(stubPackageJson(graphql, operations, apiConfigs));
+  }
+
+  private static PackageJson stubPackageJson(
+      @Nullable String graphql, List<String> operations, List<ScriptApiConfig> apiConfigs) {
+    var scriptConfig =
+        new ScriptConfig() {
+          @Override
+          public Optional<String> getMainScript() {
+            return Optional.empty();
+          }
+
+          @Override
+          public List<ScriptApiConfig> getScriptApiConfigs() {
+            return apiConfigs;
+          }
+
+          @Override
+          public Optional<String> getGraphql() {
+            return Optional.ofNullable(graphql);
+          }
+
+          @Override
+          public List<String> getOperations() {
+            return operations;
+          }
+
+          @Override
+          public Map<String, Object> getConfig() {
+            return Map.of();
+          }
+
+          @Override
+          public Optional<String> getDatabase() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setMainScript(String script) {}
+
+          @Override
+          public void setGraphql(String g) {}
+        };
+
+    return new PackageJson() {
+      @Override
+      public List<String> getEnabledEngines() {
+        return List.of();
+      }
+
+      @Override
+      public void setEnabledEngines(List<String> enabledEngines) {}
+
+      @Override
+      public EnginesConfig getEngines() {
+        return null;
+      }
+
+      @Override
+      public ConnectorsConfig getConnectors() {
+        return null;
+      }
+
+      @Override
+      public DiscoveryConfig getDiscovery() {
+        return null;
+      }
+
+      @Override
+      public void toFile(Path path, boolean pretty) {}
+
+      @Override
+      public ScriptConfig getScriptConfig() {
+        return scriptConfig;
+      }
+
+      @Override
+      public CompilerConfig getCompilerConfig() {
+        return null;
+      }
+
+      @Override
+      public int getVersion() {
+        return 1;
+      }
+
+      @Override
+      public boolean hasScriptKey() {
+        return true;
+      }
+
+      @Override
+      public TestRunnerConfiguration getTestConfig() {
+        return null;
+      }
+    };
+  }
+
+  private static ScriptApiConfig apiConfig(List<String> operations) {
+    return new ScriptApiConfig() {
+      @Override
+      public String getVersion() {
+        return "v1";
+      }
+
+      @Override
+      public String getSchema() {
+        return "v1-schema.graphqls";
+      }
+
+      @Override
+      public List<String> getOperations() {
+        return operations;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Fixes #2021 

- Preserve user-defined operations when GraphQL schema is inferred by adding a new, `defaultOperations` field
- Add unit tests