### PR TITLE
fix: Surface real root cause when CLI run/test pipeline fails to start

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -117,11 +117,8 @@ public class DatasqrlRun {
     initPostgres();
     initKafka();
 
-    // Start the Flink job first: it validates the compiled plan (e.g. resolving environment
-    // variables) and throws synchronously on the calling thread. Deploying the server verticle
-    // afterwards keeps a Flink failure from masquerading as a generic verticle deployment error.
-    tableResult = runFlinkJob();
     startVertx();
+    tableResult = runFlinkJob();
 
     if (shutdownLatch != null) {
       Runtime.getRuntime().addShutdownHook(new Thread(this::stop, "flink-shutdown"));

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -52,6 +52,9 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.SneakyThrows;
@@ -74,6 +77,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 public class DatasqrlRun {
 
   private static final int TOPIC_CREATE_TIMEOUT_MS = 8000;
+  private static final int VERTX_DEPLOY_TIMEOUT_SEC = 30;
 
   private final Path planDir;
   private final PackageJson sqrlConfig;
@@ -113,8 +117,11 @@ public class DatasqrlRun {
     initPostgres();
     initKafka();
 
-    startVertx();
+    // Start the Flink job first: it validates the compiled plan (e.g. resolving environment
+    // variables) and throws synchronously on the calling thread. Deploying the server verticle
+    // afterwards keeps a Flink failure from masquerading as a generic verticle deployment error.
     tableResult = runFlinkJob();
+    startVertx();
 
     if (shutdownLatch != null) {
       Runtime.getRuntime().addShutdownHook(new Thread(this::stop, "flink-shutdown"));
@@ -303,17 +310,25 @@ public class DatasqrlRun {
         new MicrometerMetricsFactory(prometheusMeterRegistry).newOptions().setEnabled(true);
 
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(metricsOptions));
-    vertx
-        .deployVerticle(serverVerticle)
-        .onComplete(
-            res -> {
-              if (res.succeeded()) {
-                log.info("Vertx deployment succeeded. ID: {}", res.result());
-              } else {
-                log.error("Vertx deployment failed", res.cause());
-                vertx.close().onComplete(v -> System.exit(1));
-              }
-            });
+
+    // Block until the verticle is deployed so any deployment failure is thrown on the calling
+    // thread with its real cause, instead of being logged and exiting from a Vert.x event-loop
+    // thread (which masked the underlying error).
+    try {
+      var deploymentId =
+          vertx
+              .deployVerticle(serverVerticle)
+              .toCompletionStage()
+              .toCompletableFuture()
+              .get(VERTX_DEPLOY_TIMEOUT_SEC, TimeUnit.SECONDS);
+      log.info("Vertx deployment succeeded. ID: {}", deploymentId);
+    } catch (ExecutionException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
+      throw new IllegalStateException("Failed to deploy the GraphQL server verticle", cause);
+    } catch (TimeoutException e) {
+      throw new IllegalStateException(
+          "Timed out waiting for the GraphQL server verticle to deploy", e);
+    }
   }
 
   @SneakyThrows

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
@@ -170,12 +170,11 @@ public class DatasqrlTest {
                       var jobStatusCompletableFuture =
                           result.getJobClient().map(JobClient::getJobStatus).get();
                       var status = jobStatusCompletableFuture.get(1, TimeUnit.SECONDS);
-                      if (status == JobStatus.FAILED) {
-                        testResults.add(TestResult.Failure.flink(null));
-                        return true;
-                      }
-
-                      return status == JobStatus.FINISHED || status == JobStatus.CANCELED;
+                      // The real failure cause is fetched from getJobExecutionResult() below,
+                      // so a terminal state is enough to stop polling here.
+                      return status == JobStatus.FAILED
+                          || status == JobStatus.FINISHED
+                          || status == JobStatus.CANCELED;
 
                     } catch (Exception e) {
                       return true;
@@ -192,9 +191,11 @@ public class DatasqrlTest {
             .getJobExecutionResult()
             .get(2, TimeUnit.SECONDS); // flink will hold if the minicluster is stopped
       } catch (ExecutionException e) {
-        // try to catch the job failure if we can
-        testResults.add(TestResult.Failure.flink(e));
+        // The job reached a terminal failure state; surface its real root cause.
+        var cause = e.getCause() != null ? e.getCause() : e;
+        testResults.add(TestResult.Failure.flink(cause));
       } catch (Exception ignored) {
+        // Timed out or interrupted while the job is still running; nothing conclusive to report.
       }
 
       // 5. Validate JDBC views, run the API queries, finish subscriptions and snapshot the API
@@ -246,6 +247,11 @@ public class DatasqrlTest {
           }
         }
       }
+    } catch (Exception e) {
+      // The pipeline failed to start or run (e.g. a missing environment variable referenced by the
+      // compiled Flink plan). Record it as a real failure with its root cause so the message is
+      // printed and the exit code is non-zero, instead of being swallowed during cleanup.
+      testResults.add(TestResult.Failure.pipeline(e));
     } finally {
       run.cancel();
       Thread.sleep(1000); // wait for log lines to clear out

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestResult.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestResult.java
@@ -163,6 +163,10 @@ public abstract class TestResult {
       return new Failure("JDBC validation failed", cause);
     }
 
+    public static Failure pipeline(Throwable cause) {
+      return new Failure("Pipeline failed to start", cause);
+    }
+
     @Override
     public String getTestName() {
       return msg;
@@ -182,6 +186,13 @@ public abstract class TestResult {
     public void printDetails(OutputFormatter formatter, Optional<Path> testDir) {
       formatter.error(msg);
       if (cause != null) {
+        var rootCause = cause;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+          rootCause = rootCause.getCause();
+        }
+        if (rootCause.getMessage() != null) {
+          formatter.error(rootCause.getMessage());
+        }
         cause.printStackTrace();
       }
     }

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
@@ -16,15 +16,20 @@
 package com.datasqrl.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.datasqrl.config.PackageJson;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,6 +49,27 @@ class DatasqrlRunTest {
     env = new HashMap<>();
 
     underTest = DatasqrlRun.nonBlocking(tempDir.resolve("plan"), null, flinkConfig, env);
+  }
+
+  @Test
+  void run_whenCompiledPlanReferencesMissingEnvVar_propagatesClearError() throws Exception {
+    var planDir = tempDir.resolve("plan");
+    Files.createDirectories(planDir);
+    Files.writeString(
+        planDir.resolve("flink-sql.sql"),
+        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${DEPLOYMENT_ID}');\n");
+
+    var realFlinkConfig = new Configuration();
+    realFlinkConfig.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+
+    var sqrlConfig = mock(PackageJson.class, RETURNS_DEEP_STUBS);
+    when(sqrlConfig.getCompilerConfig().compileFlinkPlan()).thenReturn(false);
+
+    var run = DatasqrlRun.nonBlocking(planDir, sqrlConfig, realFlinkConfig, new HashMap<>());
+
+    assertThatThrownBy(run::run)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("DEPLOYMENT_ID");
   }
 
   @Test

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
@@ -57,7 +57,7 @@ class DatasqrlRunTest {
     Files.createDirectories(planDir);
     Files.writeString(
         planDir.resolve("flink-sql.sql"),
-        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${DEPLOYMENT_ID}');\n");
+        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${NON_EXISTING_ENV_VAR}');\n");
 
     var realFlinkConfig = new Configuration();
     realFlinkConfig.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
@@ -69,7 +69,7 @@ class DatasqrlRunTest {
 
     assertThatThrownBy(run::run)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("DEPLOYMENT_ID");
+        .hasMessageContaining("NON_EXISTING_ENV_VAR");
   }
 
   @Test

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlTestTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlTestTest.java
@@ -26,7 +26,7 @@ import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.config.PackageJson;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ class DatasqrlTestTest {
     // swallowed.
     Files.writeString(
         planDir.resolve("flink-sql.sql"),
-        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${DEPLOYMENT_ID}');\n");
+        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${NON_EXISTING_ENV_VAR}');\n");
 
     var sqrlConfig = mock(PackageJson.class, RETURNS_DEEP_STUBS);
     when(sqrlConfig.getCompilerConfig().compileFlinkPlan()).thenReturn(false);
@@ -61,12 +61,11 @@ class DatasqrlTestTest {
             planDir,
             sqrlConfig,
             new Configuration(),
-            new HashMap<>(),
+            Map.of(),
             new TestOutputManager(tempDir),
             new NoOutputFormatter());
 
     var exitCode = underTest.run();
-
     assertThat(exitCode).isNotZero();
   }
 }

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlTestTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlTestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.cli.output.NoOutputFormatter;
+import com.datasqrl.cli.output.TestOutputManager;
+import com.datasqrl.config.PackageJson;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Optional;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DatasqrlTestTest {
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void run_whenPipelineFailsToStart_recordsFailureWithNonZeroExit() throws Exception {
+    var planDir = tempDir.resolve("plan");
+    Files.createDirectories(planDir);
+    // The compiled plan references an environment variable that is not provided. The runner throws
+    // a clear IllegalStateException, which must be reported as a test failure rather than
+    // swallowed.
+    Files.writeString(
+        planDir.resolve("flink-sql.sql"),
+        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${DEPLOYMENT_ID}');\n");
+
+    var sqrlConfig = mock(PackageJson.class, RETURNS_DEEP_STUBS);
+    when(sqrlConfig.getCompilerConfig().compileFlinkPlan()).thenReturn(false);
+    when(sqrlConfig.getTestConfig().getSnapshotDir(any())).thenReturn(tempDir.resolve("snapshots"));
+    when(sqrlConfig.getTestConfig().getTestDir(any())).thenReturn(Optional.empty());
+    when(sqrlConfig.getTestConfig().getDelaySec()).thenReturn(5);
+    when(sqrlConfig.getTestConfig().getMutationDelaySec()).thenReturn(0);
+    when(sqrlConfig.getTestConfig().getRequiredCheckpoints()).thenReturn(0);
+
+    var underTest =
+        new DatasqrlTest(
+            tempDir,
+            planDir,
+            sqrlConfig,
+            new Configuration(),
+            new HashMap<>(),
+            new TestOutputManager(tempDir),
+            new NoOutputFormatter());
+
+    var exitCode = underTest.run();
+
+    assertThat(exitCode).isNotZero();
+  }
+}


### PR DESCRIPTION
## Problem

When a compiled Flink plan references an environment variable that isn't set
(e.g. `${DEPLOYMENT_ID}`), the runner throws a clear, correct error — but the
CLI swallowed it and printed only the misleading:

```
io.vertx.core.VertxException: Verticle un-deployed
```

before exiting, making a trivial misconfiguration nearly impossible to diagnose
for both `datasqrl run` and `datasqrl test`.

## Root cause (the runner is blameless)

`flink-sql-runner` behaves correctly: `EnvVarResolver.resolve()` throws
`IllegalStateException("The following environment variables were referenced, but not found: [...]")`
and lets it propagate (`BaseRunner.run()` → `SqrlRunner.run()`). No masking there.

The masking was entirely in `sqrl`:

- **`DatasqrlRun.run()`** called `startVertx()` (async, fire-and-forget verticle
  deploy) *before* `runFlinkJob()`, which throws the real exception synchronously
  on the main thread.
- **`DatasqrlRun.startVertx()`** deployment failure handler logged `res.cause()` —
  which, during cleanup-triggered shutdown, is the generic `Verticle un-deployed`
  sentinel, not the real cause — and then called `System.exit(1)` from a Vert.x
  event-loop thread.
- **`DatasqrlTest.run()`** wrapped `run.run()` in a `try/finally` with no `catch`;
  the `finally`'s `run.cancel()` → `vertx.close()` made the still-deploying
  verticle fail with `Verticle un-deployed`. The async `System.exit(1)` then raced
  the main thread (sitting in the `finally`'s `Thread.sleep(1000)`) and killed the
  JVM before the real exception was printed. Causes were also discarded at
  `TestResult.Failure.flink(null)` and in empty `catch (Exception ignored) {}` blocks.

## Fix

- ~`DatasqrlRun.run()`: run the Flink job **before** deploying the server verticle,
  so a Flink failure can't masquerade as a verticle deployment error.~ Keep the original order, cause otherwise Vert.x may miss some events.
- `DatasqrlRun.startVertx()`: block on the deployment future and rethrow the real
  cause as `IllegalStateException`; removed the `System.exit(1)` event-loop call.
- `DatasqrlTest.run()`: catch pipeline-startup failures and record them as
  `TestResult.Failure.pipeline(e)` (printed, non-zero exit); replaced the
  cause-discarding `flink(null)` with real-cause capture from
  `getJobExecutionResult()`.
- `TestResult`: added `pipeline(...)` factory and made `Failure.printDetails`
  surface the root-cause message, not just a stack trace.

## Tests

- `DatasqrlRunTest.run_whenCompiledPlanReferencesMissingEnvVar_propagatesClearError`
  asserts `run()` throws `IllegalStateException` whose message names the missing
  env var (`DEPLOYMENT_ID`).
- `DatasqrlTestTest.run_whenPipelineFailsToStart_recordsFailureWithNonZeroExit`
  asserts a missing env var yields a recorded failure and a non-zero exit code
  instead of `Verticle un-deployed`.

Full `mvn test` passes.
