### PR TITLE
docs: document dedicated-nodes and do-not-disrupt deployment options

### DIFF
--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -116,7 +116,8 @@ PostgreSQL deployments consist of one primary instance and a configurable number
         "replica-count": 1,             // Number of read replicas (0 or larger)
         "disk-size-gb": 256,            // Disk size in GB (1 or larger)
         "auto-expand-percentage": 0.2,  // Auto-expand threshold (0 to disable, must be < 1)
-        "create-indexes": true          // Whether to create table indexes (see "Create Indexes" below)
+        "create-indexes": true,         // Whether to create table indexes (see "Create Indexes" below)
+        "parameters": {}                // Extra postgresql.parameters (see "Parameters" below)
       }
     }
   }
@@ -276,3 +277,30 @@ Set it to `false` to bootstrap the database **tables-only**, skipping all index 
   }
 }
 ```
+
+## Parameters (`parameters`)
+
+Extra PostgreSQL server parameters, merged into the database's `postgresql.parameters`. Any key here overrides the built-in default for that parameter. PostgreSQL only; empty by default.
+
+| Engine | Field | Default |
+| :--- | :--- | :--- |
+| PostgreSQL | `parameters` | `{}` |
+
+Typically used in a catch-up profile that trades durability for ingest throughput while reprocessing a large backlog — for example a larger `shared_buffers`/`max_wal_size` together with `synchronous_commit: off`. Set these only in the catch-up profile: on the steady-state upgrade any parameter not listed here reverts to its default.
+
+```json5
+{
+  "engines": {
+    "postgres": {
+      "deployment": {
+        "parameters": {
+          "shared_buffers": "8GB",        // override the default (256MB)
+          "max_wal_size": "32GB",
+          "synchronous_commit": "off"     // faster backfill, durability trade-off
+        }
+      }
+    }
+  }
+}
+```
+

--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -168,15 +168,15 @@ The `dev` size is intended for development and testing with small amounts of dat
 
 ---
 
-## Node Groups (`*-node-groups`)
+## Dedicated Nodes (`*-dedicated-nodes`)
 
-Pins a component's pods onto dedicated nodes. Each engine's `deployment` accepts a list of node-group names. Each name is a **hard requirement**: if no matching node is available, the pod stays `Pending` — it never falls back to a shared node.
+Pins a component's pods onto dedicated nodes. Each engine's `deployment` accepts a list of dedicated-node names. Each name is a **hard requirement**: if no matching node is available, the pod stays `Pending` — it never falls back to a shared node.
 
 | Engine | Field(s) |
 | :--- | :--- |
-| Flink | `taskmanager-node-groups`, `jobmanager-node-groups` |
-| PostgreSQL | `node-groups` |
-| Vert.x | `node-groups` |
+| Flink | `taskmanager-dedicated-nodes`, `jobmanager-dedicated-nodes` |
+| PostgreSQL | `dedicated-nodes` |
+| Vert.x | `dedicated-nodes` |
 
 ```json5
 {
@@ -185,7 +185,7 @@ Pins a component's pods onto dedicated nodes. Each engine's `deployment` accepts
       "deployment": {
         "taskmanager-size": "medium.mem",
         "taskmanager-count": 6,
-        "taskmanager-node-groups": [ "nvme" ]   // TaskManagers MUST run on the "nvme" node group
+        "taskmanager-dedicated-nodes": [ "nvme" ]   // TaskManagers MUST run on the "nvme" dedicated nodes
       }
     }
   }
@@ -197,13 +197,13 @@ For each name `N` in the list, the pod is given:
 * a **node selector** requiring the node label `N=true` (the pin), and
 * a **toleration** for taint key `N` (so it is allowed onto the dedicated, tainted nodes).
 
-The cluster side is an infrastructure concern: a node group named `N` must label its nodes `N=true` **and** taint them `N=<value>:NoSchedule`. The taint keeps everything that does not request `N` off those nodes; the matching label + toleration place the requesting pods on them. This gives both *pinning* (the workload runs there) and *isolation* (nothing else does).
+The cluster side is an infrastructure concern: the dedicated nodes for `N` must be labeled `N=true` **and** tainted `N=<value>:NoSchedule`. The taint keeps everything that does not request `N` off those nodes; the matching label + toleration place the requesting pods on them. This gives both *pinning* (the workload runs there) and *isolation* (nothing else does).
 
 Multiple names are combined with AND — the pod requires a node carrying all of them.
 
-### Creating the node group (cluster side)
+### Provisioning the dedicated nodes (cluster side)
 
-A node group is provisioned by the cluster operator, not by the pipeline. The contract is simple: nodes in group `N` must carry the **label** `N=true` and the **taint** `N=true:NoSchedule`. The label provides the pin (pods requesting `N` land here); the taint provides the isolation (everything that does not request `N` is kept off).
+Dedicated nodes are provisioned by the cluster operator, not by the pipeline. The contract is simple: the nodes for `N` must carry the **label** `N=true` and the **taint** `N=true:NoSchedule`. The label provides the pin (pods requesting `N` land here); the taint provides the isolation (everything that does not request `N` is kept off).
 
 On a [Karpenter](https://karpenter.sh/)-managed cluster (e.g. Amazon EKS), create a `NodePool`. For a group named `nvme` backed by local-NVMe instances:
 
@@ -216,7 +216,7 @@ spec:
   template:
     metadata:
       labels:
-        nvme: "true"            # selected by pods requesting node group "nvme"
+        nvme: "true"            # selected by pods requesting dedicated nodes "nvme"
     spec:
       taints:
         - key: nvme             # repels everything that does not tolerate "nvme"
@@ -228,7 +228,7 @@ spec:
       # nodeClassRef, arch/os, disruption budgets and limits as appropriate for your cluster
 ```
 
-The label name and taint key must both equal the node-group name. Nodes in the group must also carry any standard scheduling labels your platform applies to workload nodes, so the deployment's base node selection still resolves.
+The label name and taint key must both equal the dedicated-nodes name. These nodes must also carry any standard scheduling labels your platform applies to workload nodes, so the deployment's base node selection still resolves.
 
 ---
 

--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -199,6 +199,35 @@ The cluster side is an infrastructure concern: a node group named `N` must label
 
 Multiple names are combined with AND — the pod requires a node carrying all of them.
 
+### Creating the node group (cluster side)
+
+A node group is provisioned by the cluster operator, not by the pipeline. The contract is simple: nodes in group `N` must carry the **label** `N=true` and the **taint** `N=true:NoSchedule`. The label provides the pin (pods requesting `N` land here); the taint provides the isolation (everything that does not request `N` is kept off).
+
+On a [Karpenter](https://karpenter.sh/)-managed cluster (e.g. Amazon EKS), create a `NodePool`. For a group named `nvme` backed by local-NVMe instances:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: nvme
+spec:
+  template:
+    metadata:
+      labels:
+        nvme: "true"            # selected by pods requesting node group "nvme"
+    spec:
+      taints:
+        - key: nvme             # repels everything that does not tolerate "nvme"
+          value: "true"
+          effect: NoSchedule
+      requirements:
+        - { key: node.kubernetes.io/instance-type, operator: In, values: [ i7i.2xlarge ] }
+        - { key: karpenter.sh/capacity-type, operator: In, values: [ on-demand ] }
+      # nodeClassRef, arch/os, disruption budgets and limits as appropriate for your cluster
+```
+
+The label name and taint key must both equal the node-group name. Nodes in the group must also carry any standard scheduling labels your platform applies to workload nodes, so the deployment's base node selection still resolves.
+
 ---
 
 ## Do Not Disrupt (`do-not-disrupt`)

--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -163,3 +163,62 @@ Vert.x API server deployments consist of a configurable number of identically si
 | large | 4 | 16 | 220GB | 1 | 15 |
 
 The `dev` size is intended for development and testing with small amounts of data. The `.disk` qualifier enables NVMe storage for instances that require local disk access.
+
+---
+
+## Node Groups (`*-node-groups`)
+
+Pins a component's pods onto dedicated nodes. Each engine's `deployment` accepts a list of node-group names. Each name is a **hard requirement**: if no matching node is available, the pod stays `Pending` — it never falls back to a shared node.
+
+| Engine | Field(s) |
+| :--- | :--- |
+| Flink | `taskmanager-node-groups`, `jobmanager-node-groups` |
+| PostgreSQL | `node-groups` |
+| Vert.x | `node-groups` |
+
+```json5
+{
+  "engines": {
+    "flink": {
+      "deployment": {
+        "taskmanager-size": "medium.mem",
+        "taskmanager-count": 6,
+        "taskmanager-node-groups": [ "nvme" ]   // TaskManagers MUST run on the "nvme" node group
+      }
+    }
+  }
+}
+```
+
+For each name `N` in the list, the pod is given:
+
+* a **node selector** requiring the node label `N=true` (the pin), and
+* a **toleration** for taint key `N` (so it is allowed onto the dedicated, tainted nodes).
+
+The cluster side is an infrastructure concern: a node group named `N` must label its nodes `N=true` **and** taint them `N=<value>:NoSchedule`. The taint keeps everything that does not request `N` off those nodes; the matching label + toleration place the requesting pods on them. This gives both *pinning* (the workload runs there) and *isolation* (nothing else does).
+
+Multiple names are combined with AND — the pod requires a node carrying all of them.
+
+---
+
+## Do Not Disrupt (`do-not-disrupt`)
+
+Protects a component's pods from **voluntary** autoscaler disruption (node consolidation / scale-down). When `true`, the pods are annotated so the cluster autoscaler will not evict or consolidate them. Use it for long-running, stateful, or hard-to-reschedule workloads — for example a Flink catch-up that reprocesses the whole backlog, or the PostgreSQL primary during bootstrap.
+
+| Engine | Field | Default |
+| :--- | :--- | :--- |
+| Flink | `do-not-disrupt` | `false` |
+| PostgreSQL | `do-not-disrupt` | `true` |
+| Vert.x | `do-not-disrupt` | `false` |
+
+```json5
+{
+  "engines": {
+    "flink": {
+      "deployment": {
+        "do-not-disrupt": true   // keep TaskManagers/JobManager from being consolidated mid-run
+      }
+    }
+  }
+}
+```

--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -115,7 +115,8 @@ PostgreSQL deployments consist of one primary instance and a configurable number
         "instance-size": "medium",      // Instance size (see table below)
         "replica-count": 1,             // Number of read replicas (0 or larger)
         "disk-size-gb": 256,            // Disk size in GB (1 or larger)
-        "auto-expand-percentage": 0.2   // Auto-expand threshold (0 to disable, must be < 1)
+        "auto-expand-percentage": 0.2,  // Auto-expand threshold (0 to disable, must be < 1)
+        "create-indexes": true          // Whether to create table indexes (see "Create Indexes" below)
       }
     }
   }
@@ -246,6 +247,30 @@ Protects a component's pods from **voluntary** autoscaler disruption (node conso
     "flink": {
       "deployment": {
         "do-not-disrupt": true   // keep TaskManagers/JobManager from being consolidated mid-run
+      }
+    }
+  }
+}
+```
+
+---
+
+## Create Indexes (`create-indexes`)
+
+Controls whether the PostgreSQL table indexes are created for the deployment. Defaults to `true`. PostgreSQL only.
+
+| Engine | Field | Default |
+| :--- | :--- | :--- |
+| PostgreSQL | `create-indexes` | `true` |
+
+Set it to `false` to bootstrap the database **tables-only**, skipping all index creation. This is intended for a catch-up profile that reprocesses a large backlog: writing to un-indexed tables drains the backlog faster. The indexes are then built when the deployment is upgraded back to a steady-state profile (where `create-indexes` returns to its `true` default), so a catch-up deployment must be followed by such an upgrade before it serves production query traffic.
+
+```json5
+{
+  "engines": {
+    "postgres": {
+      "deployment": {
+        "create-indexes": false   // tables-only bootstrap for fast backlog draining; build indexes on the steady-state upgrade
       }
     }
   }


### PR DESCRIPTION
Documents two cloud-deployment options in `documentation/docs/configuration-engine/cloud-deployment.md`:

- **`*-node-groups`** — pins a component's pods onto dedicated nodes (hard requirement → Pending if unavailable). Each name derives a node selector (`N=true`) + a toleration for taint key `N`; infra labels+taints the node group. Covers `taskmanager-node-groups`/`jobmanager-node-groups` (Flink), `node-groups` (Postgres, Vert.x).
- **`do-not-disrupt`** — protects pods from voluntary autoscaler consolidation. Documents per-engine defaults (Flink false, Postgres true, Vert.x false).

Matches the implementation in cloud-compilation (per-service deployment config passthrough).