### PR TITLE
fix: Remove `scan.startup.mode` prop from Kafka mutation tables using `upsert-kafka`

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
@@ -217,6 +217,8 @@ public class KafkaLogEngine extends ExecutionEngine.Base implements LogEngine {
       connectorConfig.put(
           FlinkConnectorConfigWrapper.CONNECTOR_KEY,
           UPSERT_FORMAT.formatted(connectorConfig.get(FlinkConnectorConfigWrapper.CONNECTOR_KEY)));
+      // scan.startup.mode config option is invalid for upsert-kafka
+      connectorConfig.remove("scan.startup.mode");
       topicConfig.put("cleanup.policy", "compact");
     }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -66,7 +66,7 @@ public class UseCaseCompileTest {
   @Test
   @Disabled("Intended for manual usage")
   void runTestCaseByName() {
-    var pkg = USECASE_DIR.resolve("banking").resolve("package.json");
+    var pkg = USECASE_DIR.resolve("temporal-join").resolve("package.json");
     UseCaseTestHelper.testUseCase(
         snapshotExtension,
         getClass(),

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -117,6 +117,7 @@ WITH (
   'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
   'properties.compression.type' = 'zstd',
   'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'scan.startup.mode' = 'earliest-offset',
   'topic' = 'SensorReading',
   'value.fields-include' = 'ALL',
   'value.format' = 'flexible-json'

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/temporal-join/package.json
@@ -12,6 +12,11 @@
       }
     }
   },
+  "connectors": {
+    "kafka-mutation": {
+      "scan.startup.mode": "earliest-offset"
+    }
+  },
   "test-runner": {
     "delay-sec": 30,
     "mutation-delay-sec": 1,


### PR DESCRIPTION
## Key Changes
- Remove `scan.startup.mode` config from `upsert-kafka` mutation tables
- Adapt test usecase to cover the added functionality