### PR TITLE
ci: Shard container-e2e-test across 2 parallel executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,8 +375,15 @@ jobs:
               -Dit.test="$SHARD_TESTS" \
               -Ddocker.image.tag=local-${CIRCLE_SHA1} \
               -Dmcp.inspector.version=$MCP_TAG
+      - run:
+          name: Collect test results
+          command: |
+            mkdir -p ~/test-results/container-${CIRCLE_NODE_INDEX}/
+            find sqrl-testing/sqrl-testing-container/target/failsafe-reports -name "TEST-*.xml" \
+              -exec cp {} ~/test-results/container-${CIRCLE_NODE_INDEX}/ \;
+          when: always
       - store_test_results:
-          path: sqrl-testing/sqrl-testing-container/target/failsafe-reports
+          path: ~/test-results
           when: always
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,7 @@ jobs:
 
   container-e2e-test:
     executor: default-machine
+    parallelism: 2
     steps:
       - checkout-and-version
       - skip-if-docs-only
@@ -363,10 +364,20 @@ jobs:
       - run:
           name: Run container tests using TestContainers
           command: |
+            SHARD_TESTS=$(circleci tests glob "sqrl-testing/sqrl-testing-container/src/test/java/**/*IT.java" \
+              | sed 's|.*/src/test/java/||; s|/|.|g; s|\.java$||' \
+              | circleci tests split --split-by=timings --timings-type=classname \
+              | sed 's|.*\.||' \
+              | paste -sd,)
+            echo "Running shard ${CIRCLE_NODE_INDEX}: $SHARD_TESTS"
             mvn -B install -DonlyContainerE2E \
               -pl :sqrl-testing-container \
+              -Dit.test="$SHARD_TESTS" \
               -Ddocker.image.tag=local-${CIRCLE_SHA1} \
               -Dmcp.inspector.version=$MCP_TAG
+      - store_test_results:
+          path: sqrl-testing/sqrl-testing-container/target/failsafe-reports
+          when: always
 
   deploy:
     docker:


### PR DESCRIPTION
Splits the 22 container IT classes across 2 CircleCI executors, using the native `circleci tests split --split-by=timings` rather than the `TestShardingExtension` used by `integration-tests` — the extension lives in `sqrl-testing-integration` test sources and isn't on the container module's classpath, and timings-based splitting balances better than hashing given how much container test runtimes vary.

Adds `store_test_results` for the failsafe reports so the timing data exists to split on (first run falls back to name-based split).

`parallelism` keeps a single `ci/circleci: container-e2e-test` status context, so no change needed in `.github/workflows/build.yml`.

Note: the docker image build step now runs on both executors, in parallel.