### PR TITLE
ci: Mirror tagged releases to GHCR alongside Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,6 +402,8 @@ jobs:
             set -x
 
             # Push to Docker Hub for tagged releases (datasqrl/*) and main=:dev (datasqrl/*).
+            # Tagged releases are also mirrored to ghcr.io/datasqrl/* so downstream can pull
+            # without hitting Docker Hub rate limits.
             # Push PR images to ghcr.io/datasqrl/* so downstream CI (e.g. datasqrl-examples) can
             # validate examples against the snapshot built from this PR.
             if [ "$IS_RELEASE" != "true" ] && [ "$TAG_SUFFIX" != "dev" ] && [[ "$TAG_SUFFIX" != pr-* ]]; then
@@ -446,11 +448,18 @@ jobs:
               local dir="$1"  ; shift
               local extra_args="$@"
 
+              # Mirror releases to GHCR alongside Docker Hub so downstream can pull
+              # without hitting Docker Hub rate limits.
+              local tags=(-t $REGISTRY/$repo:$TAG_SUFFIX)
+              if [ "$IS_RELEASE" = "true" ]; then
+                tags+=(-t ghcr.io/datasqrl/$repo:$TAG_SUFFIX)
+              fi
+
               docker buildx build \
                 --platform linux/amd64,linux/arm64 \
                 --push \
                 $extra_args \
-                -t $REGISTRY/$repo:$TAG_SUFFIX \
+                "${tags[@]}" \
                 -f $dir/Dockerfile \
                 $dir
 
@@ -459,6 +468,11 @@ jobs:
                 docker buildx imagetools create \
                   -t $REGISTRY/$repo:latest \
                   $REGISTRY/$repo:$TAG_SUFFIX
+                if [ "$IS_RELEASE" = "true" ]; then
+                  docker buildx imagetools create \
+                    -t ghcr.io/datasqrl/$repo:latest \
+                    $REGISTRY/$repo:$TAG_SUFFIX
+                fi
               fi
             }
 


### PR DESCRIPTION
Tagged releases currently publish `cmd` and `sqrl-server` images only to Docker Hub. This mirrors them to `ghcr.io/datasqrl/*` in the same `buildx build` so consumers can pull from GHCR and avoid Docker Hub rate limits.

- Adds a GHCR tag to the release build (single build, pushed to both registries — both are already logged in).
- Mirrors `:latest` to GHCR on stable releases too.
- No change to `:dev` (main) or PR image behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)