### PR TITLE
feat: DuckDB S3 credential-chain support for IRSA-backed Iceberg reads

### DIFF
--- a/Dockerfile.duckdb-extensions
+++ b/Dockerfile.duckdb-extensions
@@ -11,7 +11,7 @@ RUN set -eux; \
     duckdb_cli_version="$(printf '%s' "${duckdb_jdbc_version}" | cut -d. -f1-3)"; \
     export DUCKDB_VERSION="${duckdb_cli_version}"; \
     curl https://install.duckdb.org | sh; \
-    /root/.duckdb/cli/${duckdb_cli_version}/duckdb -c "INSTALL iceberg; INSTALL httpfs; INSTALL cache_httpfs FROM community;"; \
+    /root/.duckdb/cli/${duckdb_cli_version}/duckdb -c "INSTALL iceberg; INSTALL httpfs; INSTALL aws; INSTALL cache_httpfs FROM community;"; \
     mkdir -p "${DUCKDB_EXTENSIONS_DIR}"; \
     cp -a /root/.duckdb/extensions/. "${DUCKDB_EXTENSIONS_DIR}/"; \
     rm -rf /root/.duckdb

--- a/documentation/docs/configuration-engine/duckdb.md
+++ b/documentation/docs/configuration-engine/duckdb.md
@@ -10,6 +10,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 | `memory-limit`         | **string**  | -                | Sets DuckDB's `memory_limit`, for example `"8GB"`                              |
 | `use-disk-cache`       | **boolean** | `false`          | Install and load `cache_httpfs` extension                                      |
 | `use-version-guessing` | **boolean** | `false`          | Sets `unsafe_enable_version_guessing` flag to be able to read uncommitted data |
+| `use-credential-chain` | **boolean** | `false`          | Load the `aws` extension and create an S3 secret backed by the AWS credential provider chain |
 
 ## Example Configuration
 
@@ -31,6 +32,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 - Ideal for local development and testing of analytical workloads
 - Excellent performance on analytical queries with vectorized execution
 - Can read Iceberg tables directly without additional infrastructure
+- Enable `use-credential-chain` when reading S3-backed Iceberg from an environment that supplies credentials through the AWS provider chain rather than static keys — e.g. EKS IRSA, where the pod only has a projected web-identity token. Plain `httpfs` does not perform the web-identity exchange, so without this flag S3 reads fail with `HTTP 403`.
 - Supports both in-memory and persistent database modes
 - Perfect for prototyping before deploying to cloud query engines like Snowflake
 - Lightweight alternative to larger analytical databases

--- a/documentation/docs/configuration-engine/duckdb.md
+++ b/documentation/docs/configuration-engine/duckdb.md
@@ -10,7 +10,7 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 | `memory-limit`         | **string**  | -                | Sets DuckDB's `memory_limit`, for example `"8GB"`                              |
 | `use-disk-cache`       | **boolean** | `false`          | Install and load `cache_httpfs` extension                                      |
 | `use-version-guessing` | **boolean** | `false`          | Sets `unsafe_enable_version_guessing` flag to be able to read uncommitted data |
-| `use-credential-chain` | **boolean** | `false`          | Load the `aws` extension and create an S3 secret backed by the AWS credential provider chain |
+| `use-credential-chain` | **boolean** | `false`          | Load the `aws` extension and create an S3 secret backed by the AWS credential provider chain. Credentials are **not refreshed** — see below |
 
 ## Example Configuration
 
@@ -36,3 +36,17 @@ DuckDB is a vectorized database query engine that excels at analytical queries a
 - Supports both in-memory and persistent database modes
 - Perfect for prototyping before deploying to cloud query engines like Snowflake
 - Lightweight alternative to larger analytical databases
+
+### Credential refresh is not supported
+
+The S3 secret is created by the connection init SQL, so credentials are resolved once when a DuckDB
+connection is opened and are **never refreshed for the life of that connection**. Provider-chain
+credentials are usually temporary — an IRSA web-identity session typically lasts an hour — so a
+long-running server can start failing S3 reads with `HTTP 403` once they expire, and keep failing
+until the pool opens a new physical connection and re-runs the init SQL.
+
+This cannot be fixed from SQRL alone: DuckDB's `httpfs` does not refresh credentials at every call
+site that needs them ([duckdb/duckdb-httpfs#165](https://github.com/duckdb/duckdb-httpfs/pull/165),
+still unmerged). Until that lands, treat `use-credential-chain` as suitable for short-lived queries
+and for workloads that tolerate connection recycling, and expect failures wherever a single
+connection must serve reads for longer than the credential lifetime.

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -203,6 +203,9 @@
             },
             "use-version-guessing": {
               "type": "boolean"
+            },
+            "use-credential-chain": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false,

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/JdbcConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/JdbcConfig.java
@@ -48,5 +48,8 @@ public class JdbcConfig {
 
     @JsonProperty("memory-limit")
     private String memoryLimit;
+
+    @JsonProperty("use-credential-chain")
+    private boolean useCredentialChain;
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbInitializer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/util/DuckDbInitializer.java
@@ -18,6 +18,7 @@ package com.datasqrl.util;
 import static com.datasqrl.env.EnvVariableNames.DUCKDB_EXTENSIONS_DIR;
 
 import com.datasqrl.server.config.JdbcConfig;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.RequiredArgsConstructor;
@@ -56,9 +57,24 @@ public final class DuckDbInitializer {
       return;
     }
 
+    buildInitSql(extensionDir);
+  }
+
+  @VisibleForTesting
+  String buildInitSql(String extensionDir) {
     joiner.add("SET extension_directory='" + extensionDir + "'");
     joiner.add("LOAD iceberg");
     joiner.add("LOAD httpfs");
+
+    if (config.isUseCredentialChain()) {
+      // Let DuckDB use the AWS SDK default credential provider chain, which includes the
+      // web-identity provider that backs EKS IRSA. The default chain is required here: an explicit
+      // CHAIN containing 'sts' is rejected unless an ASSUME_ROLE_ARN is also supplied, since DuckDB
+      // maps 'sts' to AssumeRole, not to the web-identity token flow.
+      joiner.add("LOAD aws");
+      joiner.add(
+          "CREATE OR REPLACE SECRET sqrl_s3_credential_chain (TYPE S3, PROVIDER credential_chain)");
+    }
 
     if (config.isUseDiskCache()) {
       joiner.add("LOAD cache_httpfs");
@@ -67,5 +83,7 @@ public final class DuckDbInitializer {
     if (config.isUseVersionGuessing()) {
       joiner.add("SET unsafe_enable_version_guessing = true");
     }
+
+    return joiner.toString();
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/util/DuckDbInitializerTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/util/DuckDbInitializerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datasqrl.server.config.JdbcConfig;
+import org.junit.jupiter.api.Test;
+
+class DuckDbInitializerTest {
+
+  private static final String EXTENSION_DIR = "/opt/duckdb_extensions";
+
+  @Test
+  void givenDefaultConfig_whenBuildInitSql_thenLoadsCoreExtensionsOnly() {
+    var sql = new DuckDbInitializer(new JdbcConfig.DuckDbConfig()).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .isEqualTo("SET extension_directory='" + EXTENSION_DIR + "';LOAD iceberg;LOAD httpfs;");
+    assertThat(sql).doesNotContain("LOAD aws").doesNotContain("CREATE OR REPLACE SECRET");
+  }
+
+  @Test
+  void givenCredentialChainEnabled_whenBuildInitSql_thenLoadsAwsAndCreatesS3Secret() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+
+    var sql = new DuckDbInitializer(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .contains("LOAD aws;")
+        .contains(
+            "CREATE OR REPLACE SECRET sqrl_s3_credential_chain (TYPE S3, PROVIDER credential_chain);");
+    assertThat(sql)
+        .as(
+            "must use the default chain; an explicit CHAIN with 'sts' is rejected without ASSUME_ROLE_ARN")
+        .doesNotContain("CHAIN '");
+  }
+
+  @Test
+  void givenCredentialChainEnabled_whenBuildInitSql_thenLoadsAwsAfterHttpfsAndBeforeSecret() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+
+    var sql = new DuckDbInitializer(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql.indexOf("LOAD httpfs"))
+        .isLessThan(sql.indexOf("LOAD aws"))
+        .isGreaterThanOrEqualTo(0);
+    assertThat(sql.indexOf("LOAD aws")).isLessThan(sql.indexOf("CREATE OR REPLACE SECRET"));
+  }
+
+  @Test
+  void givenAllFlagsEnabled_whenBuildInitSql_thenAppliesEveryStatement() {
+    var config = new JdbcConfig.DuckDbConfig();
+    config.setUseCredentialChain(true);
+    config.setUseDiskCache(true);
+    config.setUseVersionGuessing(true);
+
+    var sql = new DuckDbInitializer(config).buildInitSql(EXTENSION_DIR);
+
+    assertThat(sql)
+        .contains("LOAD aws;")
+        .contains("LOAD cache_httpfs;")
+        .contains("SET unsafe_enable_version_guessing = true;");
+  }
+}


### PR DESCRIPTION
Reopens/supersedes #2096 (that PR's branch was deleted so it can't be reopened in place).

## Problem

When the Vert.x server reads an S3-backed Iceberg table through the **DuckDB** engine from an in-cluster pod (EKS **IRSA**), the query fails with `HTTP 403 Forbidden / AccessDenied — No credentials are provided`.

DuckDB's `httpfs` only auto-detects **env-var** credentials (`AWS_ACCESS_KEY_ID`/`SECRET`/`SESSION_TOKEN`) or an explicit credential secret. It does **not** use the projected web-identity token that backs IRSA, so on an IRSA-only pod it sends an **anonymous** request → 403. (Flink writes succeed because Flink's S3 layer does the web-identity exchange.)

This was proven directly inside a running server pod: anonymous `iceberg_scan('s3://…')` → `403 No credentials`; after adding the credential-chain secret below, the same read returned **1,810,576 rows**.

## Change

Opt-in `use-credential-chain` flag on the DuckDB engine. When enabled, the connection init SQL adds:

```sql
LOAD aws;
CREATE OR REPLACE SECRET sqrl_s3_credential_chain (TYPE S3, PROVIDER credential_chain);
```

`PROVIDER credential_chain` (with **no explicit `CHAIN`**) delegates to the AWS SDK default provider chain, which includes the web-identity provider used by IRSA — so DuckDB obtains temporary creds from the projected service-account token, exactly like Flink.

> Note: an explicit `CHAIN 'env;config;sts;…'` does **not** work — DuckDB maps `sts` to AssumeRole and rejects it without an `ASSUME_ROLE_ARN`. The default chain is required. (This is the correction vs the original #2096.)

The flag defaults to `false`, preserving today's behavior.

## Files

- `DuckDbExtensions.java` — emit `LOAD aws` + default-chain `CREATE SECRET` when the flag is set; `@VisibleForTesting buildInitSql(extensionDir)` overload for unit testing.
- `JdbcConfig.DuckDbConfig` — new `use-credential-chain` boolean.
- `packageSchema.json` — register the new key.
- `Dockerfile.duckdb-extensions` — `INSTALL aws` so the extension is bundled (the `credential_chain` provider requires it; confirmed it is not bundled today).
- `documentation/docs/configuration-engine/duckdb.md` — document the flag + IRSA rationale.
- `DuckDbExtensionsTest.java` — covers default vs credential-chain init SQL, ordering, all-flags, and that no explicit `CHAIN` is emitted.

## Validation

- `DuckDbExtensionsTest` — 4 tests green (JDK 17).
- The `credential_chain` secret was validated live in a server pod (IRSA-only): private-bucket `iceberg_scan` returned 1.8M rows with the secret, 403 without it.
- Downstream: `IcebergDeploymentIT` in cloud-compilation has the full datagen→Iceberg(Glue/S3FileIO/`s3://`)→Flink-write path green; this PR closes the read-side gap. Setting `use-credential-chain: true` on the duckdb engine turns that IT's GraphQL read green.

Draft until a maintainer confirms the secret name + bundling the `aws` extension.