### PR TITLE
fix: Preserve relationship fields when ORDER BY uses a column outside the SELECT clause

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -327,6 +327,12 @@ public class Sqrl2FlinkSQLTranslator {
       } else {
         errors.warn("Expected top-level sort on relnode: %s", relNode.explain());
       }
+    } else {
+      /* We keep the sort (e.g. for table functions), but Calcite projects any ORDER BY key that is
+      not in the SELECT clause into the sort's input. Trim those again so the result type stays the
+      declared one - otherwise the extra columns show up in the API and base table (and hence
+      relationship) inference fails because the row types no longer match. */
+      relNode = relRoot.project();
     }
     var analyzer =
         new SQRLLogicalPlanAnalyzer(

--- a/sqrl-planner/src/main/java/com/datasqrl/util/CalciteUtil.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/util/CalciteUtil.java
@@ -38,6 +38,7 @@ import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
@@ -208,6 +209,10 @@ public class CalciteUtil {
 
   public static Optional<Integer> getLimit(RelNode relNode) {
     Optional<Integer> limit = Optional.empty();
+    // A sort whose keys are not all in the SELECT clause is wrapped in a trimming projection
+    if (relNode instanceof Project project) {
+      relNode = project.getInput();
+    }
     if (relNode instanceof Sort sort) {
       limit = SqrlRexUtil.getLimit(sort.fetch);
     }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
@@ -95,11 +95,12 @@ Inputs:
 Annotations:
  - stream-root: Customer
  - parameters: name, vector
- - base-table: CustomersByVector
+ - base-table: CustomerVectorEmbed
 Plan:
-LogicalSort(sort0=[$3], dir0=[DESC-nulls-last])
-  LogicalProject(customerid=[$0], name=[$1], name_vector=[$2], EXPR$3=[cosine_similarity(?1, $2)])
-    LogicalTableScan(table=[[default_catalog, default_database, CustomerVectorEmbed]])
+LogicalProject(customerid=[$0], name=[$1], name_vector=[$2])
+  LogicalSort(sort0=[$3], dir0=[DESC-nulls-last])
+    LogicalProject(customerid=[$0], name=[$1], name_vector=[$2], EXPR$3=[cosine_similarity(?1, $2)])
+      LogicalTableScan(table=[[default_catalog, default_database, CustomerVectorEmbed]])
 SQL:
 CREATE VIEW `CustomersByVector` AS 
                 SELECT * FROM CustomerVectorEmbed ORDER BY cosine_similarity(?      , name_vector) DESC;
@@ -583,7 +584,7 @@ END
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"customerid\", \"name\", \"name_vector\", 1 - (($2 ::vector) <=> \"name_vector\")\nFROM \"CustomerVectorEmbed_2\"\nORDER BY 1 - (($2 ::vector) <=> \"name_vector\") DESC NULLS LAST",
+              "sql" : "SELECT \"customerid\", \"name\", \"name_vector\"\nFROM (SELECT \"customerid\", \"name\", \"name_vector\", 1 - (($2 ::vector) <=> \"name_vector\") AS \"EXPR$3\"\n  FROM \"CustomerVectorEmbed_2\"\n  ORDER BY 1 - (($2 ::vector) <=> \"name_vector\") DESC NULLS LAST) AS \"t1\"",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -722,7 +723,7 @@ END
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "type Customer {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype CustomerVectorEmbed {\n  customerid: Long!\n  name: String!\n}\n\ntype CustomersByVector {\n  customerid: Long!\n  name: String!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  Customer(limit: Int = 10, offset: Int = 0): [Customer!]\n  CustomerVectorEmbed(limit: Int = 10, offset: Int = 0): [CustomerVectorEmbed!]\n  CustomersByName(inputName: String!, limit: Int = 10, offset: Int = 0): [Customer!]\n  CustomersByVector(name: String!, limit: Int = 10, offset: Int = 0): [CustomersByVector!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+        "schema" : "type Customer {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype CustomerVectorEmbed {\n  customerid: Long!\n  name: String!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  Customer(limit: Int = 10, offset: Int = 0): [Customer!]\n  CustomerVectorEmbed(limit: Int = 10, offset: Int = 0): [CustomerVectorEmbed!]\n  CustomersByName(inputName: String!, limit: Int = 10, offset: Int = 0): [Customer!]\n  CustomersByVector(name: String!, limit: Int = 10, offset: Int = 0): [CustomerVectorEmbed!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
       }
     }
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
@@ -26,6 +26,7 @@ type Query {
   cleanQuery(limit: Int = 10, offset: Int = 0): [Thing!]
   joinQuery(limit: Int = 10, offset: Int = 0): [Thing!]
   subqueryQuery(limit: Int = 10, offset: Int = 0): [Thing!]
+  sortedQuery(minId: String!, limit: Int = 10, offset: Int = 0): [Thing!]
 }
 
 type Thing {
@@ -116,6 +117,18 @@ Schema:
 Inputs:
  - default_catalog.default_database.Thing
  - default_catalog.default_database.Tombstone
+
+=== sortedQuery
+ID:          default_catalog.default_database.sortedQuery
+Type:        query
+Stage:       postgres
+---
+Inputs:
+ - default_catalog.default_database.Detail
+ - default_catalog.default_database.Thing
+Annotations:
+ - parameters: minId
+ - base-table: Thing
 
 === subqueryQuery
 ID:          default_catalog.default_database.subqueryQuery
@@ -451,6 +464,41 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "database" : "POSTGRES"
             }
           }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "sortedQuery",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "minId"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"t1\".\"id\", \"t1\".\"label\"\nFROM (SELECT \"Thing\".\"id\", \"Thing\".\"label\", \"Detail\".\"info\"\n  FROM \"Thing\"\n   INNER JOIN \"Detail\" ON \"Thing\".\"id\" = \"Detail\".\"id\"\n  WHERE \"Thing\".\"id\" >= $1\n  ORDER BY \"Detail\".\"info\" DESC NULLS LAST) AS \"t1\"",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "path" : "minId",
+                  "sqlType" : "VARCHAR"
+                }
+              ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
         }
       ],
       "mutations" : [ ],
@@ -611,11 +659,42 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
           "uriTemplate" : "queries/subqueryQuery{?offset,limit}"
+        },
+        {
+          "function" : {
+            "name" : "GetsortedQuery",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                },
+                "minId" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [
+                "minId"
+              ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "query sortedQuery($minId: String!, $limit: Int = 10, $offset: Int = 0) {\nsortedQuery(minId: $minId, limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "sortedQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/sortedQuery{?offset,limit,minId}"
         }
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype Detail {\n  id: String!\n  info: String!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  Detail(limit: Int = 10, offset: Int = 0): [Detail!]\n  Thing(limit: Int = 10, offset: Int = 0): [Thing!]\n  Tombstone(limit: Int = 10, offset: Int = 0): [Tombstone!]\n  cleanQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n  joinQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n  subqueryQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n}\n\ntype Thing {\n  id: String!\n  label: String!\n  detail: Detail\n}\n\ntype Tombstone {\n  id: String!\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+        "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype Detail {\n  id: String!\n  info: String!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  Detail(limit: Int = 10, offset: Int = 0): [Detail!]\n  Thing(limit: Int = 10, offset: Int = 0): [Thing!]\n  Tombstone(limit: Int = 10, offset: Int = 0): [Tombstone!]\n  cleanQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n  joinQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n  subqueryQuery(limit: Int = 10, offset: Int = 0): [Thing!]\n  sortedQuery(minId: String!, limit: Int = 10, offset: Int = 0): [Thing!]\n}\n\ntype Thing {\n  id: String!\n  label: String!\n  detail: Detail\n}\n\ntype Tombstone {\n  id: String!\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
       }
     }
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
@@ -15,11 +15,6 @@ type DocumentSimilarity {
   score: Float
 }
 
-type DocumentSimilarityIndex {
-  doc_id: Int!
-  category_id: Int!
-}
-
 "A JSON scalar"
 scalar JSON
 
@@ -33,7 +28,7 @@ type Query {
   CategoryCentroids(category_id: Int!, limit: Int = 10, offset: Int = 0): [CategoryCentroids!]
   VectorData(limit: Int = 10, offset: Int = 0): [VectorData!]
   DocumentSimilarity(doc_id: Int!, limit: Int = 10, offset: Int = 0): [DocumentSimilarity!]
-  DocumentSimilarityIndex(doc_id: Int!, limit: Int = 10, offset: Int = 0): [DocumentSimilarityIndex!]
+  DocumentSimilarityIndex(doc_id: Int!, limit: Int = 10, offset: Int = 0): [VectorData!]
 }
 
 type VectorData {
@@ -90,7 +85,7 @@ Inputs:
  - default_catalog.default_database.VectorData
 Annotations:
  - parameters: doc_id
- - base-table: DocumentSimilarityIndex
+ - base-table: VectorData
 
 === VectorData
 ID:          default_catalog.default_database.VectorData
@@ -288,7 +283,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"VectorData0\".\"doc_id\", \"VectorData0\".\"category_id\", \"VectorData0\".\"vector\", 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\")\nFROM \"VectorData\"\n INNER JOIN \"VectorData\" AS \"VectorData0\" ON 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\") > 0.5\nWHERE \"VectorData\".\"doc_id\" = $1 AND \"VectorData\".\"doc_id\" <> \"VectorData0\".\"doc_id\"\nORDER BY 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\") DESC NULLS LAST",
+              "sql" : "SELECT \"t1\".\"doc_id\", \"t1\".\"category_id\", \"t1\".\"vector\"\nFROM (SELECT \"VectorData0\".\"doc_id\", \"VectorData0\".\"category_id\", \"VectorData0\".\"vector\", 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\") AS \"EXPR$3\"\n  FROM \"VectorData\"\n   INNER JOIN \"VectorData\" AS \"VectorData0\" ON 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\") > 0.5\n  WHERE \"VectorData\".\"doc_id\" = $1 AND \"VectorData\".\"doc_id\" <> \"VectorData0\".\"doc_id\"\n  ORDER BY 1 - (\"VectorData\".\"vector\" <=> \"VectorData0\".\"vector\") DESC NULLS LAST) AS \"t1\"",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -428,7 +423,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "type CategoryCentroids {\n  category_id: Int!\n  center_vector: [Float]\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype DocumentSimilarity {\n  doc_id: Int!\n  score: Float\n}\n\ntype DocumentSimilarityIndex {\n  doc_id: Int!\n  category_id: Int!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  CategoryCentroids(category_id: Int!, limit: Int = 10, offset: Int = 0): [CategoryCentroids!]\n  VectorData(limit: Int = 10, offset: Int = 0): [VectorData!]\n  DocumentSimilarity(doc_id: Int!, limit: Int = 10, offset: Int = 0): [DocumentSimilarity!]\n  DocumentSimilarityIndex(doc_id: Int!, limit: Int = 10, offset: Int = 0): [DocumentSimilarityIndex!]\n}\n\ntype VectorData {\n  doc_id: Int!\n  category_id: Int!\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+        "schema" : "type CategoryCentroids {\n  category_id: Int!\n  center_vector: [Float]\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype DocumentSimilarity {\n  doc_id: Int!\n  score: Float\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  CategoryCentroids(category_id: Int!, limit: Int = 10, offset: Int = 0): [CategoryCentroids!]\n  VectorData(limit: Int = 10, offset: Int = 0): [VectorData!]\n  DocumentSimilarity(doc_id: Int!, limit: Int = 10, offset: Int = 0): [DocumentSimilarity!]\n  DocumentSimilarityIndex(doc_id: Int!, limit: Int = 10, offset: Int = 0): [VectorData!]\n}\n\ntype VectorData {\n  doc_id: Int!\n  category_id: Int!\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
       }
     }
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/relationship-filter.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/relationship-filter.sqrl
@@ -23,3 +23,9 @@ WHERE id NOT IN (SELECT id FROM Tombstone);
 joinQuery := SELECT th.* FROM Thing th
 LEFT JOIN Tombstone tomb ON th.id = tomb.id
 WHERE tomb.id IS NULL;
+
+-- D) table function ordered by a joined column not in the SELECT list
+sortedQuery(minId String NOT NULL) := SELECT th.* FROM Thing th
+JOIN Detail d ON th.id = d.id
+WHERE th.id >= :minId
+ORDER BY d.info DESC;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/snapshots/sortedQuery.snapshot
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/snapshots/sortedQuery.snapshot
@@ -1,0 +1,20 @@
+{
+  "data" : {
+    "sortedQuery" : [ {
+      "id" : "c",
+      "detail" : {
+        "info" : "detail-c"
+      }
+    }, {
+      "id" : "b",
+      "detail" : {
+        "info" : "detail-b"
+      }
+    }, {
+      "id" : "a",
+      "detail" : {
+        "info" : "detail-a"
+      }
+    } ]
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/tests/sortedQuery.graphql
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/relationship-filter/tests/sortedQuery.graphql
@@ -1,0 +1,8 @@
+query sortedQuery {
+    sortedQuery(minId: "a") {
+        id
+        detail {
+            info
+        }
+    }
+}


### PR DESCRIPTION
Closes #2228.

A table function that sorts on a column outside its `SELECT` clause silently lost its base table, so the result got a synthetic GraphQL type instead of the source table's type and every relationship field disappeared. The sort key also leaked into the result as an extra column.

## Cause

Calcite cannot sort on an expression that is not in the row, so it projects the `ORDER BY` keys into the sort's input and leaves the caller to trim them again via `RelRoot.fields`. `Sqrl2FlinkSQLTranslator.analyzeView` never applied that trim on the branch that keeps the sort — the branch `resolveSqrlTableFunction` uses. Analysis therefore ran on a row type still carrying the sort keys, and base table inference in `SQRLLogicalPlanAnalyzer` matches a source table by row type equality:

```java
.filter(tbl -> tbl.getRowType().equals(originalRelnode.getRowType()))
```

No match, no base table, no relationship fields. Views take the other branch and hit the explicit `MISSING_SORT_COLUMN` fatal, which is why only parameterised table functions failed silently.

## Fix

`relRoot.project()` when the sort is kept. It is a no-op when the sort keys are already selected, so nothing changes for queries that were not affected.

`CalciteUtil.getLimit` now looks through that trimming projection — otherwise `... ORDER BY x LIMIT 1` on a non-selected `x` would lose its `ZERO_ONE` multiplicity.

## Behaviour change

Two existing use cases were silently hit by this bug and are corrected by the fix:

- `stdlib-vector`: `DocumentSimilarityIndex` returned a synthetic `DocumentSimilarityIndex` type, now returns `VectorData`.
- `functionParameterExpressionTest`: `CustomersByVector` returned a synthetic type, now returns `CustomerVectorEmbed`.

The generated SQL nests the `ORDER BY` in a subquery where trimming applies, e.g.

```sql
SELECT "t1"."id", "t1"."label"
FROM (SELECT "Thing"."id", "Thing"."label", "Detail"."info"
  FROM "Thing" INNER JOIN "Detail" ON "Thing"."id" = "Detail"."id"
  WHERE "Thing"."id" >= $1
  ORDER BY "Detail"."info" DESC NULLS LAST) AS "t1"
```

## Tests

`sortedQuery` added to the `relationship-filter` use case, covering both halves: it returns `[Thing!]` with `detail` resolvable, and the new `tests/sortedQuery.graphql` runs it through `FullUseCaseIT` against real Postgres to confirm the nested `ORDER BY` still orders the result (`c`, `b`, `a`).
