### PR TITLE
feat: Add server GraphQL query metrics

### DIFF
--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/GraphQLServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/GraphQLServerVerticle.java
@@ -24,6 +24,7 @@ import com.datasqrl.server.exec.FlinkExecFunctionPlan;
 import com.datasqrl.server.exec.FlinkFunctionExecutor;
 import com.datasqrl.server.graphql.CustomScalars;
 import com.datasqrl.server.graphql.GraphQLEngineBuilder;
+import com.datasqrl.server.graphql.GraphQLQueryMetricsInstrumentation;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.jdbc.DatabaseType;
 import com.datasqrl.server.jdbc.JdbcClientsConfig;
@@ -32,6 +33,7 @@ import com.datasqrl.server.jdbc.VertxParamArgumentTypeMapper;
 import com.google.common.collect.ImmutableMap;
 import com.symbaloo.graphqlmicrometer.MicrometerInstrumentation;
 import graphql.GraphQL;
+import graphql.execution.instrumentation.ChainedInstrumentation;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
@@ -48,6 +50,8 @@ import io.vertx.sqlclient.SqlClient;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,7 +70,7 @@ public class GraphQLServerVerticle extends AbstractVerticle {
   private final List<AuthenticationProvider> authProviders;
   private final Optional<FlinkExecFunctionPlan> execFunctionPlan;
 
-  private GraphQL graphQLEngine;
+  @Getter @Nullable private GraphQL graphQLEngine;
 
   @Override
   public void start(Promise<Void> startPromise) {
@@ -169,15 +173,6 @@ public class GraphQLServerVerticle extends AbstractVerticle {
     }
   }
 
-  /**
-   * Returns the GraphQL engine instance for internal use by other verticles.
-   *
-   * @return the GraphQL engine, or null if not yet initialized
-   */
-  public GraphQL getGraphQLEngine() {
-    return this.graphQLEngine;
-  }
-
   public GraphQL createGraphQL(
       Map<DatabaseType, SqlClient> clients,
       SubscriptionConfigurationImpl subscriptionConfig,
@@ -185,6 +180,13 @@ public class GraphQLServerVerticle extends AbstractVerticle {
       FunctionExecutor functionExecutor) {
     try {
       var vertxJdbcClient = new VertxJdbcClient(clients);
+      var vertxServerCtx =
+          new VertxServerContext(
+              vertxJdbcClient,
+              metadataReaders,
+              functionExecutor,
+              new VertxParamArgumentTypeMapper());
+
       var graphQL =
           model.accept(
               new GraphQLEngineBuilder.Builder()
@@ -192,15 +194,17 @@ public class GraphQLServerVerticle extends AbstractVerticle {
                   .withSubscriptionConfiguration(subscriptionConfig)
                   .withExtendedScalarTypes(CustomScalars.getExtendedScalars())
                   .build(),
-              new VertxServerContext(
-                  vertxJdbcClient,
-                  metadataReaders,
-                  functionExecutor,
-                  new VertxParamArgumentTypeMapper()));
+              vertxServerCtx);
+
       var meterRegistry = BackendRegistries.getDefaultNow();
       if (meterRegistry != null) {
-        graphQL.instrumentation(new MicrometerInstrumentation(meterRegistry));
+        graphQL.instrumentation(
+            new ChainedInstrumentation(
+                List.of(
+                    new MicrometerInstrumentation(meterRegistry),
+                    new GraphQLQueryMetricsInstrumentation(meterRegistry, modelVersion, model))));
       }
+
       return graphQL.build();
     } catch (Exception e) {
       log.error("Unable to create GraphQL", e);

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentation.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.graphql;
+
+import static java.util.Objects.requireNonNull;
+
+import com.datasqrl.server.graphql.RootGraphQLModel.ArgumentLookupQueryCoords;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLNamedSchemaElement;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Records latency metrics for GraphQL queries generated in the server model. */
+public class GraphQLQueryMetricsInstrumentation extends SimplePerformantInstrumentation {
+
+  public static final String METRIC_NAME = "sqrl.graphql.query.duration";
+
+  private final Map<QueryKey, Timer> timers;
+
+  public GraphQLQueryMetricsInstrumentation(
+      MeterRegistry registry, String modelVersion, RootGraphQLModel model) {
+
+    this.timers =
+        model.getQueries().stream()
+            .filter(ArgumentLookupQueryCoords.class::isInstance)
+            .map(coords -> new QueryKey(coords.getParentType(), coords.getFieldName()))
+            .distinct()
+            .collect(
+                Collectors.toConcurrentMap(
+                    Function.identity(), key -> createTimer(registry, modelVersion, key)));
+  }
+
+  @Override
+  public DataFetcher<?> instrumentDataFetcher(
+      DataFetcher<?> dataFetcher,
+      InstrumentationFieldFetchParameters parameters,
+      InstrumentationState state) {
+
+    var environment = parameters.getEnvironment();
+    var parentType = environment.getParentType();
+    if (!(parentType instanceof GraphQLNamedSchemaElement namedParentType)) {
+      return dataFetcher;
+    }
+
+    var key = new QueryKey(namedParentType.getName(), environment.getFieldDefinition().getName());
+    var timer = timers.get(key);
+    if (timer == null) {
+      return dataFetcher;
+    }
+
+    return env -> {
+      var startNanos = System.nanoTime();
+      try {
+        var result = dataFetcher.get(env);
+        if (result instanceof CompletionStage<?> stage) {
+          return stage.whenComplete((value, error) -> record(timer, startNanos));
+        }
+
+        record(timer, startNanos);
+        return result;
+      } catch (Exception e) {
+        record(timer, startNanos);
+        throw e;
+      }
+    };
+  }
+
+  private static Timer createTimer(MeterRegistry registry, String modelVersion, QueryKey key) {
+    return Timer.builder(METRIC_NAME)
+        .description("GraphQL query execution duration")
+        .tag("version", modelVersion)
+        .tag("type", key.parentType())
+        .tag("name", key.fieldName())
+        .publishPercentiles(0.5, 0.99)
+        .register(registry);
+  }
+
+  private static void record(Timer timer, long startNanos) {
+    timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+  }
+
+  private record QueryKey(String parentType, String fieldName) {
+
+    private QueryKey {
+      requireNonNull(parentType, "parentType must not be null");
+      requireNonNull(fieldName, "fieldName must not be null");
+    }
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentationTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.server.graphql.RootGraphQLModel.ArgumentLookupQueryCoords;
+import com.datasqrl.server.graphql.RootGraphQLModel.FieldLookupQueryCoords;
+import graphql.Scalars;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+class GraphQLQueryMetricsInstrumentationTest {
+
+  @Test
+  void givenArgumentLookupQuery_whenDataFetcherCompletes_thenRecordsTimer() throws Exception {
+    var registry = new SimpleMeterRegistry();
+    var instrumentation = newInstrumentation(registry, argumentQuery("Query", "HighTempAlert"));
+    var params = parameters("Query", "HighTempAlert");
+    var environment = params.getEnvironment();
+
+    DataFetcher<?> fetcher = env -> "result";
+    var instrumented = instrumentation.instrumentDataFetcher(fetcher, params, null);
+
+    assertThat(instrumented.get(environment)).isEqualTo("result");
+
+    assertThat(timerCount(registry, "Query", "HighTempAlert")).isEqualTo(1);
+  }
+
+  @Test
+  void givenArgumentLookupQuery_whenAsyncDataFetcherCompletes_thenRecordsTimerAfterCompletion()
+      throws Exception {
+    var registry = new SimpleMeterRegistry();
+    var instrumentation = newInstrumentation(registry, argumentQuery("Query", "HighTempAlert"));
+    var params = parameters("Query", "HighTempAlert");
+    var environment = params.getEnvironment();
+    var future = new CompletableFuture<String>();
+
+    DataFetcher<?> fetcher = env -> future;
+    var instrumented = instrumentation.instrumentDataFetcher(fetcher, params, null);
+    var result = (CompletionStage<?>) instrumented.get(environment);
+
+    assertThat(timerCount(registry, "Query", "HighTempAlert")).isZero();
+
+    future.complete("result");
+    assertThat(result.toCompletableFuture().get()).isEqualTo("result");
+    assertThat(timerCount(registry, "Query", "HighTempAlert")).isEqualTo(1);
+  }
+
+  @Test
+  void givenArgumentLookupQuery_whenDataFetcherFails_thenRecordsTimer() {
+    var registry = new SimpleMeterRegistry();
+    var instrumentation = newInstrumentation(registry, argumentQuery("Query", "HighTempAlert"));
+    var params = parameters("Query", "HighTempAlert");
+    var environment = params.getEnvironment();
+
+    DataFetcher<?> fetcher =
+        env -> {
+          throw new IllegalStateException("boom");
+        };
+    var instrumented = instrumentation.instrumentDataFetcher(fetcher, params, null);
+
+    assertThatThrownBy(() -> instrumented.get(environment))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(timerCount(registry, "Query", "HighTempAlert")).isEqualTo(1);
+  }
+
+  @Test
+  void givenFieldLookupQuery_whenInstrumentationCreated_thenDoesNotRegisterTimer() {
+    var registry = new SimpleMeterRegistry();
+    var fieldLookupQuery =
+        FieldLookupQueryCoords.builder()
+            .parentType("SensorReading")
+            .fieldName("eventTime")
+            .columnName("event_time")
+            .build();
+
+    newInstrumentation(registry, fieldLookupQuery);
+
+    assertThat(
+            registry
+                .find(GraphQLQueryMetricsInstrumentation.METRIC_NAME)
+                .tag("version", "v1")
+                .tag("type", "SensorReading")
+                .tag("name", "eventTime")
+                .timer())
+        .isNull();
+  }
+
+  @Test
+  void givenUnregisteredField_whenDataFetcherInstrumented_thenReturnsOriginalFetcher() {
+    var registry = new SimpleMeterRegistry();
+    var instrumentation = newInstrumentation(registry, argumentQuery("Query", "HighTempAlert"));
+    var params = parameters("Query", "SensorReading");
+
+    DataFetcher<?> fetcher = env -> "result";
+    var instrumented = instrumentation.instrumentDataFetcher(fetcher, params, null);
+
+    assertThat(instrumented).isSameAs(fetcher);
+  }
+
+  private static GraphQLQueryMetricsInstrumentation newInstrumentation(
+      SimpleMeterRegistry registry, RootGraphQLModel.QueryCoords queryCoords) {
+
+    var model = RootGraphQLModel.builder().query(queryCoords).build();
+    return new GraphQLQueryMetricsInstrumentation(registry, "v1", model);
+  }
+
+  private static ArgumentLookupQueryCoords argumentQuery(String parentType, String fieldName) {
+    return ArgumentLookupQueryCoords.builder().parentType(parentType).fieldName(fieldName).build();
+  }
+
+  private static InstrumentationFieldFetchParameters parameters(
+      String parentTypeName, String fieldName) {
+    var environment = mock(DataFetchingEnvironment.class);
+    var parentType = GraphQLObjectType.newObject().name(parentTypeName).build();
+    var fieldDefinition =
+        GraphQLFieldDefinition.newFieldDefinition()
+            .name(fieldName)
+            .type(Scalars.GraphQLString)
+            .build();
+
+    when(environment.getParentType()).thenReturn(parentType);
+    when(environment.getFieldDefinition()).thenReturn(fieldDefinition);
+
+    var params = mock(InstrumentationFieldFetchParameters.class);
+    when(params.getEnvironment()).thenReturn(environment);
+
+    return params;
+  }
+
+  private static long timerCount(
+      SimpleMeterRegistry registry, String parentType, String fieldName) {
+    return registry
+        .get(GraphQLQueryMetricsInstrumentation.METRIC_NAME)
+        .tag("version", "v1")
+        .tag("type", parentType)
+        .tag("name", fieldName)
+        .timer()
+        .count();
+  }
+}


### PR DESCRIPTION
## Key Changes

- Added Micrometer timers for GraphQL queries loaded from `vertx.json`.
- Tagged query metrics by `version`, `parentType`, and `fieldName`.
- Published `p50`, `p99`, `count`, and `sum` metrics through the existing Prometheus `/metrics` endpoint.
- Excluded `FieldLookupQueryCoords` so scalar/property field fetchers are not measured.
- Added unit coverage for sync, async, failure, unregistered field, and field-lookup exclusion cases.

### Base metric name
```
sqrl.graphql.query.duration
```

With the below tags:
- `version`: API version
- `type`:  represents the `parentType`, which currently maps to `Query`
- `name`: represents the `fieldName`, which means the table/relationship name defined in SQRL

### Example Prometheus output
```
sqrl_graphql_query_duration_seconds_count{version="v1",parentType="Query",fieldName="HighTempAlert"} 42
sqrl_graphql_query_duration_seconds_sum{version="v1",parentType="Query",fieldName="HighTempAlert"} 3.721
sqrl_graphql_query_duration_seconds{version="v1",parentType="Query",fieldName="HighTempAlert",quantile="0.5"} 0.018
sqrl_graphql_query_duration_seconds{version="v1",parentType="Query",fieldName="HighTempAlert",quantile="0.99"} 0.241
```
Meaning:
- `count=42`: HighTempAlert was executed 42 times
- `sum=3.721`: total execution time was 3.721 seconds
- `quantile="0.5"`: p50 latency was 18ms
- `quantile="0.99"`: p99 latency was 241ms