### PR TITLE
feat: Add GraphQL query tail sample tracing instrumentation

### DIFF
--- a/sqrl-cli/src/main/resources/templates/server-config.json
+++ b/sqrl-cli/src/main/resources/templates/server-config.json
@@ -127,11 +127,11 @@
     "sslMode" : "DISABLE",
     "sslNegotiation" : "POSTGRES",
     "useLayer7Proxy" : false,
+    "usingDomainSocket" : false,
     "socketAddress" : {
       "inetSocket" : true,
       "domainSocket" : false
-    },
-    "usingDomainSocket" : false
+    }
   },
   "poolOptions" : {
     "maxSize" : 4,
@@ -186,5 +186,13 @@
     "value.deserializer" : "com.datasqrl.server.kafka.JsonDeserializer"
   },
   "duckDbConfig" : null,
-  "snowflakeConfig" : null
+  "snowflakeConfig" : null,
+  "graphQLTailSampleTracingConfig" : {
+    "enabled" : false,
+    "defaultThresholdMs" : 60000,
+    "alwaysLogErrors" : true,
+    "maxLoggedTracesPerMinute" : 60,
+    "maxFieldTraces" : 50,
+    "thresholds" : { }
+  }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/GraphQLServerVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/GraphQLServerVerticle.java
@@ -25,6 +25,7 @@ import com.datasqrl.server.exec.FlinkFunctionExecutor;
 import com.datasqrl.server.graphql.CustomScalars;
 import com.datasqrl.server.graphql.GraphQLEngineBuilder;
 import com.datasqrl.server.graphql.GraphQLQueryMetricsInstrumentation;
+import com.datasqrl.server.graphql.GraphQLTailSampleTracingInstrumentation;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.jdbc.DatabaseType;
 import com.datasqrl.server.jdbc.JdbcClientsConfig;
@@ -34,6 +35,7 @@ import com.google.common.collect.ImmutableMap;
 import com.symbaloo.graphqlmicrometer.MicrometerInstrumentation;
 import graphql.GraphQL;
 import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
@@ -47,6 +49,7 @@ import io.vertx.ext.web.handler.graphql.GraphiQLHandler;
 import io.vertx.ext.web.handler.graphql.ws.GraphQLWSHandler;
 import io.vertx.micrometer.backends.BackendRegistries;
 import io.vertx.sqlclient.SqlClient;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -196,13 +199,20 @@ public class GraphQLServerVerticle extends AbstractVerticle {
                   .build(),
               vertxServerCtx);
 
+      var instrumentations = new ArrayList<Instrumentation>();
       var meterRegistry = BackendRegistries.getDefaultNow();
       if (meterRegistry != null) {
-        graphQL.instrumentation(
-            new ChainedInstrumentation(
-                List.of(
-                    new MicrometerInstrumentation(meterRegistry),
-                    new GraphQLQueryMetricsInstrumentation(meterRegistry, modelVersion, model))));
+        instrumentations.add(new MicrometerInstrumentation(meterRegistry));
+        instrumentations.add(
+            new GraphQLQueryMetricsInstrumentation(meterRegistry, modelVersion, model));
+      }
+      if (config.getGraphQLTailSampleTracingConfig().isEnabled()) {
+        instrumentations.add(
+            new GraphQLTailSampleTracingInstrumentation(
+                modelVersion, model, config.getGraphQLTailSampleTracingConfig()));
+      }
+      if (!instrumentations.isEmpty()) {
+        graphQL.instrumentation(new ChainedInstrumentation(instrumentations));
       }
 
       return graphQL.build();

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLTailSampleTracingConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLTailSampleTracingConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GraphQLTailSampleTracingConfig {
+
+  private boolean enabled = false;
+  private long defaultThresholdMs = 60000;
+  private boolean alwaysLogErrors = true;
+  private int maxLoggedTracesPerMinute = 60;
+  private int maxFieldTraces = 50;
+  private Map<String, Long> thresholds = Map.of();
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/ServerConfig.java
@@ -61,6 +61,8 @@ public class ServerConfig {
   private PoolOptions poolOptions = new PoolOptions();
   private CorsHandlerOptions corsHandlerOptions = new CorsHandlerOptions();
   private SwaggerConfig swaggerConfig = new SwaggerConfig();
+  private GraphQLTailSampleTracingConfig graphQLTailSampleTracingConfig =
+      new GraphQLTailSampleTracingConfig();
   private Map<String, Object> jwtAuth;
   private OAuthConfig oauthConfig;
 
@@ -172,6 +174,14 @@ public class ServerConfig {
   public void setSwaggerConfigFromJson(Map<String, Object> options) {
     this.swaggerConfig =
         options == null ? new SwaggerConfig() : MAPPER.convertValue(options, SwaggerConfig.class);
+  }
+
+  @JsonSetter("graphQLTailSampleTracingConfig")
+  public void setGraphQLTailSampleTracingConfigFromJson(Map<String, Object> options) {
+    this.graphQLTailSampleTracingConfig =
+        options == null
+            ? new GraphQLTailSampleTracingConfig()
+            : MAPPER.convertValue(options, GraphQLTailSampleTracingConfig.class);
   }
 
   private JsonObject getJsonObjectOrEmpty(Map<String, Object> options) {

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentation.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLQueryMetricsInstrumentation.java
@@ -15,8 +15,6 @@
  */
 package com.datasqrl.server.graphql;
 
-import static java.util.Objects.requireNonNull;
-
 import com.datasqrl.server.graphql.RootGraphQLModel.ArgumentLookupQueryCoords;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimplePerformantInstrumentation;
@@ -98,13 +96,5 @@ public class GraphQLQueryMetricsInstrumentation extends SimplePerformantInstrume
 
   private static void record(Timer timer, long startNanos) {
     timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
-  }
-
-  private record QueryKey(String parentType, String fieldName) {
-
-    private QueryKey {
-      requireNonNull(parentType, "parentType must not be null");
-      requireNonNull(fieldName, "fieldName must not be null");
-    }
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentation.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentation.java
@@ -28,6 +28,8 @@ import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.language.OperationDefinition;
+import graphql.parser.Parser;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLNamedSchemaElement;
 import java.nio.charset.StandardCharsets;
@@ -104,7 +106,7 @@ public class GraphQLTailSampleTracingInstrumentation extends SimplePerformantIns
       InstrumentationExecutionParameters parameters, InstrumentationState state) {
 
     if (state instanceof TraceState traceState) {
-      traceState.operationName = parameters.getOperation();
+      traceState.operationName = operationName(parameters);
       traceState.startNanos = System.nanoTime();
 
       return SimpleInstrumentationContext.whenCompleted(
@@ -289,6 +291,35 @@ public class GraphQLTailSampleTracingInstrumentation extends SimplePerformantIns
       return HexFormat.of().formatHex(hash, 0, 8);
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 digest is unavailable", e);
+    }
+  }
+
+  /**
+   * Returns the client-provided operation name, or derives the declared name for single-operation
+   * documents where the HTTP request omitted the optional operationName field.
+   */
+  private static String operationName(InstrumentationExecutionParameters parameters) {
+    var operationName = parameters.getOperation();
+    if (operationName != null && !operationName.isBlank()) {
+      return operationName;
+    }
+
+    var query = parameters.getQuery();
+    if (query.isBlank()) {
+      return null;
+    }
+
+    try {
+      var operations = Parser.parse(query).getDefinitionsOfType(OperationDefinition.class);
+      if (operations.size() != 1) {
+        return null;
+      }
+
+      var parsedName = operations.get(0).getName();
+      return parsedName == null || parsedName.isBlank() ? null : parsedName;
+    } catch (RuntimeException e) {
+      log.debug("Failed to parse GraphQL query param for tail sample tracing", e);
+      return null;
     }
   }
 

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentation.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentation.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.graphql;
+
+import com.datasqrl.server.config.GraphQLTailSampleTracingConfig;
+import com.datasqrl.server.graphql.RootGraphQLModel.ArgumentLookupQueryCoords;
+import com.datasqrl.util.JsonUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLNamedSchemaElement;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/** Logs one structured warning for slow or failed GraphQL executions after execution completes. */
+@Slf4j
+public class GraphQLTailSampleTracingInstrumentation extends SimplePerformantInstrumentation {
+
+  private static final String METRIC_NAME = "sqrl.graphql.query.tail_trace";
+
+  private final Object rateLimitLock = new Object();
+
+  private final String modelVersion;
+  private final Map<QueryKey, Long> thresholds;
+  private final long defaultThresholdMs;
+  private final boolean alwaysLogErrors;
+  private final int maxLoggedTracesPerMinute;
+  private final int maxFieldTraces;
+
+  private long windowStartMillis = System.currentTimeMillis();
+  private int loggedInWindow = 0;
+
+  /**
+   * Creates tail-sampling instrumentation for SQRL-backed GraphQL query fetchers in the supplied
+   * model. Only {@link ArgumentLookupQueryCoords} entries are traced because those correspond to
+   * generated query execution work rather than simple property lookup fields.
+   */
+  public GraphQLTailSampleTracingInstrumentation(
+      @NonNull String modelVersion,
+      @NonNull RootGraphQLModel model,
+      @NonNull GraphQLTailSampleTracingConfig config) {
+
+    this.modelVersion = modelVersion;
+    this.defaultThresholdMs = Math.max(1, config.getDefaultThresholdMs());
+    this.alwaysLogErrors = config.isAlwaysLogErrors();
+    this.maxLoggedTracesPerMinute = config.getMaxLoggedTracesPerMinute();
+    this.maxFieldTraces = Math.max(1, config.getMaxFieldTraces());
+    this.thresholds =
+        model.getQueries().stream()
+            .filter(ArgumentLookupQueryCoords.class::isInstance)
+            .map(coords -> new QueryKey(coords.getParentType(), coords.getFieldName()))
+            .distinct()
+            .collect(
+                Collectors.toConcurrentMap(
+                    Function.identity(), key -> thresholdFor(config.getThresholds(), key)));
+  }
+
+  /** Creates per-execution mutable trace state shared by the instrumentation callbacks. */
+  @Override
+  public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+    return new TraceState();
+  }
+
+  /**
+   * Starts the end-to-end GraphQL execution timer and registers the completion callback that makes
+   * the tail-sampling decision after the operation result is known.
+   */
+  @Override
+  public InstrumentationContext<ExecutionResult> beginExecution(
+      InstrumentationExecutionParameters parameters, InstrumentationState state) {
+
+    if (state instanceof TraceState traceState) {
+      traceState.operationName = parameters.getOperation();
+      traceState.startNanos = System.nanoTime();
+
+      return SimpleInstrumentationContext.whenCompleted(
+          (result, throwable) -> logIfSampled(parameters, traceState, result, throwable));
+    }
+
+    return SimpleInstrumentationContext.noOp();
+  }
+
+  /**
+   * Wraps generated SQRL query data fetchers so their individual latencies can be included in the
+   * tail trace when the full GraphQL execution is slow or failed.
+   */
+  @Override
+  public DataFetcher<?> instrumentDataFetcher(
+      DataFetcher<?> dataFetcher,
+      InstrumentationFieldFetchParameters parameters,
+      InstrumentationState state) {
+
+    if (!(state instanceof TraceState traceState)) {
+      return dataFetcher;
+    }
+
+    var environment = parameters.getEnvironment();
+    var parentType = environment.getParentType();
+    if (!(parentType instanceof GraphQLNamedSchemaElement namedParentType)) {
+      return dataFetcher;
+    }
+
+    var key = new QueryKey(namedParentType.getName(), environment.getFieldDefinition().getName());
+    if (!thresholds.containsKey(key)) {
+      return dataFetcher;
+    }
+
+    return env -> {
+      var startNanos = System.nanoTime();
+      try {
+        var result = dataFetcher.get(env);
+        if (result instanceof CompletionStage<?> stage) {
+          return stage.whenComplete(
+              (value, error) ->
+                  recordFieldTrace(
+                      traceState,
+                      key,
+                      env.getExecutionStepInfo().getPath().toString(),
+                      startNanos,
+                      error));
+        }
+
+        recordFieldTrace(
+            traceState, key, env.getExecutionStepInfo().getPath().toString(), startNanos, null);
+        return result;
+      } catch (Exception e) {
+        recordFieldTrace(
+            traceState, key, env.getExecutionStepInfo().getPath().toString(), startNanos, e);
+        throw e;
+      }
+    };
+  }
+
+  /**
+   * Evaluates the completed execution against the slow-query and error policies, then emits a
+   * single structured warning if the request should be retained by the tail sampler.
+   */
+  private void logIfSampled(
+      InstrumentationExecutionParameters parameters,
+      TraceState state,
+      ExecutionResult result,
+      Throwable throwable) {
+
+    var durationMs = elapsedMs(state.startNanos);
+    var errorCount = result == null ? 0 : result.getErrors().size();
+    var failed = throwable != null || errorCount > 0;
+    var slowThresholdMs = slowThresholdMs(state);
+    var slow = durationMs >= slowThresholdMs;
+
+    if ((!slow && !(alwaysLogErrors && failed)) || !tryAcquireLogPermit()) {
+      return;
+    }
+
+    var logEvent =
+        new TailTraceLogEvent(
+            METRIC_NAME,
+            modelVersion,
+            state.operationName,
+            durationMs,
+            slowThresholdMs,
+            slow ? "slow" : "error",
+            errorCount,
+            hash(parameters.getQuery()),
+            fieldLogEvents(state),
+            throwable == null ? null : throwable.getClass().getName(),
+            throwable == null ? null : throwable.getMessage());
+
+    logEvent(logEvent);
+  }
+
+  /** Converts the bounded set of captured field fetch timings into the serializable log DTO. */
+  private List<FieldTraceLogEvent> fieldLogEvents(TraceState state) {
+    var fields = new ArrayList<FieldTraceLogEvent>();
+    for (var fieldTrace : state.fieldTraces) {
+      if (fields.size() >= maxFieldTraces) {
+        break;
+      }
+      fields.add(
+          new FieldTraceLogEvent(
+              fieldTrace.path(),
+              fieldTrace.durationMs(),
+              thresholds.getOrDefault(fieldTrace.key(), defaultThresholdMs),
+              fieldTrace.failed()));
+    }
+    return fields;
+  }
+
+  private void logEvent(TailTraceLogEvent logEvent) {
+    try {
+      log.warn("{}", JsonUtils.MAPPER.writeValueAsString(logEvent));
+    } catch (JsonProcessingException e) {
+      log.warn("Failed to serialize GraphQL tail trace log event", e);
+    }
+  }
+
+  /**
+   * Returns the threshold that applies to this execution. For multi-fetcher operations, the
+   * strictest configured field threshold is used so any slow component can retain the trace.
+   */
+  private long slowThresholdMs(TraceState state) {
+    return state.fieldTraces.stream()
+        .map(FieldTrace::key)
+        .map(key -> thresholds.getOrDefault(key, defaultThresholdMs))
+        .min(Long::compareTo)
+        .orElse(defaultThresholdMs);
+  }
+
+  /** Records one generated SQRL field fetch timing without blocking the request path. */
+  private void recordFieldTrace(
+      TraceState state, QueryKey key, String path, long startNanos, Throwable throwable) {
+
+    state.fieldTraces.add(new FieldTrace(key, path, elapsedMs(startNanos), throwable != null));
+  }
+
+  /** Applies a simple process-local per-minute cap to avoid flooding logs during incidents. */
+  private boolean tryAcquireLogPermit() {
+    if (maxLoggedTracesPerMinute <= 0) {
+      return true;
+    }
+
+    synchronized (rateLimitLock) {
+      var now = System.currentTimeMillis();
+      if (now - windowStartMillis >= TimeUnit.MINUTES.toMillis(1)) {
+        windowStartMillis = now;
+        loggedInWindow = 0;
+      }
+      if (loggedInWindow >= maxLoggedTracesPerMinute) {
+        return false;
+      }
+      loggedInWindow++;
+      return true;
+    }
+  }
+
+  private long elapsedMs(long startNanos) {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+  }
+
+  /** Returns the configured per-field threshold or the default threshold if none is configured. */
+  private long thresholdFor(Map<String, Long> configuredThresholds, QueryKey key) {
+    return configuredThresholds.getOrDefault(key.toString(), defaultThresholdMs);
+  }
+
+  /**
+   * Hashes the GraphQL query text so traces can be correlated without logging raw query strings.
+   */
+  private static String hash(String value) {
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      var hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hash, 0, 8);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 digest is unavailable", e);
+    }
+  }
+
+  private static class TraceState implements InstrumentationState {
+    private final Queue<FieldTrace> fieldTraces = new ConcurrentLinkedQueue<>();
+    private long startNanos;
+    private String operationName;
+  }
+
+  private record FieldTrace(QueryKey key, String path, long durationMs, boolean failed) {}
+
+  private record TailTraceLogEvent(
+      String event,
+      String modelVersion,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String operationName,
+      long durationMs,
+      long thresholdMs,
+      String sampleReason,
+      int errors,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String queryHash,
+      List<FieldTraceLogEvent> fields,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String exceptionType,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String exceptionMessage) {}
+
+  private record FieldTraceLogEvent(
+      String path, long durationMs, long thresholdMs, boolean failed) {}
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/QueryKey.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/graphql/QueryKey.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.graphql;
+
+import lombok.NonNull;
+
+record QueryKey(@NonNull String parentType, @NonNull String fieldName) {
+
+  @Override
+  public String toString() {
+    return parentType + "." + fieldName;
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
@@ -38,6 +38,8 @@ class ServerConfigTest {
     assertThat(serverConfig.getCorsHandlerOptions()).isNotNull();
     assertThat(serverConfig.getJwtAuth()).isNull();
     assertThat(serverConfig.getSwaggerConfig()).isNotNull();
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig()).isNotNull();
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig().isEnabled()).isFalse();
     assertThat(serverConfig.getKafkaMutationConfig()).isNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNull();
   }
@@ -56,6 +58,14 @@ class ServerConfigTest {
     json.set("corsHandlerOptions", MAPPER.createObjectNode().put("allowCredentials", true));
     json.set("jwtAuth", MAPPER.createObjectNode().put("algorithm", "HS256"));
     json.set("swaggerConfig", MAPPER.createObjectNode().put("enabled", true));
+    json.set(
+        "graphQLTailSampleTracingConfig",
+        MAPPER
+            .createObjectNode()
+            .put("enabled", true)
+            .put("defaultThresholdMs", 750)
+            .put("maxLoggedTracesPerMinute", 10)
+            .set("thresholds", MAPPER.createObjectNode().put("Query.HighTempAlert", 250)));
 
     var kafkaMutationConfig = MAPPER.createObjectNode();
     kafkaMutationConfig.put("bootstrap.servers", "localhost:9092");
@@ -78,6 +88,13 @@ class ServerConfigTest {
     assertThat(serverConfig.getCorsHandlerOptions()).isNotNull();
     assertThat(serverConfig.getJwtAuth()).isNotNull();
     assertThat(serverConfig.getSwaggerConfig()).isNotNull();
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig().isEnabled()).isTrue();
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig().getDefaultThresholdMs())
+        .isEqualTo(750);
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig().getMaxLoggedTracesPerMinute())
+        .isEqualTo(10);
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig().getThresholds())
+        .containsEntry("Query.HighTempAlert", 250L);
     assertThat(serverConfig.getKafkaMutationConfig()).isNotNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNotNull();
   }
@@ -93,6 +110,7 @@ class ServerConfigTest {
     json.putNull("corsHandlerOptions");
     json.putNull("jwtAuth");
     json.putNull("swaggerConfig");
+    json.putNull("graphQLTailSampleTracingConfig");
     json.putNull("kafkaMutationConfig");
     json.putNull("kafkaSubscriptionConfig");
 
@@ -105,6 +123,7 @@ class ServerConfigTest {
     assertThat(serverConfig.getPoolOptions()).isNotNull();
     assertThat(serverConfig.getCorsHandlerOptions()).isNotNull();
     assertThat(serverConfig.getSwaggerConfig()).isNotNull();
+    assertThat(serverConfig.getGraphQLTailSampleTracingConfig()).isNotNull();
 
     // PgConnectOptions uses empty default when null
     assertThat(serverConfig.getPgConnectOptions()).isNotNull();

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentationTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentationTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.server.config.GraphQLTailSampleTracingConfig;
+import com.datasqrl.server.graphql.RootGraphQLModel.ArgumentLookupQueryCoords;
+import com.datasqrl.util.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import graphql.ExecutionResult;
+import graphql.Scalars;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+
+class GraphQLTailSampleTracingInstrumentationTest {
+
+  @Test
+  void givenSlowQuery_whenExecutionCompletes_thenLogsTraceWarning() throws Exception {
+    var appender = attachAppender();
+    try {
+      var instrumentation = newInstrumentation(config(1, Map.of("Query.HighTempAlert", 1L)));
+      var state = instrumentation.createState(mock(InstrumentationCreateStateParameters.class));
+      var executionContext =
+          instrumentation.beginExecution(
+              executionParameters(
+                  "query HighTempAlertQuery { HighTempAlert }", "HighTempAlertQuery"),
+              state);
+      var environment = environment("Query", "HighTempAlert", "/HighTempAlert");
+      DataFetcher<?> fetcher = env -> "result";
+
+      var instrumented =
+          instrumentation.instrumentDataFetcher(fetcher, parameters(environment), state);
+      assertThat(instrumented.get(environment)).isEqualTo("result");
+
+      Thread.sleep(5);
+      executionContext.onCompleted(executionResult(List.of()), null);
+
+      var event = singleLogEvent(appender);
+      assertThat(event.get("event").asText()).isEqualTo("sqrl.graphql.query.tail_trace");
+      assertThat(event.get("modelVersion").asText()).isEqualTo("v1");
+      assertThat(event.get("operationName").asText()).isEqualTo("HighTempAlertQuery");
+      assertThat(event.get("sampleReason").asText()).isEqualTo("slow");
+      assertThat(event.get("thresholdMs").asLong()).isEqualTo(1);
+      assertThat(event.get("errors").asInt()).isZero();
+      assertThat(event.get("queryHash").asText()).isNotBlank();
+      assertThat(event.get("fields")).hasSize(1);
+      assertThat(event.get("fields").get(0).get("path").asText()).isEqualTo("/HighTempAlert");
+      assertThat(event.get("fields").get(0).get("thresholdMs").asLong()).isEqualTo(1);
+      assertThat(event.get("fields").get(0).get("failed").asBoolean()).isFalse();
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void givenFastQuery_whenExecutionCompletes_thenDoesNotLogTraceWarning() throws Exception {
+    var appender = attachAppender();
+    try {
+      var instrumentation = newInstrumentation(config(60_000, Map.of()));
+      var state = instrumentation.createState(mock(InstrumentationCreateStateParameters.class));
+      var executionContext =
+          instrumentation.beginExecution(
+              executionParameters(
+                  "query HighTempAlertQuery { HighTempAlert }", "HighTempAlertQuery"),
+              state);
+      var environment = environment("Query", "HighTempAlert", "/HighTempAlert");
+      DataFetcher<?> fetcher = env -> "result";
+
+      var instrumented =
+          instrumentation.instrumentDataFetcher(fetcher, parameters(environment), state);
+      assertThat(instrumented.get(environment)).isEqualTo("result");
+      executionContext.onCompleted(executionResult(List.of()), null);
+
+      assertThat(appender.messages()).isEmpty();
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void givenFailedQuery_whenExecutionCompletes_thenLogsErrorTraceWarning() throws Exception {
+    var appender = attachAppender();
+    try {
+      var instrumentation = newInstrumentation(config(60_000, Map.of()));
+      var state = instrumentation.createState(mock(InstrumentationCreateStateParameters.class));
+      var executionContext =
+          instrumentation.beginExecution(
+              executionParameters(
+                  "query HighTempAlertQuery { HighTempAlert }", "HighTempAlertQuery"),
+              state);
+      var environment = environment("Query", "HighTempAlert", "/HighTempAlert");
+      DataFetcher<?> fetcher =
+          env -> {
+            throw new IllegalStateException("boom");
+          };
+
+      var instrumented =
+          instrumentation.instrumentDataFetcher(fetcher, parameters(environment), state);
+      assertThatThrownBy(() -> instrumented.get(environment))
+          .isInstanceOf(IllegalStateException.class);
+      executionContext.onCompleted(executionResult(List.of()), new IllegalStateException("boom"));
+
+      var event = singleLogEvent(appender);
+      assertThat(event.get("sampleReason").asText()).isEqualTo("error");
+      assertThat(event.get("exceptionType").asText())
+          .isEqualTo(IllegalStateException.class.getName());
+      assertThat(event.get("exceptionMessage").asText()).isEqualTo("boom");
+      assertThat(event.get("fields").get(0).get("failed").asBoolean()).isTrue();
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void givenUnregisteredField_whenDataFetcherInstrumented_thenReturnsOriginalFetcher() {
+    var instrumentation = newInstrumentation(config(1, Map.of()));
+    var state = instrumentation.createState(mock(InstrumentationCreateStateParameters.class));
+    var environment = environment("Query", "OtherField", "/OtherField");
+    DataFetcher<?> fetcher = env -> "result";
+
+    var instrumented =
+        instrumentation.instrumentDataFetcher(fetcher, parameters(environment), state);
+
+    assertThat(instrumented).isSameAs(fetcher);
+  }
+
+  private static GraphQLTailSampleTracingInstrumentation newInstrumentation(
+      GraphQLTailSampleTracingConfig config) {
+    var model = RootGraphQLModel.builder().query(argumentQuery("Query", "HighTempAlert")).build();
+    return new GraphQLTailSampleTracingInstrumentation("v1", model, config);
+  }
+
+  private static GraphQLTailSampleTracingConfig config(
+      long defaultThresholdMs, Map<String, Long> thresholds) {
+    var config = new GraphQLTailSampleTracingConfig();
+    config.setDefaultThresholdMs(defaultThresholdMs);
+    config.setThresholds(thresholds);
+    config.setMaxLoggedTracesPerMinute(0);
+    return config;
+  }
+
+  private static ArgumentLookupQueryCoords argumentQuery(String parentType, String fieldName) {
+    return ArgumentLookupQueryCoords.builder().parentType(parentType).fieldName(fieldName).build();
+  }
+
+  private static InstrumentationExecutionParameters executionParameters(
+      String query, String operationName) {
+    var parameters = mock(InstrumentationExecutionParameters.class);
+    when(parameters.getQuery()).thenReturn(query);
+    when(parameters.getOperation()).thenReturn(operationName);
+    return parameters;
+  }
+
+  private static InstrumentationFieldFetchParameters parameters(
+      DataFetchingEnvironment environment) {
+    var params = mock(InstrumentationFieldFetchParameters.class);
+    when(params.getEnvironment()).thenReturn(environment);
+    return params;
+  }
+
+  private static DataFetchingEnvironment environment(
+      String parentTypeName, String fieldName, String path) {
+    var environment = mock(DataFetchingEnvironment.class);
+    var parentType = GraphQLObjectType.newObject().name(parentTypeName).build();
+    var fieldDefinition =
+        GraphQLFieldDefinition.newFieldDefinition()
+            .name(fieldName)
+            .type(Scalars.GraphQLString)
+            .build();
+    var stepInfo = mock(ExecutionStepInfo.class);
+
+    when(stepInfo.getPath()).thenReturn(ResultPath.parse(path));
+    when(environment.getParentType()).thenReturn(parentType);
+    when(environment.getFieldDefinition()).thenReturn(fieldDefinition);
+    when(environment.getExecutionStepInfo()).thenReturn(stepInfo);
+
+    return environment;
+  }
+
+  private static ExecutionResult executionResult(List<?> errors) {
+    var result = mock(ExecutionResult.class);
+    when(result.getErrors()).thenReturn((List) errors);
+    return result;
+  }
+
+  private static JsonNode singleLogEvent(CapturingAppender appender) throws Exception {
+    assertThat(appender.messages()).hasSize(1);
+    return JsonUtils.MAPPER.readTree(appender.messages().get(0));
+  }
+
+  private static CapturingAppender attachAppender() {
+    var appender = new CapturingAppender();
+    appender.start();
+    logger().setLevel(Level.WARN);
+    logger().addAppender(appender);
+    return appender;
+  }
+
+  private static void detachAppender(CapturingAppender appender) {
+    logger().removeAppender(appender);
+    appender.stop();
+  }
+
+  private static Logger logger() {
+    return (Logger) LogManager.getLogger(GraphQLTailSampleTracingInstrumentation.class);
+  }
+
+  private static class CapturingAppender extends AbstractAppender {
+
+    private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+    private CapturingAppender() {
+      super("graphql-tail-sample-tracing-test", null, null, false, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      events.add(event.toImmutable());
+    }
+
+    private List<String> messages() {
+      return events.stream().map(event -> event.getMessage().getFormattedMessage()).toList();
+    }
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentationTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/graphql/GraphQLTailSampleTracingInstrumentationTest.java
@@ -49,16 +49,15 @@ import org.junit.jupiter.api.Test;
 class GraphQLTailSampleTracingInstrumentationTest {
 
   @Test
-  void givenSlowQuery_whenExecutionCompletes_thenLogsTraceWarning() throws Exception {
+  void givenSlowNamedQueryWithoutOperationParameter_whenExecutionCompletes_thenLogsTraceWarning()
+      throws Exception {
     var appender = attachAppender();
     try {
       var instrumentation = newInstrumentation(config(1, Map.of("Query.HighTempAlert", 1L)));
       var state = instrumentation.createState(mock(InstrumentationCreateStateParameters.class));
       var executionContext =
           instrumentation.beginExecution(
-              executionParameters(
-                  "query HighTempAlertQuery { HighTempAlert }", "HighTempAlertQuery"),
-              state);
+              executionParameters("query HighTempAlertQuery { HighTempAlert }", null), state);
       var environment = environment("Query", "HighTempAlert", "/HighTempAlert");
       DataFetcher<?> fetcher = env -> "result";
 

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/GraphQLTailSampleTracingContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/GraphQLTailSampleTracingContainerIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.container.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.datasqrl.env.EnvVariableNames;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import lombok.SneakyThrows;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class GraphQLTailSampleTracingContainerIT {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @RegisterExtension
+  static SqrlContainerExtension sqrl = new SqrlContainerExtension("server-functions");
+
+  @RegisterExtension
+  static PostgresContainerExtension postgres =
+      new PostgresContainerExtension(sqrl, GraphQLTailSampleTracingContainerIT::executeStatements);
+
+  private static void executeStatements(Statement stmt) throws SQLException {
+    stmt.execute(
+        "CREATE TABLE IF NOT EXISTS \"Customers\" ("
+            + "\"customerid\" BIGINT NOT NULL,"
+            + "\"email\" TEXT NOT NULL,"
+            + "\"name\" TEXT NOT NULL,"
+            + "\"lastUpdated\" BIGINT NOT NULL,"
+            + "\"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL,"
+            + "PRIMARY KEY (\"customerid\",\"lastUpdated\"))");
+
+    stmt.execute(
+        "INSERT INTO \"Customers\" VALUES (1, 'bob.jones@example.com', 'Bob Jones', 1730700002000, '2025-11-11T00:00:00Z')");
+  }
+
+  @Test
+  @SneakyThrows
+  void givenTailSampleTracingEnabled_whenGraphQLQueryHasMultipleFields_thenWarnTraceIsLogged() {
+    postgres.startPostgreSQLContainer();
+    sqrl.compileSqrlProject();
+    applyTestTailSampleTracingConfig();
+
+    sqrl.startGraphQLServer(
+        container ->
+            container
+                .withEnv(EnvVariableNames.POSTGRES_HOST, "postgresql")
+                .withEnv(EnvVariableNames.POSTGRES_USERNAME, postgres.getPostgresql().getUsername())
+                .withEnv(EnvVariableNames.POSTGRES_PASSWORD, postgres.getPostgresql().getPassword())
+                .withEnv(
+                    EnvVariableNames.POSTGRES_DATABASE, postgres.getPostgresql().getDatabaseName())
+                .withEnv(EnvVariableNames.KAFKA_BOOTSTRAP_SERVERS, "localhost:9092"));
+
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query TailTrace { CustomersByName(inputName: \\\"Bobblabla\\\") { customerid name } CustomersById(a: 15, b: 10) { customerid name } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      var responseJson = MAPPER.readTree(EntityUtils.toString(response.getEntity()));
+      assertThat(responseJson.has("errors")).isFalse();
+      assertThat(responseJson.at("/data/CustomersByName/0/name").asText()).isEqualTo("Bob Jones");
+      assertThat(responseJson.at("/data/CustomersById/0/name").asText()).isEqualTo("Bob Jones");
+    }
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              var event = getTailTraceLogEvent();
+              assertThat(event.get("event").asText()).isEqualTo("sqrl.graphql.query.tail_trace");
+              assertThat(event.get("operationName").asText()).isEqualTo("TailTrace");
+              assertThat(event.get("sampleReason").asText()).isEqualTo("slow");
+              assertThat(event.get("thresholdMs").asLong()).isEqualTo(1);
+              assertThat(event.get("fields")).hasSizeGreaterThanOrEqualTo(2);
+              assertThat(event.get("fields").findValuesAsText("path"))
+                  .contains("/CustomersByName", "/CustomersById");
+            });
+  }
+
+  @SneakyThrows
+  private void applyTestTailSampleTracingConfig() {
+    var configPath = sqrl.getTestDir().resolve("build/deploy/plan/vertx-config.json");
+    var config = (ObjectNode) MAPPER.readTree(configPath.toFile());
+    var tracingConfig = MAPPER.createObjectNode();
+    tracingConfig.put("enabled", true);
+    tracingConfig.put("defaultThresholdMs", 1);
+    tracingConfig.put("maxLoggedTracesPerMinute", 0);
+    tracingConfig.put("maxFieldTraces", 10);
+    config.set("graphQLTailSampleTracingConfig", tracingConfig);
+    MAPPER.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config);
+  }
+
+  @SneakyThrows
+  private JsonNode getTailTraceLogEvent() {
+    var marker = "{\"event\":\"sqrl.graphql.query.tail_trace\"";
+    var logs = sqrl.getServerContainer().getLogs();
+    var eventStart = logs.indexOf(marker);
+    assertThat(eventStart)
+        .as("Expected tail trace event in server logs:\n%s", logs)
+        .isNotNegative();
+
+    var eventEnd = logs.indexOf(System.lineSeparator(), eventStart);
+    var eventJson =
+        eventEnd < 0 ? logs.substring(eventStart) : logs.substring(eventStart, eventEnd);
+    return MAPPER.readTree(eventJson);
+  }
+}

--- a/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/GraphQLTailSampleTracingContainerIT.java
+++ b/sqrl-testing/sqrl-testing-container/src/test/java/com/datasqrl/container/testing/GraphQLTailSampleTracingContainerIT.java
@@ -98,6 +98,54 @@ public class GraphQLTailSampleTracingContainerIT {
             });
   }
 
+  @Test
+  @SneakyThrows
+  void givenDefaultThresholdAndLowQueryThreshold_whenGraphQLQueryRuns_thenWarnTraceIsLogged() {
+    postgres.startPostgreSQLContainer();
+    sqrl.compileSqrlProject();
+    applyQuerySpecificTailSampleTracingConfig();
+
+    sqrl.startGraphQLServer(
+        container ->
+            container
+                .withEnv(EnvVariableNames.POSTGRES_HOST, "postgresql")
+                .withEnv(EnvVariableNames.POSTGRES_USERNAME, postgres.getPostgresql().getUsername())
+                .withEnv(EnvVariableNames.POSTGRES_PASSWORD, postgres.getPostgresql().getPassword())
+                .withEnv(
+                    EnvVariableNames.POSTGRES_DATABASE, postgres.getPostgresql().getDatabaseName())
+                .withEnv(EnvVariableNames.KAFKA_BOOTSTRAP_SERVERS, "localhost:9092"));
+
+    try (var response =
+        sqrl.executeGraphQLQuery(
+            "{\"query\":\"query QuerySpecificTailTrace { CustomersByName(inputName: \\\"Bobblabla\\\") { customerid name } CustomersById(a: 15, b: 10) { customerid name } }\"}")) {
+      assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+      var responseJson = MAPPER.readTree(EntityUtils.toString(response.getEntity()));
+      assertThat(responseJson.has("errors")).isFalse();
+      assertThat(responseJson.at("/data/CustomersByName/0/name").asText()).isEqualTo("Bob Jones");
+      assertThat(responseJson.at("/data/CustomersById/0/name").asText()).isEqualTo("Bob Jones");
+    }
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              var event = getTailTraceLogEvent();
+              assertThat(event.get("operationName").asText()).isEqualTo("QuerySpecificTailTrace");
+              assertThat(event.get("sampleReason").asText()).isEqualTo("slow");
+              assertThat(event.get("thresholdMs").asLong()).isEqualTo(1);
+              assertThat(event.get("fields")).hasSizeGreaterThanOrEqualTo(2);
+              assertThat(event.get("fields").findValuesAsText("path"))
+                  .contains("/CustomersByName", "/CustomersById");
+              assertThat(event.get("fields"))
+                  .anySatisfy(
+                      field -> {
+                        assertThat(field.get("path").asText()).isEqualTo("/CustomersByName");
+                        assertThat(field.get("thresholdMs").asLong()).isEqualTo(1);
+                      });
+            });
+  }
+
   @SneakyThrows
   private void applyTestTailSampleTracingConfig() {
     var configPath = sqrl.getTestDir().resolve("build/deploy/plan/vertx-config.json");
@@ -107,6 +155,22 @@ public class GraphQLTailSampleTracingContainerIT {
     tracingConfig.put("defaultThresholdMs", 1);
     tracingConfig.put("maxLoggedTracesPerMinute", 0);
     tracingConfig.put("maxFieldTraces", 10);
+    config.set("graphQLTailSampleTracingConfig", tracingConfig);
+    MAPPER.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config);
+  }
+
+  @SneakyThrows
+  private void applyQuerySpecificTailSampleTracingConfig() {
+    var configPath = sqrl.getTestDir().resolve("build/deploy/plan/vertx-config.json");
+    var config = (ObjectNode) MAPPER.readTree(configPath.toFile());
+    var tracingConfig = MAPPER.createObjectNode();
+    var thresholds = MAPPER.createObjectNode();
+
+    thresholds.put("Query.CustomersByName", 1);
+    tracingConfig.put("enabled", true);
+    tracingConfig.put("maxLoggedTracesPerMinute", 0);
+    tracingConfig.put("maxFieldTraces", 10);
+    tracingConfig.set("thresholds", thresholds);
     config.set("graphQLTailSampleTracingConfig", tracingConfig);
     MAPPER.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config);
   }


### PR DESCRIPTION
## Key Changes

- Added tail-sampled GraphQL tracing for SQRL-backed queries.
- Logs structured `WARN` events for slow or failed GraphQL executions.
- Supports default and per-query latency thresholds.
- Adds per-minute log rate limiting and bounded field trace output.
- Uses Jackson-serialized POJOs for trace log events.
- Wires tracing through `GraphQLServerVerticle` via `GraphQLTailSampleTracingConfig`.
- Adds unit tests for fast, slow, failed, and unregistered query cases.

## TODO

- [x] Add integration and maybe a container test