### PR TITLE
feat: add configurable memory-limit for DuckDB engine

### DIFF
--- a/documentation/docs/configuration-engine/duckdb.md
+++ b/documentation/docs/configuration-engine/duckdb.md
@@ -7,6 +7,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 | Key                    | Type        | Default          | Description                                                                    |
 |------------------------|-------------|------------------|--------------------------------------------------------------------------------|
 | `url`                  | **string**  | `"jdbc:duckdb:"` | Full JDBC URL for the database connection                                      |
+| `memory-limit`         | **string**  | -                | Sets DuckDB's `memory_limit`, for example `"8GB"`                              |
 | `use-disk-cache`       | **boolean** | `false`          | Install and load `cache_httpfs` extension                                      |
 | `use-version-guessing` | **boolean** | `false`          | Sets `unsafe_enable_version_guessing` flag to be able to read uncommitted data |
 
@@ -17,6 +18,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
   "engines": {
     "duckdb": {
       "url": "jdbc:duckdb:",
+      "memory-limit": "4GB",
       "use-disk-cache": true,
       "use-version-guessing": true
     }

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -172,6 +172,9 @@
             "url": {
               "type": "string"
             },
+            "memory-limit": {
+              "type": "string"
+            },
             "use-disk-cache": {
               "type": "boolean"
             },

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
@@ -45,5 +45,8 @@ public class JdbcConfig {
 
     @JsonProperty("use-version-guessing")
     private boolean useVersionGuessing;
+
+    @JsonProperty("memory-limit")
+    private String memoryLimit;
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/jdbc/JdbcClientsConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/jdbc/JdbcClientsConfig.java
@@ -16,7 +16,7 @@
 package com.datasqrl.graphql.jdbc;
 
 import com.datasqrl.graphql.config.ServerConfig;
-import com.datasqrl.util.DuckDbExtensions;
+import com.datasqrl.util.DuckDbInitializer;
 import com.google.common.collect.ImmutableMap;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -88,8 +88,7 @@ public class JdbcClientsConfig {
 
     // No need for Class.forName() - DuckDB JDBC driver auto-registers via JDBC 4.0+ ServiceLoader
     var url = duckDbConf.getUrl();
-    var extensions = new DuckDbExtensions(duckDbConf);
-    var initSql = extensions.buildInitSql();
+    var initSql = new DuckDbInitializer(duckDbConf).buildInitSql();
 
     var hikariCfg = new HikariConfig();
     hikariCfg.setJdbcUrl(url);

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbExtensions.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbExtensions.java
@@ -34,9 +34,15 @@ public final class DuckDbExtensions {
   public Optional<String> buildInitSql() {
     var extensionDir = System.getenv(DUCKDB_EXTENSIONS_DIR);
 
+    if (config.getMemoryLimit() != null && !config.getMemoryLimit().isBlank()) {
+      joiner.add("SET memory_limit='" + config.getMemoryLimit() + "'");
+    }
+
     if (extensionDir == null || extensionDir.trim().isEmpty()) {
-      log.warn("Environment variable {} is not set, extensions will not be loaded.", extensionDir);
-      return Optional.empty();
+      log.warn(
+          "Environment variable {} is not set, extensions will not be loaded.",
+          DUCKDB_EXTENSIONS_DIR);
+      return joiner.length() > 1 ? Optional.of(joiner.toString()) : Optional.empty();
     }
 
     joiner.add("SET extension_directory='" + extensionDir + "'");

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbInitializer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbInitializer.java
@@ -22,27 +22,38 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 @RequiredArgsConstructor
 @Slf4j
-public final class DuckDbExtensions {
+public final class DuckDbInitializer {
 
   private final StringJoiner joiner = new StringJoiner(";", "", ";");
 
   private final JdbcConfig.DuckDbConfig config;
 
   public Optional<String> buildInitSql() {
-    var extensionDir = System.getenv(DUCKDB_EXTENSIONS_DIR);
-
-    if (config.getMemoryLimit() != null && !config.getMemoryLimit().isBlank()) {
+    if (StringUtils.isNotBlank(config.getMemoryLimit())) {
       joiner.add("SET memory_limit='" + config.getMemoryLimit() + "'");
     }
 
-    if (extensionDir == null || extensionDir.trim().isEmpty()) {
+    initExtensions();
+
+    if (joiner.length() > 1) {
+      return Optional.of(joiner.toString());
+    }
+
+    return Optional.empty();
+  }
+
+  private void initExtensions() {
+    var extensionDir = System.getenv(DUCKDB_EXTENSIONS_DIR);
+
+    if (StringUtils.isBlank(extensionDir)) {
       log.warn(
           "Environment variable {} is not set, extensions will not be loaded.",
           DUCKDB_EXTENSIONS_DIR);
-      return joiner.length() > 1 ? Optional.of(joiner.toString()) : Optional.empty();
+      return;
     }
 
     joiner.add("SET extension_directory='" + extensionDir + "'");
@@ -56,7 +67,5 @@ public final class DuckDbExtensions {
     if (config.isUseVersionGuessing()) {
       joiner.add("SET unsafe_enable_version_guessing = true");
     }
-
-    return Optional.of(joiner.toString());
   }
 }


### PR DESCRIPTION
## Summary

- Added `memory-limit` field to `JdbcConfig.DuckDbConfig` (JSON key `memory-limit`)
- `DuckDbExtensions.buildInitSql()` now emits `SET memory_limit='<value>'` before loading extensions when the field is set
- Fixed log statement: was logging null `extensionDir` value; now logs the env var name `DUCKDB_EXTENSIONS_DIR`

## Usage

Configure in `package.json` server section:
```json
"duckdb": {
  "url": "jdbc:duckdb:",
  "memory-limit": "20GB"
}
```

Without this setting, DuckDB defaults to ~80% of available system RAM — causing OOM kills when running alongside Flink in a shared pod.

## Test plan

- [ ] Deploy workbench query executor with `memory-limit: "20GB"` configured
- [ ] Verify `SELECT current_setting('memory_limit')` in DuckDB returns `"20.0 GiB"`
- [ ] Confirm TM pods no longer OOM crash loop under workbench query load