### PR TITLE
feat: Add JSON logging for SQRL Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -682,6 +682,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-layout-template-json</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>

--- a/sqrl-server/sqrl-server-vertx-base/pom.xml
+++ b/sqrl-server/sqrl-server-vertx-base/pom.xml
@@ -267,6 +267,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 


### PR DESCRIPTION
These dependencies are needed by the SQRL Server to be able to output logs in JSON format using `JsonTemplateLayout`, which is advised to use instead of the deprecated `JsonLayout`