### PR TITLE
feat: Introduce `test(no_rows)` to skip snapshot generation for empty test queries

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
@@ -23,7 +23,6 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import com.datasqrl.cli.output.OutputFormatter;
 import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.compile.TestPlan;
-import com.datasqrl.compile.TestPlan.GraphqlQuery.TestType;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import com.datasqrl.graphql.SqrlObjectMapper;
@@ -54,11 +53,11 @@ import lombok.SneakyThrows;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.types.Either;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.flink.types.Either;
 
 /**
  * The test runner executes the test against the running DataSQRL pipeline and snapshots the
@@ -439,12 +438,12 @@ public class DatasqrlTest {
       List<TestResult> testResults) {
 
     var name = test.isLeft() ? test.left().getName() : test.right();
-    var testType = test.isLeft() ? test.left().getTestType() : null;
+    var snapshot = !test.isLeft() || test.left().isSnapshot();
 
     var snapshotPath = snapshotDir.resolve(name + SNAPSHOT_EXT);
     var content = format(rawJson);
 
-    if (testType == TestType.NO_ROWS) {
+    if (!snapshot) {
       var res = getNoRowsResult(content, name);
       testResults.add(res);
 

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlTest.java
@@ -23,6 +23,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import com.datasqrl.cli.output.OutputFormatter;
 import com.datasqrl.cli.output.TestOutputManager;
 import com.datasqrl.compile.TestPlan;
+import com.datasqrl.compile.TestPlan.GraphqlQuery.TestType;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import com.datasqrl.graphql.SqrlObjectMapper;
@@ -57,6 +58,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.flink.types.Either;
 
 /**
  * The test runner executes the test against the running DataSQRL pipeline and snapshots the
@@ -269,7 +271,7 @@ public class DatasqrlTest {
               .sorted()
               .collect(Collectors.joining(",", "[", "]"));
 
-      snapshot(snapshotDir, client.getName(), data, testResults);
+      snapshot(Either.Right(client.getName()), snapshotDir, data, testResults);
     }
 
     var expectedSnapshots =
@@ -378,7 +380,7 @@ public class DatasqrlTest {
       var data = executeQuery(query);
 
       // Snapshot result
-      snapshot(snapshotDir, query.getName(), data, testResults);
+      snapshot(Either.Left(query), snapshotDir, data, testResults);
 
       // Wait before next mutation
       if (mutationWait > 0) {
@@ -431,10 +433,23 @@ public class DatasqrlTest {
 
   @SneakyThrows
   private void snapshot(
-      Path snapshotDir, String name, String rawJson, List<TestResult> testResults) {
+      Either<TestPlan.GraphqlQuery, String> test,
+      Path snapshotDir,
+      String rawJson,
+      List<TestResult> testResults) {
+
+    var name = test.isLeft() ? test.left().getName() : test.right();
+    var testType = test.isLeft() ? test.left().getTestType() : null;
 
     var snapshotPath = snapshotDir.resolve(name + SNAPSHOT_EXT);
     var content = format(rawJson);
+
+    if (testType == TestType.NO_ROWS) {
+      var res = getNoRowsResult(content, name);
+      testResults.add(res);
+
+      return;
+    }
 
     // Existing snapshot logic
     if (Files.exists(snapshotPath)) {
@@ -453,7 +468,19 @@ public class DatasqrlTest {
     }
   }
 
-  @SneakyThrows
+  private TestResult getNoRowsResult(String rawData, String name) {
+    try {
+      var root = SqrlObjectMapper.MAPPER.readTree(rawData);
+      var data = root.get("data");
+      if (data.hasNonNull(name) && data.get(name).isEmpty()) {
+        return new TestResult.SnapshotOk(name);
+      }
+    } catch (JsonProcessingException ignored) {
+    }
+
+    return new TestResult.NoSnapshotExpected(name, rawData);
+  }
+
   private String format(String rawData) {
     try {
       var data = SqrlObjectMapper.MAPPER.readValue(rawData, Object.class);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/TestResult.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/TestResult.java
@@ -145,6 +145,31 @@ public abstract class TestResult {
     }
   }
 
+  public static class NoSnapshotExpected extends NamedResult {
+
+    private final String failureContent;
+
+    public NoSnapshotExpected(String testName, String failureContent) {
+      super(testName);
+      this.failureContent = failureContent;
+    }
+
+    @Override
+    public boolean isSuccess() {
+      return false;
+    }
+
+    @Override
+    public int exitCode() {
+      return 1;
+    }
+
+    @Override
+    public void printDetails(OutputFormatter formatter, Optional<Path> testDir) {
+      formatter.failureDetails(getTestName(), failureContent);
+    }
+  }
+
   public static class Failure extends TestResult {
 
     private final String msg;

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/DefaultOutputFormatter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/DefaultOutputFormatter.java
@@ -140,6 +140,15 @@ public class DefaultOutputFormatter implements OutputFormatter {
   }
 
   @Override
+  public void failureDetails(String testName, String failureContent) {
+    out.println("  " + colors.bold() + testName + colors.reset());
+    out.println("  " + "-".repeat(testName.length()));
+    newline();
+    out.println(failureContent);
+    newline();
+  }
+
+  @Override
   public void failureDetails(
       String testName, String testFile, String expectedFile, String actualFile) {
     out.println("  " + colors.bold() + testName + colors.reset());

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/NoOutputFormatter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/NoOutputFormatter.java
@@ -62,6 +62,9 @@ public class NoOutputFormatter implements OutputFormatter {
   public void testSummary(int totalTests, int failures) {}
 
   @Override
+  public void failureDetails(String testName, String failureContent) {}
+
+  @Override
   public void failureDetails(
       String testName, String testFile, String expectedFile, String actualFile) {}
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/output/OutputFormatter.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/output/OutputFormatter.java
@@ -48,6 +48,8 @@ public interface OutputFormatter {
 
   void testSummary(int totalTests, int failures);
 
+  void failureDetails(String testName, String failureContent);
+
   void failureDetails(String testName, String testFile, String expectedFile, String actualFile);
 
   default Path relativizeFromCliRoot(Path path) {

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -104,7 +104,7 @@ public class CompilationProcess {
 
       // create test artifact
       if (executionGoal == ExecutionGoal.TEST) {
-        var gqlGenerator = new GqlGenerator(serverPlanOpt.get().getFunctions());
+        var gqlGenerator = new GqlGenerator(serverPlan.getFunctions());
         var jdbcViews =
             physicalPlan
                 .getPlans(JdbcPhysicalPlan.class)

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/GqlGenerator.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/GqlGenerator.java
@@ -17,7 +17,6 @@ package com.datasqrl.compile;
 
 import static com.datasqrl.planner.util.SqrTableFunctionUtil.getTableFunctionFromPath;
 
-import com.datasqrl.canonicalizer.NamePath;
 import com.datasqrl.graphql.visitor.GraphqlSchemaVisitor;
 import com.datasqrl.planner.tables.SqrlTableFunction;
 import graphql.language.Argument;
@@ -42,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -50,7 +50,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 @RequiredArgsConstructor
 class GqlGenerator extends GraphqlSchemaVisitor {
 
-  private final List<SqrlTableFunction> tableFunctions;
+  @Getter private final List<SqrlTableFunction> tableFunctions;
 
   @Override
   public List<Node> visitDocument(Document node, Object context) {
@@ -62,7 +62,7 @@ class GqlGenerator extends GraphqlSchemaVisitor {
         .map(definition -> (ObjectTypeDefinition) definition)
         .filter(definition -> definition.getName().equals("Query"))
         .flatMap(q -> processQueryDefinition(q, node).stream())
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Override
@@ -72,16 +72,16 @@ class GqlGenerator extends GraphqlSchemaVisitor {
 
   private List<Node> processQueryDefinition(ObjectTypeDefinition definition, Document document) {
     List<Node> queries = new ArrayList<>();
-    for (FieldDefinition def : definition.getFieldDefinitions()) {
-      final var tableFunction =
-          getTableFunctionFromPath(tableFunctions, NamePath.of(def.getName())).get();
-      if (tableFunction.getVisibility().isTest()) {
+    var defs = definition.getFieldDefinitions();
+    for (FieldDefinition def : defs) {
+      final var tableFn = getTableFunctionFromPath(tableFunctions, def.getName()).get();
+      if (tableFn.getVisibility().isTest()) {
         var operation =
             processOperation(
                 def.getName(),
                 (ObjectTypeDefinition) unbox(def.getType(), document).get(),
                 def.getInputValueDefinitions(),
-                tableFunction.getRowType(),
+                tableFn.getRowType(),
                 document);
         queries.add(operation);
       }

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlan.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlan.java
@@ -18,7 +18,6 @@ package com.datasqrl.compile;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,15 +37,10 @@ public class TestPlan {
   @Getter
   public static class GraphqlQuery {
 
-    public enum TestType {
-      REGULAR,
-      NO_ROWS
-    }
-
     String version;
     String name;
     String query;
-    @Nullable TestType testType;
+    boolean snapshot;
     Map<String, String> headers;
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlan.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlan.java
@@ -18,6 +18,7 @@ package com.datasqrl.compile;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,9 +37,16 @@ public class TestPlan {
   @NoArgsConstructor
   @Getter
   public static class GraphqlQuery {
+
+    public enum TestType {
+      REGULAR,
+      NO_ROWS
+    }
+
     String version;
     String name;
     String query;
+    @Nullable TestType testType;
     Map<String, String> headers;
   }
 }

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlanner.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlanner.java
@@ -18,7 +18,6 @@ package com.datasqrl.compile;
 import static com.datasqrl.planner.util.SqrTableFunctionUtil.getTableFunctionFromPath;
 
 import com.datasqrl.compile.TestPlan.GraphqlQuery;
-import com.datasqrl.compile.TestPlan.GraphqlQuery.TestType;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import com.datasqrl.graphql.ApiSources;
@@ -101,7 +100,7 @@ public class TestPlanner {
                 api.version(),
                 definition.getName(),
                 AstPrinter.printAst(definition),
-                extractTestType(definition.getName()),
+                shouldSnapshot(definition.getName()),
                 baseHeaders));
       }
     }
@@ -113,11 +112,11 @@ public class TestPlanner {
         List.copyOf(subscriptions));
   }
 
-  private TestType extractTestType(String name) {
+  private boolean shouldSnapshot(String name) {
     return getTableFunctionFromPath(gqlGenerator.getTableFunctions(), name)
         .map(tableFn1 -> tableFn1.getFunctionAnalysis().getHints())
-        .map(hints -> hints.isNoRowsTest() ? TestType.NO_ROWS : TestType.REGULAR)
-        .orElse(null);
+        .map(hints -> !hints.isNoRowsTest())
+        .orElse(true);
   }
 
   @SneakyThrows
@@ -172,7 +171,7 @@ public class TestPlanner {
                 version,
                 prefix,
                 AstPrinter.printAst(operationDefinition),
-                extractTestType(prefix),
+                shouldSnapshot(prefix),
                 headers);
         switch (operationDefinition.getOperation()) {
           case QUERY:

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlanner.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/TestPlanner.java
@@ -15,7 +15,10 @@
  */
 package com.datasqrl.compile;
 
+import static com.datasqrl.planner.util.SqrTableFunctionUtil.getTableFunctionFromPath;
+
 import com.datasqrl.compile.TestPlan.GraphqlQuery;
+import com.datasqrl.compile.TestPlan.GraphqlQuery.TestType;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.engine.database.relational.JdbcStatement;
 import com.datasqrl.graphql.ApiSources;
@@ -23,7 +26,6 @@ import com.datasqrl.util.FileUtil;
 import graphql.language.AstPrinter;
 import graphql.language.Definition;
 import graphql.language.Document;
-import graphql.language.Node;
 import graphql.language.OperationDefinition;
 import graphql.parser.Parser;
 import java.io.IOException;
@@ -92,13 +94,14 @@ public class TestPlanner {
 
       var document = parser.parseDocument(api.schema().getDefinition());
       var queryNodes = gqlGenerator.visitDocument(document, null);
-      for (Node<?> definition : queryNodes) {
-        var definition1 = (OperationDefinition) definition;
+      for (var node : queryNodes) {
+        var definition = (OperationDefinition) node;
         queries.add(
             new GraphqlQuery(
                 api.version(),
-                definition1.getName(),
-                AstPrinter.printAst(definition1),
+                definition.getName(),
+                AstPrinter.printAst(definition),
+                extractTestType(definition.getName()),
                 baseHeaders));
       }
     }
@@ -108,6 +111,13 @@ public class TestPlanner {
         List.copyOf(queries),
         List.copyOf(mutations),
         List.copyOf(subscriptions));
+  }
+
+  private TestType extractTestType(String name) {
+    return getTableFunctionFromPath(gqlGenerator.getTableFunctions(), name)
+        .map(tableFn1 -> tableFn1.getFunctionAnalysis().getHints())
+        .map(hints -> hints.isNoRowsTest() ? TestType.NO_ROWS : TestType.REGULAR)
+        .orElse(null);
   }
 
   @SneakyThrows
@@ -158,7 +168,12 @@ public class TestPlanner {
     for (Definition<?> definition : document.getDefinitions()) {
       if (definition instanceof OperationDefinition operationDefinition) {
         var query =
-            new GraphqlQuery(version, prefix, AstPrinter.printAst(operationDefinition), headers);
+            new GraphqlQuery(
+                version,
+                prefix,
+                AstPrinter.printAst(operationDefinition),
+                extractTestType(prefix),
+                headers);
         switch (operationDefinition.getOperation()) {
           case QUERY:
             queries.add(query);

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -309,7 +309,7 @@ public class SqlScriptPlanner {
     Optional<String> documentation = Optional.empty();
     if (stmt instanceof SqrlStatement statement) {
       var comments = statement.getComments();
-      hints = PlannerHints.fromHints(comments, errors);
+      hints = PlannerHints.from(comments, errors);
       if (!comments.documentation().isEmpty()) {
         documentation =
             Optional.of(

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/hint/PlannerHints.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/hint/PlannerHints.java
@@ -23,33 +23,49 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import lombok.Value;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.calcite.rel.type.RelDataTypeField;
 
-@Value
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PlannerHints {
 
   public static final PlannerHints EMPTY = new PlannerHints(List.of());
 
-  List<PlannerHint> hints;
+  private final List<PlannerHint> hints;
+
+  public static PlannerHints from(SqrlComments comments, ErrorCollector errors) {
+    var hints =
+        comments.hints().stream()
+            .map(c -> PlannerHint.from(c, errors))
+            .flatMap(Optional::stream)
+            .toList();
+
+    return new PlannerHints(hints);
+  }
 
   public Optional<ColumnNamesHint> getQueryByHint() {
-    List<PlannerHint> queryby = hints.stream().filter(QueryByHint.class::isInstance).toList();
-    if (queryby.size() > 1) {
+    var queryBy = hints.stream().filter(QueryByHint.class::isInstance).toList();
+    if (queryBy.size() > 1) {
       throw new StatementParserException(
           ErrorLabel.GENERIC,
-          queryby.get(1).getSource().getFileLocation(),
+          queryBy.get(1).getSource().getFileLocation(),
           "Cannot have more than one `query_by_*` or `no_query` hint per table");
     }
-    return queryby.stream().map(ColumnNamesHint.class::cast).findFirst();
+
+    return queryBy.stream().map(ColumnNamesHint.class::cast).findFirst();
   }
 
   public boolean isTest() {
-    return hints.stream().anyMatch(TestHint.class::isInstance);
+    return getHint(TestHint.class).isPresent();
+  }
+
+  public boolean isNoRowsTest() {
+    return getHint(TestHint.class).map(TestHint::isNoRows).orElse(false);
   }
 
   public boolean isWorkload() {
-    return hints.stream().anyMatch(WorkloadHint.class::isInstance);
+    return getHint(WorkloadHint.class).isPresent();
   }
 
   public <H> Optional<H> getHint(Class<H> hintClass) {
@@ -62,15 +78,5 @@ public class PlannerHints {
 
   public void updateColumnNamesHints(Function<String, RelDataTypeField> fieldByIndex) {
     getHints(ColumnNamesHint.class).forEach(hint -> hint.validateAndUpdate(fieldByIndex));
-  }
-
-  public static PlannerHints fromHints(SqrlComments comments, ErrorCollector errors) {
-    var hints =
-        comments.hints().stream()
-            .map(c -> PlannerHint.from(c, errors))
-            .flatMap(Optional::stream)
-            .toList();
-
-    return new PlannerHints(hints);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/hint/TestHint.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/hint/TestHint.java
@@ -15,9 +15,12 @@
  */
 package com.datasqrl.planner.hint;
 
+import com.datasqrl.error.ErrorLabel;
 import com.datasqrl.planner.parser.ParsedObject;
 import com.datasqrl.planner.parser.SqrlHint;
+import com.datasqrl.planner.parser.StatementParserException;
 import com.google.auto.service.AutoService;
+import lombok.Getter;
 
 /**
  * Defines a table to be a test case which means it will only be planned when the user runs test
@@ -27,8 +30,11 @@ public class TestHint extends PlannerHint {
 
   public static final String HINT_NAME = "test";
 
-  protected TestHint(ParsedObject<SqrlHint> source) {
+  @Getter private final boolean noRows;
+
+  protected TestHint(ParsedObject<SqrlHint> source, boolean noRows) {
     super(source, Type.DAG);
+    this.noRows = noRows;
   }
 
   @AutoService(Factory.class)
@@ -36,12 +42,29 @@ public class TestHint extends PlannerHint {
 
     @Override
     public PlannerHint create(ParsedObject<SqrlHint> source) {
-      return new TestHint(source);
+      return new TestHint(source, parseNoRows(source));
     }
 
     @Override
     public String getName() {
       return HINT_NAME;
+    }
+
+    private static boolean parseNoRows(ParsedObject<SqrlHint> source) {
+      var arguments = source.get().getOptions();
+      if (arguments == null || arguments.isEmpty()) {
+        return false;
+      }
+
+      if (arguments.size() != 1 || !"no_rows".equalsIgnoreCase(arguments.get(0))) {
+        throw new StatementParserException(
+            ErrorLabel.GENERIC,
+            source.getFileLocation(),
+            "%s hint only supports 'no_rows' as argument",
+            source.get().getName());
+      }
+
+      return true;
     }
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqrTableFunctionUtil.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqrTableFunctionUtil.java
@@ -19,16 +19,25 @@ import com.datasqrl.canonicalizer.NamePath;
 import com.datasqrl.planner.tables.SqrlTableFunction;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class SqrTableFunctionUtil {
+
+  public static Optional<SqrlTableFunction> getTableFunctionFromPath(
+      List<SqrlTableFunction> tableFunctions, String name) {
+
+    return getTableFunctionFromPath(tableFunctions, NamePath.of(name));
+  }
+
   public static Optional<SqrlTableFunction> getTableFunctionFromPath(
       List<SqrlTableFunction> tableFunctions, NamePath path) {
-    final List<SqrlTableFunction> tableFunctionsAtPath =
+
+    var tableFunctionsAtPath =
         tableFunctions.stream()
             .filter(tableFunction -> tableFunction.getFullPath().equals(path))
-            .collect(Collectors.toList());
-    assert (tableFunctionsAtPath.size() <= 1); // no overloading
+            .toList();
+
+    assert tableFunctionsAtPath.size() <= 1; // no overloading
+
     return tableFunctionsAtPath.isEmpty()
         ? Optional.empty()
         : Optional.of(tableFunctionsAtPath.get(0));

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/comprehensiveTest.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/comprehensiveTest.sqrl
@@ -67,6 +67,9 @@ CustomerTimeWindow := SELECT
 /*+ test */
 CustomerTimeWindowTest := SELECT * FROM CustomerTimeWindow ORDER BY window_end DESC;
 
+/*+ test(no_rows) */
+CustomerTimeWindowNoRowsTest := SELECT * FROM CustomerTimeWindow WHERE FALSE;
+
 /*+ workload */
 CustomerTimeWindowWorkload := SELECT * FROM CustomerTimeWindow ORDER BY window_end DESC;
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/flink-functions/flink-functions.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/flink-functions/flink-functions.sqrl
@@ -16,3 +16,6 @@ EXPORT FlinkFunctions TO print.functions;
 
 /*+test */
 FlinkFunctionsTest := SELECT name_upper, name_md5, formatted_name FROM FlinkFunctions ORDER BY name_upper ASC;
+
+/*+ test(no_rows) */
+NoRowsTest := SELECT * FROM FlinkFunctions WHERE FALSE;


### PR DESCRIPTION
## Key Changes
- Add `no_rows` arg to the `test` hint
- Add a `TestType` enum to every `GraphqlQuery` object in the test plan
- Fetch `TestType` from each test table based on the hnt value
- Add new snapshot result types print format for `no_rows` tests
- Evaluate `no_rows` tests in `DatasqrlTest` properly
- Introduced a `no_rows` test to an integration test case