### PR TITLE
fix: Replace unmaintained `dockerfile-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <vertx.version>5.0.10</vertx.version>
 
     <!-- Plugin versions -->
-    <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+    <docker-maven-plugin.version>0.46.0</docker-maven-plugin.version>
     <easy-jacoco-maven-plugin.version>0.1.4</easy-jacoco-maven-plugin.version>
     <git-code-format-maven-plugin.version>5.6</git-code-format-maven-plugin.version>
     <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
@@ -823,21 +823,24 @@
           <version>3.6.3</version>
         </plugin>
         <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>dockerfile-maven-plugin</artifactId>
-          <version>${dockerfile-maven-plugin.version}</version>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${docker-maven-plugin.version}</version>
           <configuration>
-            <repository>${docker.image.name}</repository>
-            <tag>${docker.image.tag}</tag>
-            <dockerfile>Dockerfile</dockerfile>
-            <buildArgs>
-              <IMG_REPO>${docker.image.repo}</IMG_REPO>
-              <BASE_TAG>${docker.image.base.tag}</BASE_TAG>
-              <DUCKDB_EXTENSIONS_TAG>${docker.image.duckdb.tag}</DUCKDB_EXTENSIONS_TAG>
-            </buildArgs>
-            <contextDirectory>${project.basedir}</contextDirectory>
-            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-            <pullNewerImage>false</pullNewerImage>
+            <images>
+              <image>
+                <name>${docker.image.name}:${docker.image.tag}</name>
+                <build>
+                  <contextDir>${project.basedir}</contextDir>
+                  <dockerFile>Dockerfile</dockerFile>
+                  <args>
+                    <IMG_REPO>${docker.image.repo}</IMG_REPO>
+                    <BASE_TAG>${docker.image.base.tag}</BASE_TAG>
+                    <DUCKDB_EXTENSIONS_TAG>${docker.image.duckdb.tag}</DUCKDB_EXTENSIONS_TAG>
+                  </args>
+                </build>
+              </image>
+            </images>
           </configuration>
         </plugin>
       </plugins>
@@ -1113,8 +1116,8 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -1357,8 +1360,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -1377,7 +1380,7 @@
       </activation>
       <properties>
         <skipITs>true</skipITs>
-        <dockerfile.skip>true</dockerfile.skip>
+        <docker.skip>true</docker.skip>
         <maven.test.excludeProjects>sqrl-testing-container</maven.test.excludeProjects>
       </properties>
       <build>
@@ -1408,7 +1411,7 @@
         </property>
       </activation>
       <properties>
-        <dockerfile.skip>true</dockerfile.skip>
+        <docker.skip>true</docker.skip>
         <maven.test.excludeProjects>sqrl-testing-container</maven.test.excludeProjects>
       </properties>
       <build>
@@ -1474,7 +1477,7 @@
       <properties>
         <skipTests>true</skipTests>
         <skipITs>true</skipITs>
-        <dockerfile.skip>true</dockerfile.skip>
+        <docker.skip>true</docker.skip>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -833,6 +833,7 @@
                 <build>
                   <contextDir>${project.basedir}</contextDir>
                   <dockerFile>Dockerfile</dockerFile>
+                  <filter>false</filter>
                   <args>
                     <IMG_REPO>${docker.image.repo}</IMG_REPO>
                     <BASE_TAG>${docker.image.base.tag}</BASE_TAG>

--- a/sqrl-cli/pom.xml
+++ b/sqrl-cli/pom.xml
@@ -407,8 +407,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>dockerfile-maven-plugin</artifactId>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>build-docker-image</id>

--- a/sqrl-server/sqrl-server-vertx/pom.xml
+++ b/sqrl-server/sqrl-server-vertx/pom.xml
@@ -69,8 +69,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>dockerfile-maven-plugin</artifactId>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>build-docker-image</id>


### PR DESCRIPTION
The spotify maven plugin is unmaintained since 2018, and its bundled `jnr-ffi/jffi` native lib ships only `i386` and `x86_64` slices, so it can't load on Apple Silicon, producing an error like this:
```
[ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:build (build-docker-image) on project sqrl-cli: Could not build image:
  java.util.concurrent.ExecutionException: com.spotify.docker.client.shaded.javax.ws.rs.ProcessingException: java.lang.UnsatisfiedLinkError: could not load FFI provider
  com.spotify.docker.client.shaded.jnr.ffi.provider.jffi.Provider: ExceptionInInitializerError: Can't overwrite cause with java.lang.UnsatisfiedLinkError:
  java.lang.UnsatisfiedLinkError: /private/var/folders/pz/_8sgqnzd3q526_71p7gf580m0000gn/T/jffi6171116128881189023.dylib:
  dlopen(/private/var/folders/pz/_8sgqnzd3q526_71p7gf580m0000gn/T/jffi6171116128881189023.dylib, 0x0001): tried:
  '/private/var/folders/pz/_8sgqnzd3q526_71p7gf580m0000gn/T/jffi6171116128881189023.dylib' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or
  'arm64e.v1' or 'arm64' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/private/var/folders/pz/_8sgqnzd3q526_71p7gf580m0000gn/T/jffi6171116128881189023.dylib' (no such file),
  '/private/var/folders/pz/_8sgqnzd3q526_71p7gf580m0000gn/T/jffi6171116128881189023.dylib' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or
  'arm64e.v1' or 'arm64' or 'arm64'))
```