### PR TITLE
docs: Centralize cloud deployment configs

### DIFF
--- a/documentation/docs/configuration-engine/flink.md
+++ b/documentation/docs/configuration-engine/flink.md
@@ -34,52 +34,6 @@ Refer to the [Flink Documentation](hhttps://nightlies.apache.org/flink/flink-doc
 }
 ```
 
-## Deployment Configuration
+## Cloud Deployment
 
-Flink supports deployment-specific configuration options for managing cluster resources:
-
-| Key                 | Type        | Default | Description                                                     |
-|---------------------|-------------|---------|-----------------------------------------------------------------|
-| `jobmanager-size`   | **string**  | -       | Job manager instance size: `dev`, `small`, `medium`, `large`    |
-| `taskmanager-size`  | **string**  | -       | Task manager instance size with resource variants               |
-| `taskmanager-count` | **integer** | -       | Number of task manager instances (minimum: 1)                   |
-| `secrets`           | **array**   | `null`  | Array of secret names to inject, or `null` if no secrets needed |
-| `schedule`          | **object**  | -       | Schedule for periodic awakening of the Flink job                |
-
-### Task Manager Size Options
-
-Available `taskmanager-size` options with resource variants:
-- `dev` - Development/testing size
-- `small`, `small.mem`, `small.cpu` - Small instances with memory or CPU optimization
-- `medium`, `medium.mem`, `medium.cpu` - Medium instances with resource variants  
-- `large`, `large.mem`, `large.cpu` - Large instances with resource variants
-
-### Schedule Configuration
-
-The `schedule` object configures periodic awakening of the Flink job. Both `cron` and `timezone` are required when a schedule is configured.
-
-| Key        | Type       | Required | Description                                                        |
-|------------|------------|----------|--------------------------------------------------------------------|
-| `cron`     | **string** | Yes      | Cron expression defining the schedule (e.g. `"0 0 * * *"`)        |
-| `timezone` | **string** | Yes      | IANA timezone for the cron expression (e.g. `"America/New_York"`) |
-
-### Deployment Example
-
-```json
-{
-  "engines": {
-    "flink": {
-      "deployment": {
-        "jobmanager-size": "small",
-        "taskmanager-size": "medium.mem",
-        "taskmanager-count": 2,
-        "secrets": ["flink-secrets", "db-credentials"],
-        "schedule": {
-          "cron": "0 */6 * * *",
-          "timezone": "UTC"
-        }
-      }
-    }
-  }
-}
-```
+For cloud deployment configuration (instance sizes, task manager counts, scheduling), see [Cloud Deployment Configuration](cloud-deployment.md#flink-enginesflinkdeployment).

--- a/documentation/docs/configuration-engine/postgres.md
+++ b/documentation/docs/configuration-engine/postgres.md
@@ -20,38 +20,9 @@ No mandatory configuration keys are required. Physical DDL (tables, indexes, vie
 }
 ```
 
-## Deployment Configuration
+## Cloud Deployment
 
-PostgreSQL supports deployment-specific configuration for database scaling and high availability:
-
-| Key             | Type        | Default | Description                                          |
-|-----------------|-------------|---------|------------------------------------------------------|
-| `instance-size` | **string**  | -       | Database instance size for compute and memory        |
-| `replica-count` | **integer** | -       | Number of read replicas (minimum: 0, maximum varies) |
-
-### Instance Size Options
-
-Available `instance-size` options:
-- `dev` - Development/testing size with minimal resources
-- `small` - Small production workloads
-- `medium` - Medium production workloads  
-- `large` - Large production workloads
-- `xlarge` - Extra large production workloads
-
-### Deployment Example
-
-```json
-{
-  "engines": {
-    "postgres": {
-      "deployment": {
-        "instance-size": "large",
-        "replica-count": 2
-      }
-    }
-  }
-}
-```
+For cloud deployment configuration (instance sizes, replica counts), see [Cloud Deployment Configuration](cloud-deployment.md#postgresql-enginespostgresdeployment).
 
 ## Conflict Handling
 

--- a/documentation/docs/configuration-engine/vertx.md
+++ b/documentation/docs/configuration-engine/vertx.md
@@ -257,34 +257,6 @@ The `audience` field is **required** for Auth0 client credentials requests. With
 - **JWKS endpoint** — Auth0 publishes signing keys at `https://<tenant>.auth0.com/.well-known/jwks.json`. The server fetches these automatically from the OIDC discovery document (`/.well-known/openid-configuration`) and rotates them without restart.
 - **Custom domains** — If your Auth0 tenant uses a custom domain (e.g. `https://auth.example.com/`), use that URL as both `site` and `authorizationServerUrl`.
 
-## Deployment Configuration
+## Cloud Deployment
 
-Vert.x supports deployment-specific configuration options for scaling the API server:
-
-| Key              | Type        | Default | Description                                    |
-|------------------|-------------|---------|------------------------------------------------|
-| `instance-size`  | **string**  | -       | Server instance size with storage variants     |
-| `instance-count` | **integer** | -       | Number of server instances to run (minimum: 1) |
-
-### Instance Size Options
-
-Available `instance-size` options with storage variants:
-- `dev` - Development/testing size
-- `small`, `small.disk` - Small instances with optional additional disk
-- `medium`, `medium.disk` - Medium instances with optional additional disk
-- `large`, `large.disk` - Large instances with optional additional disk
-
-### Deployment Example
-
-```json
-{
-  "engines": {
-    "vertx": {
-      "deployment": {
-        "instance-size": "medium.disk",
-        "instance-count": 3
-      }
-    }
-  }
-}
-```
+For cloud deployment configuration (instance sizes, instance counts), see [Cloud Deployment Configuration](cloud-deployment.md#vertx-enginesvertxdeployment).


### PR DESCRIPTION
so we don't have two sources that get misaligned over time.