### PR TITLE
fix: Don't throw query_by exception for no_query hint.

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -798,7 +798,7 @@ public class SqlScriptPlanner {
       fnBuilder.cacheDuration(getCacheDuration(hintsAndDocs));
       addFunctionToDag(
           fnBuilder.build(), hintsAndDocs.dropHints()); // hints don't apply to the function access
-    } else if (queryByHint.isPresent()) {
+    } else if (queryByHint.isPresent() && !(queryByHint.get() instanceof NoQueryHint)) {
       throw new StatementParserException(
           ErrorLabel.GENERIC,
           queryByHint.get().getSource().getFileLocation(),

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/subProject/sources.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/subProject/sources.sqrl
@@ -1,3 +1,4 @@
+/*+no_query */
 CREATE TABLE Customer (
     `timestamp` AS COALESCE(TO_TIMESTAMP_LTZ(lastUpdated, 0), TIMESTAMP '1970-01-01 00:00:00.000'),
     PRIMARY KEY (customerid, lastUpdated) NOT ENFORCED,


### PR DESCRIPTION
self explanatory. This stems from no_query hints being considered query_by hints which is useful in other places.