### PR TITLE
fix: Preserve SQL that has `--` in string literals

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqlScriptStatementSplitter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqlScriptStatementSplitter.java
@@ -41,8 +41,8 @@ public final class SqlScriptStatementSplitter {
 
   private static final String STATEMENT_DELIMITER = ";"; // a statement should end with `;`
   private static final String LINE_DELIMITER = "\n";
+  private static final char SINGLE_QUOTE = '\'';
 
-  private static final Pattern LINE_COMMENT_PATTERN = Pattern.compile("--.*");
   // Matches block comments that are NOT hints or doc comments
   private static final Pattern BLOCK_COMMENT_PATTERN =
       Pattern.compile("/\\*(?!\\s*\\+)(?!\\*)[\\s\\S]*?\\*/");
@@ -66,10 +66,13 @@ public final class SqlScriptStatementSplitter {
     StringBuilder current = null;
     var statementLineNo = 0;
     var lineNo = 0;
+    var inStringLiteral = false;
     for (var line : formatted.split(LINE_DELIMITER)) {
       lineNo++;
 
-      var rawLine = LINE_COMMENT_PATTERN.matcher(line).replaceAll("");
+      var lineCommentResult = removeLineComment(line, inStringLiteral);
+      var rawLine = lineCommentResult.line();
+      inStringLiteral = lineCommentResult.inStringLiteral();
       if (rawLine.isBlank()) {
         continue;
       }
@@ -138,6 +141,51 @@ public final class SqlScriptStatementSplitter {
   }
 
   /**
+   * Removes a SQL line comment from a single line while preserving {@code --} inside SQL string
+   * literals.
+   *
+   * <p>The {@code inStringLiteral} argument carries parser state from the previous line so
+   * multiline string literals are handled correctly. Only single-quoted SQL string literals are
+   * recognized; escaped quotes are handled using SQL's doubled quote syntax ({@code ''}).
+   *
+   * @param line the line to scan
+   * @param inStringLiteral whether the previous line ended inside a single-quoted string literal
+   * @return the line without its trailing comment and the updated string-literal state
+   */
+  private static LineCommentResult removeLineComment(String line, boolean inStringLiteral) {
+    var lineEnd = line.length();
+
+    for (var i = 0; i < line.length(); i++) {
+      var ch = line.charAt(i);
+
+      if (ch == SINGLE_QUOTE) {
+        if (isEscapedSingleQuote(line, i, inStringLiteral)) {
+          i++;
+          continue;
+        }
+
+        inStringLiteral = !inStringLiteral;
+        continue;
+      }
+
+      if (!inStringLiteral && startsLineComment(line, i)) {
+        lineEnd = i;
+        break;
+      }
+    }
+
+    return new LineCommentResult(line.substring(0, lineEnd), inStringLiteral);
+  }
+
+  private static boolean isEscapedSingleQuote(String line, int pos, boolean inStringLiteral) {
+    return inStringLiteral && pos + 1 < line.length() && line.charAt(pos + 1) == SINGLE_QUOTE;
+  }
+
+  private static boolean startsLineComment(String line, int pos) {
+    return line.charAt(pos) == '-' && pos + 1 < line.length() && line.charAt(pos + 1) == '-';
+  }
+
+  /**
    * Removes block comments from SQL script while preserving SQL hints and doc comments.
    *
    * <p>Newlines within removed comments are preserved as blank lines to maintain accurate line
@@ -163,4 +211,6 @@ public final class SqlScriptStatementSplitter {
 
     return result.toString();
   }
+
+  private record LineCommentResult(String line, boolean inStringLiteral) {}
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/parser/SqlScriptStatementSplitterTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/parser/SqlScriptStatementSplitterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SqlScriptStatementSplitterTest {
+
+  @Test
+  void givenLineCommentMarkerInStringLiteral_whenSplitStatements_thenPreservesLiteral() {
+    var script =
+        """
+        SELECT SUBSTR('--', 1, 1) AS `val1`,
+        'hello' AS `val2`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT SUBSTR('--', 1, 1) AS `val1`,
+            'hello' AS `val2`;
+            """);
+  }
+
+  @Test
+  void givenLineCommentOutsideStringLiteral_whenSplitStatements_thenRemovesComment() {
+    var script =
+        """
+        SELECT 'hello -- not a comment' AS `val1`;-- comment
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT 'hello -- not a comment' AS `val1`;
+            """);
+  }
+}


### PR DESCRIPTION
## Key Changes
- Make SQL line comment recognition smarter to preserve `--` inside string literals
- Add some unit tests