### PR TITLE
feat: Add Spark SQL as a shallow query engine

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/AbstractSqlConverters.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/AbstractSqlConverters.java
@@ -62,14 +62,15 @@ abstract class AbstractSqlConverters implements SqlConverters {
     return dialect;
   }
 
+  @Override
+  public final SqlDialect getCalciteSqlDialect() {
+    return calciteSqlDialect;
+  }
+
   protected SqlPrettyWriter createWriter() {
     var baseConfig = SqlPrettyWriter.config().withDialect(calciteSqlDialect);
     var config = SqrlConfigurations.SQL_TO_STRING.apply(baseConfig);
 
     return new DynamicParamSqlPrettyWriter(config);
-  }
-
-  protected final SqlDialect getCalciteSqlDialect() {
-    return calciteSqlDialect;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/FlinkSqlConverters.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/FlinkSqlConverters.java
@@ -17,9 +17,11 @@ package com.datasqrl.calcite.convert;
 
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
+import com.datasqrl.engine.stream.flink.sql.calcite.FlinkDialect;
 import com.google.auto.service.AutoService;
 import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlNode;
 
 @AutoService(SqlConverters.class)
@@ -34,6 +36,11 @@ public class FlinkSqlConverters implements SqlConverters {
   public String convert(SqlNode sqlNode) {
     // TODO: Migrate remaining FlinkRelToSqlConverter to this paradigm
     return RelToFlinkSql.convertToString(sqlNode);
+  }
+
+  @Override
+  public SqlDialect getCalciteSqlDialect() {
+    return FlinkDialect.DEFAULT;
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/SparkSqlSqlConverters.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/SparkSqlSqlConverters.java
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.calcite;
+package com.datasqrl.calcite.convert;
 
-public enum Dialect {
-  SQRL,
-  CALCITE,
-  FLINK,
-  POSTGRES,
-  SNOWFLAKE,
-  DUCKDB,
-  SPARK_SQL
+import com.datasqrl.calcite.Dialect;
+import com.datasqrl.calcite.dialect.ExtendedSparkSqlDialect;
+import com.google.auto.service.AutoService;
+
+@AutoService(SqlConverters.class)
+public class SparkSqlSqlConverters extends AbstractSqlConverters {
+
+  public SparkSqlSqlConverters() {
+    super(Dialect.SPARK_SQL, ExtendedSparkSqlDialect.DEFAULT, false);
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/SqlConverters.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/SqlConverters.java
@@ -18,6 +18,7 @@ package com.datasqrl.calcite.convert;
 import com.datasqrl.calcite.Dialect;
 import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlNode;
 
 /** Provides conversions to SQL representations for a specific dialect. */
@@ -39,6 +40,13 @@ public interface SqlConverters {
    * @return the dialect-specific SQL string
    */
   String convert(SqlNode sqlNode);
+
+  /**
+   * Returns the Calcite dialect used for conversion and dialect-specific DDL generation.
+   *
+   * @return the configured Calcite SQL dialect
+   */
+  SqlDialect getCalciteSqlDialect();
 
   Dialect getDialect();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/dialect/ExtendedSparkSqlDialect.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/dialect/ExtendedSparkSqlDialect.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.calcite.dialect;
+
+import org.apache.calcite.config.NullCollation;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.dialect.SparkSqlDialect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+public class ExtendedSparkSqlDialect extends SparkSqlDialect {
+
+  public static final Context DEFAULT_CONTEXT =
+      SqlDialect.EMPTY_CONTEXT
+          .withDatabaseProduct(DatabaseProduct.SPARK)
+          .withNullCollation(NullCollation.LOW)
+          .withIdentifierQuoteString("`");
+
+  public static final SqlDialect DEFAULT = new ExtendedSparkSqlDialect(DEFAULT_CONTEXT);
+
+  public ExtendedSparkSqlDialect(Context context) {
+    super(context);
+  }
+
+  @Override
+  public SqlNode getCastSpec(RelDataType type) {
+    var castSpec = getSparkType(type);
+
+    return new SqlDataTypeSpec(
+        new SqlAlienSystemTypeNameSpec(castSpec, type.getSqlTypeName(), SqlParserPos.ZERO),
+        SqlParserPos.ZERO);
+  }
+
+  private String getSparkType(RelDataType type) {
+    String castSpec;
+    switch (type.getSqlTypeName()) {
+      case CHAR:
+      case VARCHAR:
+        castSpec = "STRING";
+        break;
+      case BINARY:
+      case VARBINARY:
+        castSpec = "BINARY";
+        break;
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+        castSpec = "TIMESTAMP_LTZ";
+        break;
+      case TIMESTAMP:
+        castSpec = "TIMESTAMP_NTZ";
+        break;
+      case ARRAY:
+        castSpec = "ARRAY<" + getSparkType(type.getComponentType()) + ">";
+        break;
+      case MAP:
+        castSpec =
+            "MAP<"
+                + getSparkType(type.getKeyType())
+                + ", "
+                + getSparkType(type.getValueType())
+                + ">";
+        break;
+      case ROW:
+        castSpec =
+            "STRUCT<"
+                + type.getFieldList().stream()
+                    .map(
+                        field ->
+                            quoteIdentifier(field.getName()) + ": " + getSparkType(field.getType()))
+                    .reduce((left, right) -> left + ", " + right)
+                    .orElse("")
+                + ">";
+        break;
+      default:
+        return super.getCastSpec(type).toString();
+    }
+
+    return castSpec;
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
@@ -58,7 +58,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
-import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
@@ -83,6 +82,8 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
         SqlConvertersFactory.get(dialect),
         createTableDdlFactory);
   }
+
+  protected abstract SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint);
 
   @Override
   public QueryResult createQuery(
@@ -121,7 +122,7 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
     var viewName = query.function().getSimpleName();
     var rowType = query.relNode().getRowType();
     var viewSql =
-        new GenericCreateViewDdlFactory()
+        new GenericCreateViewDdlFactory(sqlConverters.getCalciteSqlDialect())
             .createView(viewName, rowType.getFieldNames(), passthroughSql);
     var view =
         new GenericJdbcStatement(
@@ -232,8 +233,6 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
         documentation.getColumn(field.getName(), null));
   }
 
-  protected abstract SqlDataTypeSpec getSqlType(RelDataType type, Optional<DataTypeHint> hint);
-
   protected String createView(
       SqlIdentifier viewNameIdentifier, SqlNodeList columnList, SqlNode viewSqlNode) {
     var createView =
@@ -241,22 +240,6 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
             SqlParserPos.ZERO, true, viewNameIdentifier, columnList, viewSqlNode);
 
     return sqlConverters.convert(createView);
-  }
-
-  public static List<String> quoteIdentifier(List<String> columns) {
-    return columns.stream()
-        .map(AbstractJdbcStatementFactory::quoteIdentifier)
-        .collect(Collectors.toList());
-  }
-
-  public static String quoteIdentifier(String column) {
-    return "\"" + column + "\"";
-  }
-
-  public static List<String> quoteIdentifiers(List<String> values) {
-    return values.stream()
-        .map(AbstractJdbcStatementFactory::quoteIdentifier)
-        .collect(Collectors.toList());
   }
 
   protected Set<DatabaseTypeExtension> extractTypeExtensions(

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDbStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDbStatementFactory.java
@@ -52,7 +52,8 @@ public class DuckDbStatementFactory extends AbstractJdbcStatementFactory {
   public DuckDbStatementFactory() {
     super(
         Dialect.DUCKDB,
-        new GenericCreateTableDdlFactory()); // Iceberg creates the tables, DuckDB only queries
+        new GenericCreateTableDdlFactory(
+            DuckDbSqlDialect.DEFAULT)); // Iceberg creates the tables, DuckDB only queries
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
@@ -58,7 +58,9 @@ public class IcebergEngine extends AbstractJDBCTableFormatEngine {
 
   @Override
   public boolean supportsQueryEngine(QueryEngine engine) {
-    return engine instanceof SnowflakeEngine || engine instanceof DuckDBEngine;
+    return engine instanceof SnowflakeEngine
+        || engine instanceof DuckDBEngine
+        || engine instanceof SparkSqlEngine;
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
@@ -141,7 +141,11 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
   public JdbcStatement addIndex(IndexDefinition index) {
     var ddl =
         new CreateIndexDDL(
-            index.getName(), index.getTableName(), index.getColumnNames(), index.getType());
+            index.getName(),
+            index.getTableName(),
+            index.getColumnNames(),
+            index.getType(),
+            ExtendedPostgresSqlDialect.DEFAULT);
     return new GenericJdbcStatement(ddl.getIndexName(), Type.INDEX, ddl.getSql());
   }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeStatementFactory.java
@@ -17,6 +17,7 @@ package com.datasqrl.engine.database.relational;
 
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.calcite.dialect.ExtendedPostgresSqlDialect;
+import com.datasqrl.calcite.dialect.ExtendedSnowflakeSqlDialect;
 import com.datasqrl.calcite.dialect.snowflake.SqlCreateIcebergTableFromObjectStorage;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.Type;
@@ -35,7 +36,7 @@ public class SnowflakeStatementFactory extends AbstractJdbcStatementFactory {
   private final EngineConfig engineConfig;
 
   public SnowflakeStatementFactory(EngineConfig engineConfig) {
-    super(Dialect.SNOWFLAKE, new GenericCreateTableDdlFactory());
+    super(Dialect.SNOWFLAKE, new GenericCreateTableDdlFactory(ExtendedSnowflakeSqlDialect.DEFAULT));
     this.engineConfig = engineConfig;
   }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngine.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import com.datasqrl.config.ConnectorFactoryFactory;
+import com.datasqrl.config.JdbcDialect;
+import com.datasqrl.config.PackageJson;
+import jakarta.inject.Inject;
+import lombok.NonNull;
+
+public class SparkSqlEngine extends AbstractJDBCShallowQueryEngine {
+
+  @Inject
+  public SparkSqlEngine(@NonNull PackageJson json, ConnectorFactoryFactory connectorFactory) {
+    super(
+        SparkSqlEngineFactory.ENGINE_NAME,
+        json.getEngines().getEngineConfigOrEmpty(SparkSqlEngineFactory.ENGINE_NAME),
+        connectorFactory);
+  }
+
+  @Override
+  protected JdbcDialect getDialect() {
+    return JdbcDialect.Iceberg;
+  }
+
+  @Override
+  public JdbcStatementFactory getStatementFactory() {
+    return new SparkSqlStatementFactory();
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngineFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngineFactory.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.calcite;
+package com.datasqrl.engine.database.relational;
 
-public enum Dialect {
-  SQRL,
-  CALCITE,
-  FLINK,
-  POSTGRES,
-  SNOWFLAKE,
-  DUCKDB,
-  SPARK_SQL
+import com.datasqrl.config.EngineFactory;
+import com.datasqrl.engine.database.DatabaseEngineFactory;
+import com.google.auto.service.AutoService;
+
+@AutoService(EngineFactory.class)
+public class SparkSqlEngineFactory implements DatabaseEngineFactory {
+
+  public static final String ENGINE_NAME = "sparksql";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public Class getFactoryClass() {
+    return SparkSqlEngine.class;
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import com.datasqrl.calcite.Dialect;
+import com.datasqrl.calcite.dialect.ExtendedSparkSqlDialect;
+import com.datasqrl.engine.database.relational.ddl.GenericCreateTableDdlFactory;
+import com.datasqrl.plan.global.IndexDefinition;
+import com.datasqrl.planner.hint.DataTypeHint;
+import java.util.Optional;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlNode;
+
+public class SparkSqlStatementFactory extends AbstractJdbcStatementFactory {
+
+  public SparkSqlStatementFactory() {
+    super(Dialect.SPARK_SQL, new GenericCreateTableDdlFactory(ExtendedSparkSqlDialect.DEFAULT));
+  }
+
+  @Override
+  protected SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint) {
+    return ExtendedSparkSqlDialect.DEFAULT.getCastSpec(type);
+  }
+
+  @Override
+  public JdbcStatement addIndex(IndexDefinition indexDefinition) {
+    throw new UnsupportedOperationException("Spark SQL does not support indexes");
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/CreateIndexDDL.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/CreateIndexDDL.java
@@ -15,14 +15,13 @@
  */
 package com.datasqrl.engine.database.relational.ddl;
 
-import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifier;
-
 import com.datasqrl.plan.global.IndexType;
 import com.datasqrl.sql.SqlDDLStatement;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Value;
+import org.apache.calcite.sql.SqlDialect;
 
 @Value
 public class CreateIndexDDL implements SqlDDLStatement {
@@ -31,6 +30,20 @@ public class CreateIndexDDL implements SqlDDLStatement {
   String tableName;
   List<String> columns;
   IndexType type;
+  DdlIdentifierQuoter identifierQuoter;
+
+  public CreateIndexDDL(
+      String indexName,
+      String tableName,
+      List<String> columns,
+      IndexType type,
+      SqlDialect dialect) {
+    this.indexName = indexName;
+    this.tableName = tableName;
+    this.columns = columns;
+    this.type = type;
+    this.identifierQuoter = new DdlIdentifierQuoter(dialect);
+  }
 
   @Override
   public String getSql() {
@@ -40,8 +53,8 @@ public class CreateIndexDDL implements SqlDDLStatement {
         columnExpression =
             "to_tsvector('english', %s )"
                 .formatted(
-                    quoteIdentifier(columns).stream()
-                        .map(col -> "coalesce(%s, '')".formatted(col))
+                    identifierQuoter.quoteAll(columns).stream()
+                        .map("coalesce(%s, '')"::formatted)
                         .collect(Collectors.joining(" || ' ' || ")));
         indexType = "GIN";
         break;
@@ -55,18 +68,22 @@ public class CreateIndexDDL implements SqlDDLStatement {
               case VECTOR_EUCLID -> "vector_l2_ops";
               default -> throw new UnsupportedOperationException(type.toString());
             };
-        columnExpression = quoteIdentifier(columns.get(0)) + " " + indexModifier;
+        columnExpression = identifierQuoter.quote(columns.get(0)) + " " + indexModifier;
         indexType = "HNSW";
         break;
       default:
-        columnExpression = String.join(",", quoteIdentifier(columns));
+        columnExpression = String.join(",", identifierQuoter.quoteAll(columns));
         indexType = type.name().toLowerCase();
     }
 
     var createTable = "CREATE INDEX IF NOT EXISTS %s ON %s USING %s (%s)";
     var sql =
         createTable.formatted(
-            quoteIdentifier(indexName), quoteIdentifier(tableName), indexType, columnExpression);
+            identifierQuoter.quote(indexName),
+            identifierQuoter.quote(tableName),
+            indexType,
+            columnExpression);
+
     return sql;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/DdlIdentifierQuoter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/DdlIdentifierQuoter.java
@@ -15,24 +15,33 @@
  */
 package com.datasqrl.engine.database.relational.ddl;
 
+import jakarta.annotation.Nullable;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.sql.SqlDialect;
 
+/**
+ * Quotes DDL identifiers using the configured Calcite SQL dialect, or double quotes when no dialect
+ * is configured.
+ */
 @RequiredArgsConstructor
-public class GenericCreateViewDdlFactory {
+public final class DdlIdentifierQuoter {
 
-  private final DdlIdentifierQuoter identifierQuoter;
+  @Nullable private final SqlDialect dialect;
 
-  public GenericCreateViewDdlFactory(SqlDialect dialect) {
-    this(new DdlIdentifierQuoter(dialect));
+  public DdlIdentifierQuoter() {
+    this(null);
   }
 
-  public String createView(String viewName, List<String> columns, String select) {
-    var colStr = columns.stream().map(identifierQuoter::quote).collect(Collectors.joining(", "));
+  public String quote(String identifier) {
+    if (dialect != null) {
+      return dialect.quoteIdentifier(identifier);
+    }
 
-    return "CREATE OR REPLACE VIEW %s (%s) AS %s"
-        .formatted(identifierQuoter.quote(viewName), colStr, select);
+    return "\"" + identifier + "\"";
+  }
+
+  public List<String> quoteAll(List<String> identifiers) {
+    return identifiers.stream().map(this::quote).toList();
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/GenericCreateTableDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/GenericCreateTableDdlFactory.java
@@ -15,18 +15,26 @@
  */
 package com.datasqrl.engine.database.relational.ddl;
 
-import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifier;
-import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifiers;
-
 import com.datasqrl.deployment.model.JdbcStatementModel.Field;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement.CreateTableDdlFactory;
 import java.util.List;
 import java.util.StringJoiner;
+import org.apache.calcite.sql.SqlDialect;
 
 public class GenericCreateTableDdlFactory implements CreateTableDdlFactory {
 
   private static final String CREATE_TABLE_TEMPLATE = "CREATE TABLE IF NOT EXISTS %s (%s)";
+
+  private final DdlIdentifierQuoter identifierQuoter;
+
+  public GenericCreateTableDdlFactory(SqlDialect dialect) {
+    this.identifierQuoter = new DdlIdentifierQuoter(dialect);
+  }
+
+  protected GenericCreateTableDdlFactory() {
+    this.identifierQuoter = new DdlIdentifierQuoter();
+  }
 
   @Override
   public String createTableDdl(CreateTableJdbcStatement stmt) {
@@ -34,9 +42,7 @@ public class GenericCreateTableDdlFactory implements CreateTableDdlFactory {
     var tableElements = new StringJoiner(", ");
 
     // Add field definitions
-    stmt.getFields().stream()
-        .map(GenericCreateTableDdlFactory::fieldToSql)
-        .forEach(tableElements::add);
+    stmt.getFields().stream().map(this::fieldToSql).forEach(tableElements::add);
 
     // Add primary key constraint if present
     if (!stmt.getPrimaryKey().isEmpty()) {
@@ -47,13 +53,21 @@ public class GenericCreateTableDdlFactory implements CreateTableDdlFactory {
         quoteIdentifier(stmt.getName()), tableElements.toString());
   }
 
-  protected static String listToSql(List<String> columns) {
+  protected String listToSql(List<String> columns) {
     return String.join(",", quoteIdentifiers(columns));
   }
 
-  protected static String fieldToSql(Field field) {
+  protected String fieldToSql(Field field) {
     var notNull = field.nullable() ? "" : "NOT NULL";
 
-    return "\"%s\" %s %s".formatted(field.name(), field.type(), notNull).trim();
+    return "%s %s %s".formatted(quoteIdentifier(field.name()), field.type(), notNull).trim();
+  }
+
+  protected String quoteIdentifier(String identifier) {
+    return identifierQuoter.quote(identifier);
+  }
+
+  protected List<String> quoteIdentifiers(List<String> identifiers) {
+    return identifierQuoter.quoteAll(identifiers);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/PostgresCreateTableDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/PostgresCreateTableDdlFactory.java
@@ -15,17 +15,14 @@
  */
 package com.datasqrl.engine.database.relational.ddl;
 
-import static com.datasqrl.engine.database.relational.AbstractJdbcStatementFactory.quoteIdentifier;
-
+import com.datasqrl.calcite.dialect.ExtendedPostgresSqlDialect;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
 public class PostgresCreateTableDdlFactory extends GenericCreateTableDdlFactory {
 
   private static final Set<PartitionType> SUPPORTED_PARTITIONS =
@@ -34,6 +31,11 @@ public class PostgresCreateTableDdlFactory extends GenericCreateTableDdlFactory 
   private static final String PARTITION_SUFFIX = "_all";
 
   private final boolean addDefaultPartition;
+
+  public PostgresCreateTableDdlFactory(boolean addDefaultPartition) {
+    super(ExtendedPostgresSqlDialect.DEFAULT);
+    this.addDefaultPartition = addDefaultPartition;
+  }
 
   @Override
   public String createTableDdl(CreateTableJdbcStatement stmt) {

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/FullUseCaseIT.java
@@ -65,7 +65,8 @@ public class FullUseCaseIT {
 
   /** Ad-hoc debugging entry point. Change the path below to run a single use case manually. */
   static Stream<UseCaseParam> specificUseCaseProvider() {
-    return Stream.of(new UseCaseParam(USE_CASES.resolve("jwt-authorized").resolve("package.json")));
+    return Stream.of(
+        new UseCaseParam(USE_CASES.resolve("complex-mutation").resolve("package.json")));
   }
 
   @ParameterizedTest

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/UseCaseCompileTest.java
@@ -66,7 +66,7 @@ public class UseCaseCompileTest {
   @Test
   @Disabled("Intended for manual usage")
   void runTestCaseByName() {
-    var pkg = USECASE_DIR.resolve("jwt-authorized").resolve("package.json");
+    var pkg = USECASE_DIR.resolve("dialects/spark-sql-compile").resolve("package.json");
     UseCaseTestHelper.testUseCase(
         snapshotExtension,
         getClass(),

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package-sparksql-no-server.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package-sparksql-no-server.json
@@ -1,0 +1,14 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "iceberg", "sparksql"],
+  "script": {
+    "main": "script.sqrl"
+  },
+  "engines": {
+    "snowflake": {
+      "catalog-name": "MyCatalog",
+      "external-volume": "MyNewVolume",
+      "url": "${SNOWFLAKE_JDBC_URL}"
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-sparksql-no-server.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-sparksql-no-server.txt
@@ -1,0 +1,97 @@
+>>>iceberg-schema.sql
+CREATE TABLE IF NOT EXISTS "Numbers" ("id" INTEGER NOT NULL, PRIMARY KEY ("id"));
+CREATE TABLE IF NOT EXISTS "Numbers2" ("id" INTEGER NOT NULL, PRIMARY KEY ("id"))
+>>>iceberg-sparksql-schema.sql
+CREATE TABLE IF NOT EXISTS `Numbers` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`));
+CREATE TABLE IF NOT EXISTS `Numbers2` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`))
+>>>iceberg.json
+{
+  "plans" : {
+    "" : {
+      "statements" : [
+        {
+          "name" : "Numbers",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS \"Numbers\" (\"id\" INTEGER NOT NULL, PRIMARY KEY (\"id\"))",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        },
+        {
+          "name" : "Numbers2",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS \"Numbers2\" (\"id\" INTEGER NOT NULL, PRIMARY KEY (\"id\"))",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        }
+      ],
+      "standaloneExtensionStatements" : [ ]
+    },
+    "sparksql" : {
+      "statements" : [
+        {
+          "name" : "Numbers",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS `Numbers` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`))",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        },
+        {
+          "name" : "Numbers2",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS `Numbers2` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`))",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        }
+      ],
+      "standaloneExtensionStatements" : [ ]
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-spark-sql-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-spark-sql-compile-package.txt
@@ -1,0 +1,205 @@
+>>>pipeline_explain.txt
+=== SparkAggregates
+ID:          default_catalog.default_database.SparkAggregates
+Type:        state
+Stage:       flink
+Primary key: boolean_value
+Timestamp:   -
+Row count:   ~1e7
+---
+Schema:
+ - boolean_value: BOOLEAN
+ - record_count: BIGINT NOT NULL
+ - decimal_sum: DECIMAL(38, 2)
+ - double_average: DOUBLE
+ - latest_event: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+Inputs:
+ - default_catalog.default_database.SparkTypeSource
+Annotations:
+ - stream-root: SparkTypeSource
+
+=== SparkTypeMappings
+ID:          default_catalog.default_database.SparkTypeMappings
+Type:        stream
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - tiny_value: TINYINT
+ - small_value: SMALLINT
+ - int_value: INTEGER
+ - float_value: FLOAT
+ - double_value: DOUBLE
+ - decimal_value: DECIMAL(12, 2)
+ - boolean_value: BOOLEAN
+ - string_value: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+ - varchar_value: VARCHAR(32) CHARACTER SET "UTF-16LE"
+ - char_value: CHAR(8) CHARACTER SET "UTF-16LE"
+ - binary_value: BINARY(16)
+ - varbinary_value: VARBINARY(32)
+ - date_value: DATE
+ - timestamp_value: TIMESTAMP(3)
+ - timestamp_ltz_value: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+ - string_array: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY
+ - string_to_int: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE", INTEGER) MAP
+ - attributes: RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" source, INTEGER priority)
+Inputs:
+ - default_catalog.default_database.SparkTypeSource
+Annotations:
+ - stream-root: SparkTypeSource
+
+=== SparkTypeSource
+ID:          default_catalog.default_database.SparkTypeSource
+Type:        stream
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - tiny_value: TINYINT
+ - small_value: SMALLINT
+ - int_value: INTEGER
+ - float_value: FLOAT
+ - double_value: DOUBLE
+ - decimal_value: DECIMAL(12, 2)
+ - boolean_value: BOOLEAN
+ - string_value: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+ - varchar_value: VARCHAR(32) CHARACTER SET "UTF-16LE"
+ - char_value: CHAR(8) CHARACTER SET "UTF-16LE"
+ - binary_value: BINARY(16)
+ - varbinary_value: VARBINARY(32)
+ - date_value: DATE
+ - timestamp_value: TIMESTAMP(3)
+ - timestamp_ltz_value: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+ - string_array: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY
+ - string_to_int: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE", INTEGER) MAP
+ - attributes: RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" source, INTEGER priority)
+Inputs:
+ - default_catalog.default_database.SparkTypeSource__base
+Annotations:
+ - features: DENORMALIZE (feature)
+ - stream-root: SparkTypeSource
+
+>>>flink-sql-no-functions.sql
+CREATE TABLE `SparkTypeSource` (
+  `id` BIGINT NOT NULL,
+  `tiny_value` TINYINT,
+  `small_value` SMALLINT,
+  `int_value` INTEGER,
+  `float_value` FLOAT,
+  `double_value` DOUBLE,
+  `decimal_value` DECIMAL(12, 2),
+  `boolean_value` BOOLEAN,
+  `string_value` STRING,
+  `varchar_value` VARCHAR(32),
+  `char_value` CHAR(8),
+  `binary_value` BINARY(16),
+  `varbinary_value` VARBINARY(32),
+  `date_value` DATE,
+  `timestamp_value` TIMESTAMP(3),
+  `timestamp_ltz_value` TIMESTAMP_LTZ(3),
+  `string_array` ARRAY< STRING >,
+  `string_to_int` MAP< STRING, INTEGER >,
+  `attributes` ROW< `source` STRING, `priority` INTEGER >,
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'SparkTypeSource',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash',
+  'write.upsert.enabled' = 'true'
+);
+CREATE VIEW `SparkTypeMappings`
+AS
+SELECT `id`, `tiny_value`, `small_value`, `int_value`, `float_value`, `double_value`, `decimal_value`, `boolean_value`, `string_value`, `varchar_value`, `char_value`, `binary_value`, `varbinary_value`, `date_value`, `timestamp_value`, `timestamp_ltz_value`, `string_array`, `string_to_int`, `attributes`
+FROM `SparkTypeSource`;
+CREATE VIEW `SparkAggregates`
+AS
+SELECT `boolean_value`, COUNT(*) AS `record_count`, SUM(`decimal_value`) AS `decimal_sum`, AVG(`double_value`) AS `double_average`, MAX(`timestamp_ltz_value`) AS `latest_event`
+FROM `SparkTypeSource`
+GROUP BY `boolean_value`;
+CREATE TABLE `SparkAggregates_1` (
+  `boolean_value` BOOLEAN,
+  `record_count` BIGINT NOT NULL,
+  `decimal_sum` DECIMAL(38, 2),
+  `double_average` DOUBLE,
+  `latest_event` TIMESTAMP(3) WITH LOCAL TIME ZONE,
+  PRIMARY KEY (`boolean_value`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'SparkAggregates',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash',
+  'write.upsert.enabled' = 'true'
+);
+CREATE TABLE `SparkTypeMappings_2` (
+  `id` BIGINT NOT NULL,
+  `tiny_value` TINYINT,
+  `small_value` SMALLINT,
+  `int_value` INTEGER,
+  `float_value` FLOAT,
+  `double_value` DOUBLE,
+  `decimal_value` DECIMAL(12, 2),
+  `boolean_value` BOOLEAN,
+  `string_value` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `varchar_value` VARCHAR(32) CHARACTER SET `UTF-16LE`,
+  `char_value` CHAR(8) CHARACTER SET `UTF-16LE`,
+  `binary_value` BINARY(16),
+  `varbinary_value` VARBINARY(32),
+  `date_value` DATE,
+  `timestamp_value` TIMESTAMP(3),
+  `timestamp_ltz_value` TIMESTAMP(3) WITH LOCAL TIME ZONE,
+  `string_array` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` ARRAY,
+  `string_to_int` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, INTEGER >,
+  `attributes` ROW(`source` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `priority` INTEGER),
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'SparkTypeMappings',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`SparkAggregates_1`
+SELECT *
+FROM `default_catalog`.`default_database`.`SparkAggregates`
+;
+INSERT INTO `default_catalog`.`default_database`.`SparkTypeMappings_2`
+SELECT *
+FROM `default_catalog`.`default_database`.`SparkTypeMappings`
+;
+END
+>>>iceberg-schema.sql
+CREATE TABLE IF NOT EXISTS "SparkAggregates" ("boolean_value" BOOLEAN, "record_count" BIGINT NOT NULL, "decimal_sum" NUMERIC, "double_average" DOUBLE PRECISION, "latest_event" TIMESTAMP WITH TIME ZONE, PRIMARY KEY ("boolean_value"));
+CREATE TABLE IF NOT EXISTS "SparkTypeMappings" ("id" BIGINT NOT NULL, "tiny_value" SMALLINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" FLOAT, "double_value" DOUBLE PRECISION, "decimal_value" NUMERIC, "boolean_value" BOOLEAN, "string_value" TEXT, "varchar_value" TEXT, "char_value" TEXT, "binary_value" BYTEA, "varbinary_value" BYTEA, "date_value" DATE, "timestamp_value" TIMESTAMP WITHOUT TIME ZONE, "timestamp_ltz_value" TIMESTAMP WITH TIME ZONE, "string_array" TEXT ARRAY, "string_to_int" JSONB, "attributes" JSONB, PRIMARY KEY ("id"));
+CREATE TABLE IF NOT EXISTS "SparkTypeSource" ("id" BIGINT NOT NULL, "tiny_value" SMALLINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" FLOAT, "double_value" DOUBLE PRECISION, "decimal_value" NUMERIC, "boolean_value" BOOLEAN, "string_value" TEXT, "varchar_value" TEXT, "char_value" TEXT, "binary_value" BYTEA, "varbinary_value" BYTEA, "date_value" DATE, "timestamp_value" TIMESTAMP WITHOUT TIME ZONE, "timestamp_ltz_value" TIMESTAMP WITH TIME ZONE, "string_array" TEXT ARRAY, "string_to_int" JSONB, "attributes" JSONB, PRIMARY KEY ("id"))
+>>>iceberg-sparksql-schema.sql
+CREATE TABLE IF NOT EXISTS `SparkAggregates` (`boolean_value` BOOLEAN, `record_count` BIGINT NOT NULL, `decimal_sum` DECIMAL(19, 2), `double_average` DOUBLE, `latest_event` TIMESTAMP_LTZ, PRIMARY KEY (`boolean_value`));
+CREATE TABLE IF NOT EXISTS `SparkTypeMappings` (`id` BIGINT NOT NULL, `tiny_value` TINYINT, `small_value` SMALLINT, `int_value` INTEGER, `float_value` FLOAT, `double_value` DOUBLE, `decimal_value` DECIMAL(12, 2), `boolean_value` BOOLEAN, `string_value` STRING, `varchar_value` STRING, `char_value` STRING, `binary_value` BINARY, `varbinary_value` BINARY, `date_value` DATE, `timestamp_value` TIMESTAMP_NTZ, `timestamp_ltz_value` TIMESTAMP_LTZ, `string_array` ARRAY<STRING>, `string_to_int` MAP<STRING, INTEGER>, `attributes` STRUCT<`SOURCE`: STRING, `PRIORITY`: INTEGER>, PRIMARY KEY (`id`));
+CREATE TABLE IF NOT EXISTS `SparkTypeSource` (`id` BIGINT NOT NULL, `tiny_value` TINYINT, `small_value` SMALLINT, `int_value` INTEGER, `float_value` FLOAT, `double_value` DOUBLE, `decimal_value` DECIMAL(12, 2), `boolean_value` BOOLEAN, `string_value` STRING, `varchar_value` STRING, `char_value` STRING, `binary_value` BINARY, `varbinary_value` BINARY, `date_value` DATE, `timestamp_value` TIMESTAMP_NTZ, `timestamp_ltz_value` TIMESTAMP_LTZ, `string_array` ARRAY<STRING>, `string_to_int` MAP<STRING, INTEGER>, `attributes` STRUCT<`SOURCE`: STRING, `PRIORITY`: INTEGER>, PRIMARY KEY (`id`))

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/spark-sql-compile/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/spark-sql-compile/package.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "iceberg", "sparksql"],
+  "script": {
+    "main": "spark-sql-dialect.sqrl"
+  },
+  "engines": {
+    "flink": {
+      "config": {
+        "table.exec.source.idle-timeout": "1 ms"
+      }
+    }
+  },
+  "test-runner": {
+    "delay-sec": -1
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/spark-sql-compile/spark-sql-dialect.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/spark-sql-compile/spark-sql-dialect.sqrl
@@ -1,0 +1,56 @@
+/*+engine(iceberg), no_query */
+CREATE TABLE SparkTypeSource (
+  id BIGINT NOT NULL,
+  tiny_value TINYINT,
+  small_value SMALLINT,
+  int_value INT,
+  float_value FLOAT,
+  double_value DOUBLE,
+  decimal_value DECIMAL(12, 2),
+  boolean_value BOOLEAN,
+  string_value STRING,
+  varchar_value VARCHAR(32),
+  char_value CHAR(8),
+  binary_value BINARY(16),
+  varbinary_value VARBINARY(32),
+  date_value DATE,
+  timestamp_value TIMESTAMP(3),
+  timestamp_ltz_value TIMESTAMP_LTZ(3),
+  string_array ARRAY<STRING>,
+  string_to_int MAP<STRING, INT>,
+  attributes ROW<source STRING, priority INT>,
+  PRIMARY KEY (id) NOT ENFORCED
+);
+
+SparkTypeMappings :=
+  SELECT
+    id,
+    tiny_value,
+    small_value,
+    int_value,
+    float_value,
+    double_value,
+    decimal_value,
+    boolean_value,
+    string_value,
+    varchar_value,
+    char_value,
+    binary_value,
+    varbinary_value,
+    date_value,
+    timestamp_value,
+    timestamp_ltz_value,
+    string_array,
+    string_to_int,
+    attributes
+  FROM SparkTypeSource;
+
+SparkAggregates :=
+  SELECT
+    boolean_value,
+    COUNT(*) AS record_count,
+    SUM(decimal_value) AS decimal_sum,
+    AVG(double_value) AS double_average,
+    MAX(timestamp_ltz_value) AS latest_event
+  FROM SparkTypeSource
+  GROUP BY boolean_value;


### PR DESCRIPTION
## Key Changes
- Add the `sparksql` query engine with Spark SQL statement generation backed by Iceberg deployment artifacts.
- Add Spark SQL Calcite conversion and dialect support, including backtick identifiers and Spark-native scalar, temporal, array, map, and struct type rendering.
- Refactor JDBC DDL generation to quote table, view, index, and column identifiers through the active SQL dialect.
- Make query-engine server configuration optional so engines without runtime server configuration, such as Spark SQL, are supported.
- Add a Spark SQL compile use case and snapshot covering primitive, temporal, binary, collection, row, and aggregate result types.