### PR TITLE
fix: Emit unquoted parent table name in pg_partman setup SQL

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
@@ -15,8 +15,6 @@
  */
 package com.datasqrl.function.translation.postgres.extensions;
 
-import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifier;
-
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement.PartitionType;
 import com.datasqrl.sql.DatabaseTableExtension;
@@ -57,7 +55,10 @@ public class PgPartmanExtension implements DatabaseTableExtension {
 
   private void appendTableDdl(StringBuilder sb, CreateTableJdbcStatement createTable) {
 
-    var parentTable = "public." + quoteIdentifier(createTable.getName());
+    // pg_partman resolves p_parent_table by matching split_part(name, '.', 2) against
+    // pg_class.relname, so the name must be schema-qualified but NOT identifier-quoted:
+    // 'public."Readings"' never matches relname 'Readings' and create_parent fails.
+    var parentTable = "public." + createTable.getName();
     var ttl = createTable.getTtl();
 
     // p_type was removed in pg_partman 5.x; the default (range) is what we need

--- a/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
@@ -55,14 +55,14 @@ class PgPartmanExtensionTest {
         .contains("CREATE SCHEMA IF NOT EXISTS partman")
         .contains("CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman")
         .contains("SELECT partman.create_parent")
-        .contains("p_parent_table => 'public.\"Orders_1\"'")
+        .contains("p_parent_table => 'public.Orders_1'")
         .contains("p_control => 'time'")
         .contains("p_interval => '1 week'")
         .contains("p_premake => 4")
         .contains("UPDATE partman.part_config")
         .contains("retention = '30 days'")
         .contains("retention_keep_table = false")
-        .contains("WHERE parent_table = 'public.\"Orders_1\"'")
+        .contains("WHERE parent_table = 'public.Orders_1'")
         .doesNotContain("p_type");
   }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -308,7 +308,7 @@ END
     {
       "name" : "partman",
       "type" : "EXTENSION",
-      "sql" : "CREATE SCHEMA IF NOT EXISTS partman;\nCREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.\"OrderUpdates_1\"',\n    p_control => 'time',\n    p_interval => '1 week',\n    p_premake => 4\n);\n\nUPDATE partman.part_config\n   SET retention = '30 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.\"OrderUpdates_1\"';"
+      "sql" : "CREATE SCHEMA IF NOT EXISTS partman;\nCREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.OrderUpdates_1',\n    p_control => 'time',\n    p_interval => '1 week',\n    p_premake => 4\n);\n\nUPDATE partman.part_config\n   SET retention = '30 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.OrderUpdates_1';"
     }
   ]
 }


### PR DESCRIPTION
## What
- `PgPartmanExtension` no longer identifier-quotes the table name passed to `partman.create_parent` / stored in `partman.part_config` — emits `public.Readings` instead of `public."Readings"`
- Updated `PgPartmanExtensionTest` expectations and the `DAGPlannerTest/partitionTest.txt` snapshot

## Why
- pg_partman 5.x resolves `p_parent_table` by matching `split_part(name, '.', 2)` against `pg_catalog.pg_class.relname`; a quoted name (`"Readings"`, with literal quote characters) never matches the relname (`Readings`), so `create_parent` raises `Unable to find given parent table in system catalogs`
- In CNPG deployments this SQL runs as `postInitApplicationSQLRefs`, so the failure kills initdb and the database cluster never bootstraps (found via `PgPartmanEndToEndCT` in cloud-compilation)
- Verified against the `postgres-partman:18-partman-5.4.3` image: quoted form reproduces the error, unquoted form creates the partition set