### PR TITLE
feat: DuckDB S3 credential-chain support for IRSA-backed Iceberg reads

### DIFF
--- a/Dockerfile.duckdb-extensions
+++ b/Dockerfile.duckdb-extensions
@@ -11,7 +11,7 @@ RUN set -eux; \
     duckdb_cli_version="$(printf '%s' "${duckdb_jdbc_version}" | cut -d. -f1-3)"; \
     export DUCKDB_VERSION="${duckdb_cli_version}"; \
     curl https://install.duckdb.org | sh; \
-    /root/.duckdb/cli/${duckdb_cli_version}/duckdb -c "INSTALL iceberg; INSTALL httpfs; INSTALL cache_httpfs FROM community;"; \
+    /root/.duckdb/cli/${duckdb_cli_version}/duckdb -c "INSTALL iceberg; INSTALL httpfs; INSTALL aws; INSTALL cache_httpfs FROM community;"; \
     mkdir -p "${DUCKDB_EXTENSIONS_DIR}"; \
     cp -a /root/.duckdb/extensions/. "${DUCKDB_EXTENSIONS_DIR}/"; \
     rm -rf /root/.duckdb

--- a/documentation/docs/configuration-engine/duckdb.md
+++ b/documentation/docs/configuration-engine/duckdb.md
@@ -9,6 +9,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 | `url`                  | **string**  | `"jdbc:duckdb:"` | Full JDBC URL for the database connection                                      |
 | `use-disk-cache`       | **boolean** | `false`          | Install and load `cache_httpfs` extension                                      |
 | `use-version-guessing` | **boolean** | `false`          | Sets `unsafe_enable_version_guessing` flag to be able to read uncommitted data |
+| `use-credential-chain` | **boolean** | `false`          | Load the `aws` extension and create an S3 secret backed by the AWS credential provider chain |
 
 ## Example Configuration
 
@@ -29,6 +30,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 - Ideal for local development and testing of analytical workloads
 - Excellent performance on analytical queries with vectorized execution
 - Can read Iceberg tables directly without additional infrastructure
+- Enable `use-credential-chain` when reading S3-backed Iceberg from an environment that supplies credentials through the AWS provider chain rather than static keys — e.g. EKS IRSA, where the pod only has a projected web-identity token. Plain `httpfs` does not perform the web-identity exchange, so without this flag S3 reads fail with `HTTP 403`.
 - Supports both in-memory and persistent database modes
 - Perfect for prototyping before deploying to cloud query engines like Snowflake
 - Lightweight alternative to larger analytical databases

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -177,6 +177,9 @@
             },
             "use-version-guessing": {
               "type": "boolean"
+            },
+            "use-credential-chain": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false,

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/graphql/config/JdbcConfig.java
@@ -45,5 +45,8 @@ public class JdbcConfig {
 
     @JsonProperty("use-version-guessing")
     private boolean useVersionGuessing;
+
+    @JsonProperty("use-credential-chain")
+    private boolean useCredentialChain;
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbExtensions.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbExtensions.java
@@ -18,6 +18,7 @@ package com.datasqrl.util;
 import static com.datasqrl.env.EnvVariableNames.DUCKDB_EXTENSIONS_DIR;
 
 import com.datasqrl.graphql.config.JdbcConfig;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class DuckDbExtensions {
 
-  private final StringJoiner joiner = new StringJoiner(";", "", ";");
+  // The AWS SDK credential provider chain DuckDB walks; 'sts' is the web-identity provider that
+  // backs EKS IRSA, so it must stay in the list for in-cluster pods that only have a projected
+  // service-account token (no static AWS_ACCESS_KEY_ID/SECRET).
+  private static final String CREDENTIAL_CHAIN = "env;config;sts;sso;instance;process";
 
   private final JdbcConfig.DuckDbConfig config;
 
@@ -39,9 +43,25 @@ public final class DuckDbExtensions {
       return Optional.empty();
     }
 
+    return Optional.of(buildInitSql(extensionDir));
+  }
+
+  @VisibleForTesting
+  String buildInitSql(String extensionDir) {
+    var joiner = new StringJoiner(";", "", ";");
+
     joiner.add("SET extension_directory='" + extensionDir + "'");
     joiner.add("LOAD iceberg");
     joiner.add("LOAD httpfs");
+
+    if (config.isUseCredentialChain()) {
+      joiner.add("LOAD aws");
+      joiner.add(
+          "CREATE OR REPLACE SECRET sqrl_s3_credential_chain "
+              + "(TYPE S3, PROVIDER credential_chain, CHAIN '"
+              + CREDENTIAL_CHAIN
+              + "')");
+    }
 
     if (config.isUseDiskCache()) {
       joiner.add("LOAD cache_httpfs");
@@ -51,6 +71,6 @@ public final class DuckDbExtensions {
       joiner.add("SET unsafe_enable_version_guessing = true");
     }
 
-    return Optional.of(joiner.toString());
+    return joiner.toString();
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/util/DuckDbExtensionsTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/util/DuckDbExtensionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datasqrl.graphql.config.JdbcConfig;
+import org.junit.jupiter.api.Test;
+
+class DuckDbExtensionsTest {
+
+  private static final String EXTENSION_DIR = "/opt/duckdb_extensions";
+
+  @Test
+  void givenDefaultConfig_whenBuildInitSql_thenLoadsCoreExtensionsOnly() {
+    var sql = new DuckDbExtensions(new JdbcConfig.DuckDbConfig()).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .isEqualTo("SET extension_directory='" + EXTENSION_DIR + "';LOAD iceberg;LOAD httpfs;");
+    assertThat(sql).doesNotContain("LOAD aws").doesNotContain("CREATE OR REPLACE SECRET");
+  }
+
+  @Test
+  void givenCredentialChainEnabled_whenBuildInitSql_thenLoadsAwsAndCreatesS3Secret() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+
+    var sql = new DuckDbExtensions(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .contains("LOAD aws;")
+        .contains(
+            "CREATE OR REPLACE SECRET sqrl_s3_credential_chain "
+                + "(TYPE S3, PROVIDER credential_chain, CHAIN 'env;config;sts;sso;instance;process');");
+  }
+
+  @Test
+  void givenCredentialChainEnabled_whenBuildInitSql_thenLoadsAwsAfterHttpfsAndBeforeSecret() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+
+    var sql = new DuckDbExtensions(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql.indexOf("LOAD httpfs"))
+        .isLessThan(sql.indexOf("LOAD aws"))
+        .isGreaterThanOrEqualTo(0);
+    assertThat(sql.indexOf("LOAD aws")).isLessThan(sql.indexOf("CREATE OR REPLACE SECRET"));
+  }
+
+  @Test
+  void givenAllFlagsEnabled_whenBuildInitSql_thenAppliesEveryStatement() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+    config.setUseDiskCache(true);
+    config.setUseVersionGuessing(true);
+
+    var sql = new DuckDbExtensions(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .contains("LOAD aws;")
+        .contains("LOAD cache_httpfs;")
+        .contains("SET unsafe_enable_version_guessing = true;");
+  }
+}


### PR DESCRIPTION
## Problem

When the Vert.x server reads an S3-backed Iceberg table through the **DuckDB** query engine, the request fails with `HTTP 403 Forbidden`.

Root cause: in-cluster pods (EKS) authenticate to AWS via **IRSA** — the pod gets only a projected web-identity token (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`), **no** static `AWS_ACCESS_KEY_ID`/`SECRET`. DuckDB's `httpfs` extension does not perform the STS web-identity exchange on its own; it reads only env-var / config-file / instance credentials. With none of those present it sends an **anonymous** S3 request and S3 returns 403. (Flink writes to the same bucket succeed because Flink's S3 layer does honor the web-identity token.)

This is DuckDB-specific. Production Iceberg reads go through Snowflake (which authenticates to S3 via its own storage integration), so this is not a customer-facing regression — but it blocks using the lightweight DuckDB engine for Iceberg-on-S3 in-cluster.

## Change

Add an opt-in `use-credential-chain` flag to the DuckDB engine config. When enabled, the connection init SQL additionally runs:

```sql
LOAD aws;
CREATE OR REPLACE SECRET sqrl_s3_credential_chain
  (TYPE S3, PROVIDER credential_chain, CHAIN 'env;config;sts;sso;instance;process');
```

`PROVIDER credential_chain` delegates to the AWS SDK default provider chain, and `sts` is the web-identity provider that backs IRSA — so DuckDB obtains temporary credentials from the projected service-account token, exactly like Flink. The flag defaults to `false`, preserving today's behavior.

## Files

- `DuckDbExtensions.java` — emit `LOAD aws` + credential-chain `CREATE SECRET` when the flag is set; extracted a `@VisibleForTesting String buildInitSql(extensionDir)` overload so the init SQL is unit-testable without env-var juggling.
- `JdbcConfig.DuckDbConfig` — new `use-credential-chain` boolean.
- `packageSchema.json` — register the new key.
- `Dockerfile.duckdb-extensions` — `INSTALL aws` so the extension is bundled in the image (the `credential_chain` provider requires it).
- `documentation/docs/configuration-engine/duckdb.md` — document the flag + the IRSA rationale.
- `DuckDbExtensionsTest.java` — new unit test covering default vs. credential-chain init SQL, statement ordering, and all-flags-on.

## Validation

- `DuckDbExtensionsTest` — 4 tests, green (built under JDK 17).
- google-java-format + license strict-check pass.
- End-to-end S3-read validation is exercised downstream by `IcebergDeploymentIT` in `cloud-compilation` (feature/iceberg-data-management), which currently fails its GraphQL assertion on exactly this 403; this PR is the upstream fix that unblocks it.

Draft until a maintainer confirms the secret name / chain ordering convention and the image-bundle approach for the `aws` extension.