### PR TITLE
feat: Add `RAW_JSON` alias to the custom `FlinkJsonType`

### DIFF
--- a/sqrl-planner/pom.xml
+++ b/sqrl-planner/pom.xml
@@ -151,6 +151,10 @@
     </dependency>
     <dependency>
       <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-text</artifactId>
     </dependency>
     <dependency>

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
@@ -16,6 +16,8 @@
 package com.datasqrl.engine.stream.flink;
 
 import com.datasqrl.calcite.schema.sql.SqlDataTypeSpecBuilder;
+import com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType;
+import com.datasqrl.flinkrunner.stdlib.json.FlinkJsonTypeSerializer;
 import com.datasqrl.planner.util.NonSecretEnvVarResolver;
 import com.datasqrl.sql.SqlCallRewriter;
 import jakarta.annotation.Nullable;
@@ -33,6 +35,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlLiteral;
@@ -56,11 +59,17 @@ import org.apache.flink.sql.parser.ddl.table.SqlCreateTableLike;
 import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
 import org.apache.flink.sql.parser.ddl.view.SqlCreateView;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.type.SqlRawTypeNameSpec;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.types.logical.RawType;
 
 public class FlinkSqlNodes {
 
   public static final SqlDistribution NO_DISTRIBUTION = null;
+
+  private static final String RAW_JSON = "RAW_JSON";
+  private static final RawType<FlinkJsonType> RAW_JSON_TYPE =
+      new RawType<>(FlinkJsonType.class, new FlinkJsonTypeSerializer());
 
   public static SqlIdentifier identifier(String str) {
     return new SqlIdentifier(str, SqlParserPos.ZERO);
@@ -189,6 +198,109 @@ public class FlinkSqlNodes {
         createStringLiteral(createTable.getComment()),
         createTable.isTemporary(),
         createTable.ifNotExists);
+  }
+
+  /**
+   * Replaces the RAW_JSON column type alias with the actual RAW type used by the Flink JSON
+   * functions.
+   */
+  public static SqlCreateTable resolveRawJsonTypAliases(SqlCreateTable createTable) {
+    var columns = new ArrayList<SqlNode>(createTable.getColumnList().size());
+    var changed = false;
+    for (var column : createTable.getColumnList()) {
+      var resolvedColumn = resolveRawJsonType(column);
+      columns.add(resolvedColumn);
+      changed |= resolvedColumn != column;
+    }
+
+    if (!changed) {
+      return createTable;
+    }
+
+    var resolvedColumns = new SqlNodeList(columns, createTable.getColumnList().getParserPosition());
+    if (createTable instanceof SqlCreateTableLike likeTable) {
+      return new SqlCreateTableLike(
+          likeTable.getParserPosition(),
+          likeTable.getName(),
+          resolvedColumns,
+          likeTable.getTableConstraints(),
+          createProperties(likeTable.getProperties()),
+          likeTable.getDistribution(),
+          createPartitionKeys(likeTable.getPartitionKeyList()),
+          likeTable.getWatermark().orElse(null),
+          createStringLiteral(likeTable.getComment()),
+          likeTable.getTableLike(),
+          likeTable.isTemporary(),
+          likeTable.ifNotExists);
+    }
+
+    return new SqlCreateTable(
+        createTable.getParserPosition(),
+        createTable.getName(),
+        resolvedColumns,
+        createTable.getTableConstraints(),
+        createProperties(createTable.getProperties()),
+        createTable.getDistribution(),
+        createPartitionKeys(createTable.getPartitionKeyList()),
+        createTable.getWatermark().orElse(null),
+        createStringLiteral(createTable.getComment()),
+        createTable.isTemporary(),
+        createTable.ifNotExists);
+  }
+
+  private static SqlNode resolveRawJsonType(SqlNode column) {
+    if (column instanceof SqlRegularColumn regularColumn
+        && isRawJsonType(regularColumn.getType())) {
+
+      return new SqlRegularColumn(
+          regularColumn.getParserPosition(),
+          regularColumn.getName(),
+          createStringLiteral(regularColumn.getComment()),
+          createFlexibleJsonRawType(regularColumn.getType()),
+          regularColumn.getConstraint().orElse(null));
+    }
+
+    if (column instanceof SqlMetadataColumn metadataColumn
+        && isRawJsonType(metadataColumn.getType())) {
+
+      var metadataAlias =
+          metadataColumn.getMetadataAlias().map(FlinkSqlNodes::createStringLiteral).orElse(null);
+
+      return new SqlMetadataColumn(
+          metadataColumn.getParserPosition(),
+          metadataColumn.getName(),
+          createStringLiteral(metadataColumn.getComment()),
+          createFlexibleJsonRawType(metadataColumn.getType()),
+          metadataAlias,
+          metadataColumn.isVirtual());
+    }
+
+    return column;
+  }
+
+  private static boolean isRawJsonType(SqlDataTypeSpec type) {
+    var typeName = type.getTypeNameSpec().getTypeName();
+    return typeName != null && RAW_JSON.equalsIgnoreCase(typeName.getSimple());
+  }
+
+  private static SqlDataTypeSpec createFlexibleJsonRawType(SqlDataTypeSpec originalType) {
+    var originalPosition = originalType.getParserPosition();
+    var rawTypeSql = RAW_JSON_TYPE.asSerializableString();
+
+    var position =
+        new SqlParserPos(
+            originalPosition.getLineNum(),
+            originalPosition.getColumnNum(),
+            originalPosition.getLineNum(),
+            originalPosition.getColumnNum() + rawTypeSql.length() - 1);
+
+    var rawTypeName =
+        new SqlRawTypeNameSpec(
+            SqlLiteral.createCharString(RAW_JSON_TYPE.getOriginatingClass().getName(), position),
+            SqlLiteral.createCharString(RAW_JSON_TYPE.getSerializerString(), position),
+            position);
+
+    return new SqlDataTypeSpec(rawTypeName, position).withNullable(originalType.getNullable());
   }
 
   public static SqlNodeList createProperties(Map<String, String> options) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -837,6 +837,7 @@ public class Sqrl2FlinkSQLTranslator {
     var tableSqlNode = parseSQL(createTableSql);
     checkArgument(tableSqlNode instanceof SqlCreateTable, "Expected CREATE TABLE statement");
     var tableDefinition = FlinkSqlNodes.resolveTableProperties((SqlCreateTable) tableSqlNode);
+    tableDefinition = FlinkSqlNodes.resolveRawJsonTypAliases(tableDefinition);
     var fullTable = tableDefinition;
     var origTableName = fullTable.getName().getSimple();
     final var finalTableName = tableNameModifier.apply(origTableName);

--- a/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
@@ -232,7 +232,7 @@ public class GraphQLSchemaConverter {
     List<ApiOperation> functions = new ArrayList<>();
 
     List<GraphQLFieldDefinition> queries =
-        Optional.ofNullable(schema.getQueryType())
+        Optional.of(schema.getQueryType())
             .map(GraphQLObjectType::getFieldDefinitions)
             .orElse(List.of());
     List<GraphQLFieldDefinition> mutations =
@@ -269,23 +269,24 @@ public class GraphQLSchemaConverter {
       return convert(((NonNullType) type).getType(), schema);
     }
     Argument argument = new Argument();
-    if (type instanceof ListType) {
+    if (type instanceof ListType listType) {
       argument.setType("array");
-      argument.setItems(convert(((ListType) type).getType(), schema));
-    } else if (type instanceof TypeName) {
-      String typeName = ((TypeName) type).getName();
-      GraphQLType graphQLType = schema.getType(typeName);
+      argument.setItems(convert(listType.getType(), schema));
+    } else if (type instanceof TypeName typeName) {
+      GraphQLType graphQLType = schema.getType(typeName.getName());
       if (graphQLType instanceof GraphQLInputType graphQLInputType) {
         return GraphQLSchemaConverter.this.convert(graphQLInputType);
       } else {
         throw new UnsupportedOperationException(
             "Unexpected type [" + typeName + "] with class: " + graphQLType);
       }
-    } else throw new UnsupportedOperationException("Unexpected type:  " + type);
+    } else {
+      throw new UnsupportedOperationException("Unexpected type:  " + type);
+    }
     return argument;
   }
 
-  private record Context(String opName, String prefix, int numArgs, List<GraphQLObjectType> path) {
+  public record Context(String opName, String prefix, int numArgs, List<GraphQLObjectType> path) {
 
     public Context nested(String fieldName, GraphQLObjectType type, int additionalArgs) {
       List<GraphQLObjectType> nestedPath = new ArrayList<>(path);
@@ -395,8 +396,8 @@ public class GraphQLSchemaConverter {
 
   public String convertScalarTypeToJsonType(GraphQLScalarType scalarType) {
     return switch (scalarType.getName()) {
-      case "Int" -> "integer";
-      case "Long" -> "integer";
+      case "JSON" -> null;
+      case "Int", "Long" -> "integer";
       case "Float" -> "number";
       case "String" -> "string";
       case "Boolean" -> "boolean";
@@ -413,8 +414,7 @@ public class GraphQLSchemaConverter {
       Context ctx,
       GraphQLSchemaConverterConfig config) {
     GraphQLOutputType type = unwrapType(fieldDef.getType());
-    if (type instanceof GraphQLObjectType) {
-      GraphQLObjectType objectType = (GraphQLObjectType) type;
+    if (type instanceof GraphQLObjectType objectType) {
       // Don't recurse in a cycle or if depth limit is exceeded
       if (ctx.path().contains(objectType)) {
         log.info("Detected cycle on operation `{}`. Aborting traversal.", ctx.opName());
@@ -487,8 +487,7 @@ public class GraphQLSchemaConverter {
       }
       queryBody.append(")");
     }
-    if (type instanceof GraphQLObjectType) {
-      GraphQLObjectType objectType = (GraphQLObjectType) type;
+    if (type instanceof GraphQLObjectType objectType) {
       List<GraphQLObjectType> nestedPath = new ArrayList<>(ctx.path());
       nestedPath.add(objectType);
       queryBody.append(" {\n");

--- a/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
@@ -37,12 +37,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import graphql.parser.Parser;
 import graphql.schema.GraphQLScalarType;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -111,17 +108,6 @@ public class GraphQLSchemaConverterTest {
         GraphQLSchemaConverterConfig.DEFAULT, underTest.getSchema(schemaString));
   }
 
-  @Test
-  @Disabled
-  public void testSchemaConversion() throws IOException {
-    String schemaString =
-        Files.readString(
-            Path.of(
-                "../../../datasqrl-examples/finance-credit-card-chatbot/creditcard-analytics.graphqls"));
-    String result = convertToJsonDefault(getFunctions(schemaString));
-    System.out.println(result);
-  }
-
   @SneakyThrows
   public static String convertToJsonDefault(List<ApiOperation> functions) {
     return toJsonString(functions);
@@ -162,6 +148,29 @@ public class GraphQLSchemaConverterTest {
     snapshot(functions, "rick-morty");
   }
 
+  @Test
+  @SneakyThrows
+  void givenJsonArgument_whenConvertSchema_thenCreatesUnconstrainedJsonSchema() {
+    var schema =
+        underTest.getSchema(
+            """
+            scalar JSON
+            type Query {
+              lookup(payload: JSON): String
+            }
+            """);
+
+    var functions = underTest.convertSchema(GraphQLSchemaConverterConfig.DEFAULT, schema);
+    var payload = functions.get(0).getFunction().getParameters().getProperties().get("payload");
+    var payloadSchema =
+        new ObjectMapper()
+            .readTree(toJsonString(functions))
+            .at("/0/function/parameters/properties/payload");
+
+    assertThat(payload.getType()).isNull();
+    assertThat(payloadSchema.has("type")).isFalse();
+  }
+
   @ParameterizedTest
   @MethodSource("scalarTypeToJsonTypeProvider")
   void givenScalarType_whenConvertToJsonType_thenReturnsExpectedJsonType(
@@ -180,7 +189,8 @@ public class GraphQLSchemaConverterTest {
         Arguments.of(GraphQLFloat, "number"),
         Arguments.of(GraphQLString, "string"),
         Arguments.of(GraphQLBoolean, "boolean"),
-        Arguments.of(GraphQLID, "string"));
+        Arguments.of(GraphQLID, "string"),
+        Arguments.of(CustomScalars.JSON, null));
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/stream/flink/plan/FlinkSqlNodesTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/stream/flink/plan/FlinkSqlNodesTest.java
@@ -26,11 +26,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlUserDefinedTypeNameSpec;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
+import org.apache.flink.sql.parser.ddl.table.SqlCreateTableLike;
+import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
+import org.apache.flink.sql.parser.type.SqlRawTypeNameSpec;
 import org.junit.jupiter.api.Test;
 
 class FlinkSqlNodesTest {
@@ -173,5 +181,70 @@ class FlinkSqlNodesTest {
     var sql = unparse(partitionKeysNode);
     var expectedSql = "`year`, `month`, `day`";
     assertThat(sql.trim()).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void resolveRawJsonTypAliases() {
+    var position = new SqlParserPos(3, 20, 3, 32);
+    var rawJsonType =
+        new SqlDataTypeSpec(new SqlUserDefinedTypeNameSpec("RAW_JSON", position), position)
+            .withNullable(false);
+    var regularColumn =
+        new SqlRegularColumn(
+            position,
+            FlinkSqlNodes.identifier("payload"),
+            FlinkSqlNodes.createStringLiteral("payload comment"),
+            rawJsonType,
+            null);
+    var metadataColumn =
+        new SqlMetadataColumn(
+            position,
+            FlinkSqlNodes.identifier("event_time"),
+            FlinkSqlNodes.createStringLiteral("metadata comment"),
+            rawJsonType,
+            SqlLiteral.createCharString("timestamp", position),
+            true);
+    var tableLike = new SqlTableLike(position, FlinkSqlNodes.identifier("base_table"), List.of());
+    var table =
+        new SqlCreateTableLike(
+            position,
+            FlinkSqlNodes.identifier("source_table"),
+            new SqlNodeList(List.of(regularColumn, metadataColumn), position),
+            List.of(),
+            FlinkSqlNodes.createProperties(Map.of("connector", "kafka")),
+            FlinkSqlNodes.NO_DISTRIBUTION,
+            SqlNodeList.EMPTY,
+            null,
+            FlinkSqlNodes.createStringLiteral("table comment"),
+            tableLike,
+            true,
+            true);
+
+    var resolved = FlinkSqlNodes.resolveRawJsonTypAliases(table);
+
+    assertThat(resolved).isInstanceOf(SqlCreateTableLike.class);
+    assertThat(((SqlCreateTableLike) resolved).getTableLike()).isSameAs(tableLike);
+    assertThat(resolved.getProperties()).isEqualTo(table.getProperties());
+    assertThat(resolved.getColumnList().get(0)).isInstanceOf(SqlRegularColumn.class);
+    assertThat(resolved.getColumnList().get(1)).isInstanceOf(SqlMetadataColumn.class);
+
+    var resolvedRegularColumn = (SqlRegularColumn) resolved.getColumnList().get(0);
+    assertThat(resolvedRegularColumn.getType().getTypeNameSpec())
+        .isInstanceOf(SqlRawTypeNameSpec.class);
+    assertThat(resolvedRegularColumn.getType().getNullable()).isFalse();
+    assertThat(resolvedRegularColumn.getComment()).isEqualTo("payload comment");
+    assertThat(resolvedRegularColumn.getType().getParserPosition().getLineNum())
+        .isEqualTo(position.getLineNum());
+    assertThat(resolvedRegularColumn.getType().getParserPosition().getColumnNum())
+        .isEqualTo(position.getColumnNum());
+    assertThat(resolvedRegularColumn.getType().getParserPosition().getEndColumnNum())
+        .isEqualTo(position.getColumnNum() + unparse(resolvedRegularColumn.getType()).length() - 1);
+
+    var resolvedMetadataColumn = (SqlMetadataColumn) resolved.getColumnList().get(1);
+    assertThat(resolvedMetadataColumn.getType().getTypeNameSpec())
+        .isInstanceOf(SqlRawTypeNameSpec.class);
+    assertThat(resolvedMetadataColumn.getMetadataAlias()).contains("timestamp");
+    assertThat(resolvedMetadataColumn.isVirtual()).isTrue();
+    assertThat(resolvedMetadataColumn.getComment()).isEqualTo("metadata comment");
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
@@ -65,8 +65,7 @@ public class FullUseCaseIT {
 
   /** Ad-hoc debugging entry point. Change the path below to run a single use case manually. */
   static Stream<UseCaseParam> specificUseCaseProvider() {
-    return Stream.of(
-        new UseCaseParam(USE_CASES.resolve("function-translation/duckdb").resolve("package.json")));
+    return Stream.of(new UseCaseParam(USE_CASES.resolve("jwt-authorized").resolve("package.json")));
   }
 
   @ParameterizedTest

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -66,7 +66,7 @@ public class UseCaseCompileTest {
   @Test
   @Disabled("Intended for manual usage")
   void runTestCaseByName() {
-    var pkg = USECASE_DIR.resolve("temporal-join").resolve("package.json");
+    var pkg = USECASE_DIR.resolve("jwt-authorized").resolve("package.json");
     UseCaseTestHelper.testUseCase(
         snapshotExtension,
         getClass(),

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -644,9 +644,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
             "parameters" : {
               "type" : "object",
               "properties" : {
-                "payload" : {
-                  "type" : "string"
-                }
+                "payload" : { }
               },
               "required" : [ ]
             }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -2,18 +2,18 @@
 type AuthInputData {
   event_id: String!
   val: Long!
-  message: String!
+  payload: JSON
   event_time: DateTime!
 }
 
 input AuthInputDataInput {
-  message: String!
+  payload: JSON
 }
 
 type AuthInputDataResultOutput {
   event_id: String!
   val: Long!
-  message: String!
+  payload: JSON
   event_time: DateTime!
 }
 
@@ -82,7 +82,7 @@ Row count:   ~1e8
 Schema:
  - event_id: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - val: BIGINT NOT NULL
- - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - payload: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
 Inputs:
  - default_catalog.default_database.AuthInputData__base
@@ -166,12 +166,12 @@ Type:        stream
 Stage:       flink
 Primary key: event_id
 Timestamp:   event_time
-Row count:   ~5e7
+Row count:   ~9e7
 ---
 Schema:
  - event_id: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
  - val: BIGINT NOT NULL
- - message: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - payload: RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
  - event_time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
 Inputs:
  - default_catalog.default_database.AuthInputData
@@ -202,7 +202,7 @@ FROM (VALUES ROW('a'),
 CREATE TABLE `AuthInputData` (
   `event_id` STRING NOT NULL,
   `val` BIGINT NOT NULL,
-  `message` STRING NOT NULL,
+  `payload` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
   `event_time` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
   WATERMARK FOR `event_time` AS `event_time` - INTERVAL '0.0' SECOND
 )
@@ -219,7 +219,7 @@ CREATE VIEW `_Messages`
 AS
 SELECT *
 FROM `AuthInputData`
-WHERE `message` <> '';
+WHERE `payload` IS NOT NULL;
 CREATE TABLE `MyStringTable_1` (
   `val` CHAR(1) CHARACTER SET `UTF-16LE` NOT NULL,
   PRIMARY KEY (`val`) NOT ENFORCED
@@ -247,7 +247,7 @@ WITH (
 CREATE TABLE `_Messages_3` (
   `event_id` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
   `val` BIGINT NOT NULL,
-  `message` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `payload` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
   `event_time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL
 )
 WITH (
@@ -644,18 +644,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
             "parameters" : {
               "type" : "object",
               "properties" : {
-                "message" : {
+                "payload" : {
                   "type" : "string"
                 }
               },
-              "required" : [
-                "message"
-              ]
+              "required" : [ ]
             }
           },
           "format" : "JSON",
           "apiQuery" : {
-            "query" : "mutation AuthInputData($message: String!) {\nAuthInputData(event: { message: $message }) {\nevent_id\nval\nmessage\nevent_time\n}\n\n}",
+            "query" : "mutation AuthInputData($payload: JSON) {\nAuthInputData(event: { payload: $payload }) {\nevent_id\nval\npayload\nevent_time\n}\n\n}",
             "queryName" : "AuthInputData",
             "operationType" : "MUTATION"
           },
@@ -666,7 +664,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "type AuthInputData {\n  event_id: String!\n  val: Long!\n  message: String!\n  event_time: DateTime!\n}\n\ninput AuthInputDataInput {\n  message: String!\n}\n\ntype AuthInputDataResultOutput {\n  event_id: String!\n  val: Long!\n  message: String!\n  event_time: DateTime!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Mutation {\n  AuthInputData(event: AuthInputDataInput!): AuthInputDataResultOutput!\n}\n\ntype MyStringTable {\n  val: String!\n}\n\ntype MyTable {\n  val: Int!\n}\n\ntype Query {\n  MyStringTable(limit: Int = 10, offset: Int = 0): [MyStringTable!]\n  MyTable(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthMyTable(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthMyTableValues(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthStringMyTableValues(limit: Int = 10, offset: Int = 0): [MyStringTable!]\n}\n\ntype Subscription {\n  MessageSubscription: AuthInputData\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+        "schema" : "type AuthInputData {\n  event_id: String!\n  val: Long!\n  payload: JSON\n  event_time: DateTime!\n}\n\ninput AuthInputDataInput {\n  payload: JSON\n}\n\ntype AuthInputDataResultOutput {\n  event_id: String!\n  val: Long!\n  payload: JSON\n  event_time: DateTime!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Mutation {\n  AuthInputData(event: AuthInputDataInput!): AuthInputDataResultOutput!\n}\n\ntype MyStringTable {\n  val: String!\n}\n\ntype MyTable {\n  val: Int!\n}\n\ntype Query {\n  MyStringTable(limit: Int = 10, offset: Int = 0): [MyStringTable!]\n  MyTable(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthMyTable(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthMyTableValues(limit: Int = 10, offset: Int = 0): [MyTable!]\n  AuthStringMyTableValues(limit: Int = 10, offset: Int = 0): [MyStringTable!]\n}\n\ntype Subscription {\n  MessageSubscription: AuthInputData\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
       }
     }
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/jwt-authorized.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/jwt-authorized.sqrl
@@ -4,11 +4,11 @@ IMPORT jwt-authorized-base.*;
 CREATE TABLE AuthInputData (
     event_id STRING NOT NULL METADATA FROM 'uuid',
     val BIGINT NOT NULL METADATA FROM 'auth.val',
-    message STRING NOT NULL,
+    payload RAW_JSON,
     event_time TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp'
 );
 
-_Messages := SELECT * FROM AuthInputData WHERE message <> '';
+_Messages := SELECT * FROM AuthInputData WHERE payload IS NOT NULL;
 
 MessageSubscription(val BIGINT NOT NULL METADATA FROM 'auth.val') :=
                 SUBSCRIBE SELECT * FROM _Messages WHERE val = :val;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/snapshots/AuthInputData-valid-subscription.snapshot
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/snapshots/AuthInputData-valid-subscription.snapshot
@@ -2,14 +2,18 @@
   "data" : {
     "MessageSubscription" : {
       "val" : 1,
-      "message" : "Hello"
+      "payload" : {
+        "message" : "Hello"
+      }
     }
   }
 }, {
   "data" : {
     "MessageSubscription" : {
       "val" : 1,
-      "message" : "World"
+      "payload" : {
+        "message" : "World"
+      }
     }
   }
 } ]

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/tests/AuthInputData-valid-mutation.graphql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/tests/AuthInputData-valid-mutation.graphql
@@ -1,8 +1,8 @@
 mutation {
-  mut1: AuthInputData(event: {message: "Hello"}) {
+  mut1: AuthInputData(event: {payload: {message: "Hello"}}) {
     val
   }
-  mut2: AuthInputData(event: {message: "World"}) {
+  mut2: AuthInputData(event: {payload: {message: "World"}}) {
     val
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/tests/AuthInputData-valid-subscription.graphql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/jwt-authorized/tests/AuthInputData-valid-subscription.graphql
@@ -1,6 +1,6 @@
 subscription {
   MessageSubscription {
     val
-    message
+    payload
   }
 }


### PR DESCRIPTION
## Key Changes
- Added `RAW_JSON` type alias so it's not necessary to use the complete raw representation as col type (see below)
  - It only gets resolved in `CREATE TABLE ...` statements, after the statement got parsed into an `SqlNode`
- Wired in the alias resolution to `Sqrl2FlinkSQLTranslator`
- Updated GraphQL -> JSON type converter to not assign any specific JSON-type to the `JSON` GraphQL scalar, so it can represent any kind of JSON
- Updated `jwt-authorized` usecase to use `RAW_JSON` in a mutation table

```
RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM=')
```

> [!IMPORTANT]
> The current CI failures are expected. This change requires https://github.com/DataSQRL/flink-sql-runner/pull/368 to be merged.