### PR TITLE
fix: Disable Flink job failure recovery for `test` cmd

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
@@ -16,8 +16,11 @@
 package com.datasqrl.cli;
 
 import com.datasqrl.config.SqrlConstants;
+import com.datasqrl.util.ConfigLoaderUtils;
 import com.datasqrl.util.OsProcessManager;
 import java.nio.file.Path;
+import lombok.SneakyThrows;
+import org.apache.flink.configuration.Configuration;
 import picocli.CommandLine.Option;
 
 public abstract class BaseOsProcessManagerCmd extends BaseCmd {
@@ -47,5 +50,16 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
     }
 
     return cli.rootDir.resolve(targetFolder);
+  }
+
+  /**
+   * Loads the Flink configuration generated for the plan directory.
+   *
+   * @param planDir directory containing the compiled plan artifacts
+   * @return loaded Flink configuration
+   */
+  @SneakyThrows
+  protected Configuration getFlinkConfig(Path planDir) {
+    return ConfigLoaderUtils.loadFlinkConfig(planDir);
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/ExecCmd.java
@@ -19,7 +19,6 @@ import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.util.ConfigLoaderUtils;
-import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -49,11 +48,15 @@ public class ExecCmd extends BaseOsProcessManagerCmd {
   }
 
   /**
-   * Loads the Flink configuration from the plan directory. If no deployment target is configured,
-   * defaults to local attached execution.
+   * Loads the Flink configuration and defaults execution to local attached mode when no deployment
+   * target is configured.
+   *
+   * @param planDir directory containing the compiled plan artifacts
+   * @return Flink configuration for command execution
    */
-  private Configuration getFlinkConfig(Path planDir) throws IOException {
-    var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
+  @Override
+  protected Configuration getFlinkConfig(Path planDir) {
+    var flinkConfig = super.getFlinkConfig(planDir);
     if (!flinkConfig.contains(DeploymentOptions.TARGET)) {
       flinkConfig.set(DeploymentOptions.TARGET, "local");
       flinkConfig.set(DeploymentOptions.ATTACHED, true);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/RunCmd.java
@@ -45,7 +45,7 @@ public class RunCmd extends AbstractCompileCmd {
     // Run
     var env = GlobalEnvironmentStore.getAll();
     var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
-    var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
+    var flinkConfig = getFlinkConfig(planDir);
 
     var sqrlRun = DatasqrlRun.blocking(planDir, sqrlConfig, flinkConfig, env);
     sqrlRun.run();

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestCmd.java
@@ -21,7 +21,11 @@ import com.datasqrl.env.GlobalEnvironmentStore;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.plan.validate.ExecutionGoal;
 import com.datasqrl.util.ConfigLoaderUtils;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import picocli.CommandLine.Command;
 
 @Command(
@@ -54,7 +58,7 @@ public class TestCmd extends AbstractCompileCmd {
       // Test
       var env = GlobalEnvironmentStore.getAll();
       var sqrlConfig = ConfigLoaderUtils.loadResolvedConfig(errors, getBuildDir());
-      var flinkConfig = ConfigLoaderUtils.loadFlinkConfig(planDir);
+      var flinkConfig = getFlinkConfig(planDir);
 
       var sqrlTest =
           new DatasqrlTest(
@@ -70,6 +74,23 @@ public class TestCmd extends AbstractCompileCmd {
         formatter.newline();
       }
     }
+  }
+
+  /**
+   * Loads the Flink configuration and disables job restarting for test runs.
+   *
+   * @param planDir directory containing the compiled plan artifacts
+   * @return Flink configuration for test execution
+   */
+  @Override
+  protected Configuration getFlinkConfig(Path planDir) {
+    var flinkConfig = super.getFlinkConfig(planDir);
+    flinkConfig.set(RestartStrategyOptions.RESTART_STRATEGY, "none");
+    flinkConfig.set(
+        ClusterOptions.UNCAUGHT_EXCEPTION_HANDLING,
+        ClusterOptions.UncaughtExceptionHandleMode.FAIL);
+
+    return flinkConfig;
   }
 
   @Override

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/TestCmdTest.java
@@ -25,7 +25,9 @@ import com.datasqrl.plan.validate.ExecutionGoal;
 import com.datasqrl.util.ConfigLoaderUtils;
 import com.datasqrl.util.OsProcessManager;
 import java.nio.file.Path;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +41,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TestCmdTest {
 
   @Mock private ErrorCollector errors;
-  @Mock private Configuration flinkConfig;
 
   private TestCmd testCmd;
 
@@ -71,6 +72,7 @@ class TestCmdTest {
     try (MockedStatic<ConfigLoaderUtils> mocked = mockStatic(ConfigLoaderUtils.class)) {
 
       var mockSqrlConfig = mock(PackageJson.class);
+      var flinkConfig = new Configuration();
       mocked
           .when(() -> ConfigLoaderUtils.loadResolvedConfig(errors, buildDir))
           .thenReturn(mockSqrlConfig);
@@ -96,6 +98,10 @@ class TestCmdTest {
 
         DatasqrlTest constructed = datasqrlTestMocked.constructed().get(0);
         verify(constructed).run();
+
+        assertThat(flinkConfig.get(RestartStrategyOptions.RESTART_STRATEGY)).isEqualTo("none");
+        assertThat(flinkConfig.get(ClusterOptions.UNCAUGHT_EXCEPTION_HANDLING))
+            .isEqualTo(ClusterOptions.UncaughtExceptionHandleMode.FAIL);
       }
     }
   }


### PR DESCRIPTION
Explicitly disable Flink job recovery for `test` cmd run by updating the loaded Flink configuration before starting up the Flink job.