### PR TITLE
fix: Rework comment parsing in `SqlScriptStatementSplitter`

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqlScriptStatementSplitter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/parser/SqlScriptStatementSplitter.java
@@ -20,7 +20,6 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -43,10 +42,6 @@ public final class SqlScriptStatementSplitter {
   private static final String LINE_DELIMITER = "\n";
   private static final char SINGLE_QUOTE = '\'';
 
-  // Matches block comments that are NOT hints or doc comments
-  private static final Pattern BLOCK_COMMENT_PATTERN =
-      Pattern.compile("/\\*(?!\\s*\\+)(?!\\*)[\\s\\S]*?\\*/");
-
   /**
    * Parses SQL statements from a script.
    *
@@ -61,18 +56,21 @@ public final class SqlScriptStatementSplitter {
     var statements = new ArrayList<ParsedObject<String>>();
 
     var formatted = formatEndOfSqlFile(script);
-    formatted = removeBlockComments(formatted);
 
     StringBuilder current = null;
     var statementLineNo = 0;
     var lineNo = 0;
     var inStringLiteral = false;
+    var inPreservedBlockComment = false;
+    var inBlockComment = false;
     for (var line : formatted.split(LINE_DELIMITER)) {
       lineNo++;
 
-      var lineCommentResult = removeLineComment(line, inStringLiteral);
-      var rawLine = lineCommentResult.line();
-      inStringLiteral = lineCommentResult.inStringLiteral();
+      var parsedLine = parseLine(line, inStringLiteral, inPreservedBlockComment, inBlockComment);
+      var rawLine = parsedLine.line();
+      inStringLiteral = parsedLine.inStringLiteral();
+      inPreservedBlockComment = parsedLine.inPreservedBlockComment();
+      inBlockComment = parsedLine.inBlockComment();
       if (rawLine.isBlank()) {
         continue;
       }
@@ -85,7 +83,10 @@ public final class SqlScriptStatementSplitter {
       current.append(rawLine);
       current.append(LINE_DELIMITER);
 
-      if (!inStringLiteral && rawLine.trim().endsWith(STATEMENT_DELIMITER)) {
+      if (!inStringLiteral
+          && !inPreservedBlockComment
+          && !inBlockComment
+          && rawLine.trim().endsWith(STATEMENT_DELIMITER)) {
         var fileLoc = new FileLocation(statementLineNo, 1);
         var parsedObj = new ParsedObject<>(current.toString(), fileLoc);
         statements.add(parsedObj);
@@ -142,25 +143,62 @@ public final class SqlScriptStatementSplitter {
   }
 
   /**
-   * Removes a SQL line comment from a single line while preserving {@code --} inside SQL string
-   * literals.
+   * Parses a single line, removing SQL line comments and regular block comments while preserving
+   * comment markers in string literals, SQL hints, and doc comments.
    *
-   * <p>The {@code inStringLiteral} argument carries parser state from the previous line so
-   * multiline string literals are handled correctly. Only single-quoted SQL string literals are
+   * <p>The state arguments carry parser state from the previous line so multiline string literals
+   * and block comments are handled correctly. Only single-quoted SQL string literals are
    * recognized; escaped quotes are handled using SQL's doubled quote syntax ({@code ''}).
    *
-   * @param line the line to scan
+   * @param line the line to parse
    * @param inStringLiteral whether the previous line ended inside a single-quoted string literal
-   * @return the line without its trailing comment and the updated string-literal state
+   * @param inPreservedBlockComment whether the previous line ended inside a doc comment or SQL hint
+   * @param inBlockComment whether the previous line ended inside a regular block comment
+   * @return the parsed line and updated parser state
    */
-  private static LineCommentResult removeLineComment(String line, boolean inStringLiteral) {
-    var lineEnd = line.length();
+  private static ParsedLine parseLine(
+      String line,
+      boolean inStringLiteral,
+      boolean inPreservedBlockComment,
+      boolean inBlockComment) {
+    var parsed = new StringBuilder();
 
     for (var i = 0; i < line.length(); i++) {
+      if (inBlockComment) {
+        if (endsBlockComment(line, i)) {
+          inBlockComment = false;
+          i++;
+        }
+        continue;
+      }
+
+      if (inPreservedBlockComment) {
+        parsed.append(line.charAt(i));
+        if (endsBlockComment(line, i)) {
+          parsed.append(line.charAt(i + 1));
+          inPreservedBlockComment = false;
+          i++;
+        }
+        continue;
+      }
+
+      if (!inStringLiteral && startsBlockComment(line, i)) {
+        if (startsDocComment(line, i) || startsHintComment(line, i)) {
+          inPreservedBlockComment = true;
+          parsed.append(line.charAt(i));
+        } else {
+          inBlockComment = true;
+          i++;
+        }
+        continue;
+      }
+
       var ch = line.charAt(i);
 
       if (ch == SINGLE_QUOTE) {
+        parsed.append(ch);
         if (isEscapedSingleQuote(line, i, inStringLiteral)) {
+          parsed.append(line.charAt(i + 1));
           i++;
           continue;
         }
@@ -170,12 +208,14 @@ public final class SqlScriptStatementSplitter {
       }
 
       if (!inStringLiteral && startsLineComment(line, i)) {
-        lineEnd = i;
         break;
       }
+
+      parsed.append(ch);
     }
 
-    return new LineCommentResult(line.substring(0, lineEnd), inStringLiteral);
+    return new ParsedLine(
+        parsed.toString(), inStringLiteral, inPreservedBlockComment, inBlockComment);
   }
 
   private static boolean isEscapedSingleQuote(String line, int pos, boolean inStringLiteral) {
@@ -186,32 +226,31 @@ public final class SqlScriptStatementSplitter {
     return line.charAt(pos) == '-' && pos + 1 < line.length() && line.charAt(pos + 1) == '-';
   }
 
-  /**
-   * Removes block comments from SQL script while preserving SQL hints and doc comments.
-   *
-   * <p>Newlines within removed comments are preserved as blank lines to maintain accurate line
-   * numbering for error reporting.
-   *
-   * @param text The SQL script text.
-   * @return The text with regular block comments removed.
-   */
-  private static String removeBlockComments(String text) {
-    var matcher = BLOCK_COMMENT_PATTERN.matcher(text);
-    var result = new StringBuilder();
-    var lastEnd = 0;
-
-    while (matcher.find()) {
-      result.append(text, lastEnd, matcher.start());
-      // Count newlines in the comment and preserve them as blank lines
-      var comment = matcher.group();
-      var newlineCount = comment.chars().filter(ch -> ch == '\n').count();
-      result.append(LINE_DELIMITER.repeat((int) newlineCount));
-      lastEnd = matcher.end();
-    }
-    result.append(text.substring(lastEnd));
-
-    return result.toString();
+  private static boolean startsBlockComment(String text, int pos) {
+    return text.charAt(pos) == '/' && pos + 1 < text.length() && text.charAt(pos + 1) == '*';
   }
 
-  private record LineCommentResult(String line, boolean inStringLiteral) {}
+  private static boolean startsDocComment(String line, int pos) {
+    return line.charAt(pos) == '/'
+        && pos + 2 < line.length()
+        && line.charAt(pos + 1) == '*'
+        && line.charAt(pos + 2) == '*';
+  }
+
+  private static boolean startsHintComment(String text, int pos) {
+    return text.charAt(pos) == '/'
+        && pos + 2 < text.length()
+        && text.charAt(pos + 1) == '*'
+        && text.charAt(pos + 2) == '+';
+  }
+
+  private static boolean endsBlockComment(String line, int pos) {
+    return line.charAt(pos) == '*' && pos + 1 < line.length() && line.charAt(pos + 1) == '/';
+  }
+
+  private record ParsedLine(
+      String line,
+      boolean inStringLiteral,
+      boolean inPreservedBlockComment,
+      boolean inBlockComment) {}
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/parser/SqlScriptStatementSplitterTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/parser/SqlScriptStatementSplitterTest.java
@@ -41,6 +41,31 @@ class SqlScriptStatementSplitterTest {
   }
 
   @Test
+  void givenDocCommentMarkerInStringLiteral_whenSplitStatements_thenPreservesLiteral() {
+    var script =
+        """
+        SELECT 'first line;
+                /** doc comment
+                    multi line
+                */
+                last line' AS `val`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT 'first line;
+                    /** doc comment
+                        multi line
+                    */
+                    last line' AS `val`;
+            """);
+  }
+
+  @Test
   void givenLineCommentOutsideStringLiteral_whenSplitStatements_thenRemovesComment() {
     var script =
         """
@@ -75,6 +100,144 @@ class SqlScriptStatementSplitterTest {
             SELECT 'first line;
                     -- not a comment
                     last line' AS `val`;
+            """);
+  }
+
+  @Test
+  void givenSingleQuoteInSingleLineDocComment_whenSplitStatements_thenIgnoresQuote() {
+    var script =
+        """
+        /** Dummy one liner comment. '' This -- is still part of the doc' comment. */
+        SELECT 'hello -- not a comment' AS `val`;-- comment
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            /** Dummy one liner comment. '' This -- is still part of the doc' comment. */
+            SELECT 'hello -- not a comment' AS `val`;
+            """);
+  }
+
+  @Test
+  void givenSingleQuoteInMultiLineDocComment_whenSplitStatements_thenIgnoresQuote() {
+    var script =
+        """
+        /** Dummy multi line comment. ''
+            This -- is still part of the doc' comment. */
+        SELECT 'hello -- not a comment' AS `val`;-- comment
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            /** Dummy multi line comment. ''
+                This -- is still part of the doc' comment. */
+            SELECT 'hello -- not a comment' AS `val`;
+            """);
+  }
+
+  @Test
+  void givenBlockCommentInStringLiteral_whenSplitStatements_thenPreservesLiteral() {
+    var script =
+        """
+        SELECT 'first line;
+                /* block comment
+                    multi line
+                */
+                last line' AS `val`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT 'first line;
+                    /* block comment
+                        multi line
+                    */
+                    last line' AS `val`;
+            """);
+  }
+
+  @Test
+  void givenBlockCommentOutsideStringLiteral_whenSplitStatements_thenRemovesComment() {
+    var script =
+        """
+        SELECT 1 /* regular block comment */ AS `val`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT 1  AS `val`;
+            """);
+  }
+
+  @Test
+  void givenMultilineBlockCommentOutsideStringLiteral_whenSplitStatements_thenRemovesComment() {
+    var script =
+        """
+        SELECT 1 AS `before`
+        /* block comment with ' quote, -- line comment, and ; delimiter
+           still inside the block comment
+        */
+        , 2 AS `after`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT 1 AS `before`
+            , 2 AS `after`;
+            """);
+  }
+
+  @Test
+  void givenSqlHintComment_whenSplitStatements_thenPreservesHint() {
+    var script =
+        """
+        SELECT /*+ OPTIONS('key'='value') */ 1 AS `val`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT /*+ OPTIONS('key'='value') */ 1 AS `val`;
+            """);
+  }
+
+  @Test
+  void givenWhitespaceBeforeHintPlus_whenSplitStatements_thenRemovesBlockComment() {
+    var script =
+        """
+        SELECT /* + not a hint */ 1 AS `val`
+        """;
+
+    var statements = SqlScriptStatementSplitter.splitStatements(script);
+
+    assertThat(statements)
+        .extracting(ParsedObject::get)
+        .containsExactly(
+            """
+            SELECT  1 AS `val`;
             """);
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/ExternalUseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/ExternalUseCaseCompileTest.java
@@ -31,8 +31,7 @@ public class ExternalUseCaseCompileTest {
     UseCaseTestHelper.testUseCase(
         snapshotExtension,
         getClass(),
-        Path.of(
-            "/Users/refrnc/dev/datasqrl/customers/medidata-workbench/query-converter/converter-package.json"),
+        Path.of("/path/to/package"),
         UseCaseTestHelper.defaultBuildDirFilter(),
         UseCaseTestHelper.defaultPlanDirFilter());
   }


### PR DESCRIPTION
## Key Changes
- Reworked `SqlScriptStatementSplitter` to parse line comments, block comments, doc comments, SQL hints, and single-quoted string literals in one stateful pass.
- Removed regex-based block comment stripping so `/* ... */` inside string literals is preserved correctly.
- Preserved Java-style doc comments `/** ... */` and SQL hints `/*+ ... */`, while removing regular block comments and `--` line comments outside string literals.
- Added regression tests for multiline string literals, doc comments with quotes/comment markers, block comments inside/outside literals, multiline block comments, and exact SQL hint detection.