### PR TITLE
ci: Remove unit test retry count from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,7 +957,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.5</version>
         <configuration>
-          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <includes>
             <include>**/*Test.java</include>
           </includes>


### PR DESCRIPTION
The retry actually hides if a snapshot is missing from the repo:
```
[WARNING] Flakes: 
[WARNING] com.datasqrl.DAGPlannerTest.scripts(Path)[10]
[ERROR]   Run 1: DAGPlannerTest.scripts:74 Creating snapshots: file:///home/circleci/project/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
[INFO]   Run 2: PASS
```

We alreafy eliminated unit test flakiness, so it's reasonable to just disable the retry.