### PR TITLE
feat: Support defining sort order in `index` hints

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
@@ -142,9 +142,11 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
             index.getName(),
             index.getTableName(),
             index.getColumnNames(),
+            index.getDirections(),
             index.getType(),
             ExtendedPostgresSqlDialect.DEFAULT);
-    return new GenericJdbcStatement(ddl.getIndexName(), Type.INDEX, ddl.getSql());
+
+    return new GenericJdbcStatement(ddl.indexName(), Type.INDEX, ddl.getSql());
   }
 
   /*

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
@@ -144,9 +144,11 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
             index.getName(),
             index.getTableName(),
             index.getColumnNames(),
+            index.getDirections(),
             index.getType(),
             ExtendedPostgresSqlDialect.DEFAULT);
-    return new GenericJdbcStatement(ddl.getIndexName(), Type.INDEX, ddl.getSql());
+
+    return new GenericJdbcStatement(ddl.indexName(), Type.INDEX, ddl.getSql());
   }
 
   /*

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/CreateIndexDDL.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/CreateIndexDDL.java
@@ -20,29 +20,28 @@ import com.datasqrl.sql.SqlDDLStatement;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Value;
+import java.util.stream.IntStream;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.sql.SqlDialect;
 
-@Value
-public class CreateIndexDDL implements SqlDDLStatement {
-
-  String indexName;
-  String tableName;
-  List<String> columns;
-  IndexType type;
-  DdlIdentifierQuoter identifierQuoter;
+public record CreateIndexDDL(
+    String indexName,
+    String tableName,
+    List<String> columns,
+    List<Direction> directions,
+    IndexType type,
+    DdlIdentifierQuoter identifierQuoter)
+    implements SqlDDLStatement {
 
   public CreateIndexDDL(
       String indexName,
       String tableName,
       List<String> columns,
+      List<Direction> directions,
       IndexType type,
-      SqlDialect dialect) {
-    this.indexName = indexName;
-    this.tableName = tableName;
-    this.columns = columns;
-    this.type = type;
-    this.identifierQuoter = new DdlIdentifierQuoter(dialect);
+      SqlDialect identifierQuoter) {
+    this(
+        indexName, tableName, columns, directions, type, new DdlIdentifierQuoter(identifierQuoter));
   }
 
   @Override
@@ -72,7 +71,10 @@ public class CreateIndexDDL implements SqlDDLStatement {
         indexType = "HNSW";
         break;
       default:
-        columnExpression = String.join(",", identifierQuoter.quoteAll(columns));
+        columnExpression =
+            IntStream.range(0, columns.size())
+                .mapToObj(this::formatIndexColumn)
+                .collect(Collectors.joining(","));
         indexType = type.name().toLowerCase();
     }
 
@@ -85,5 +87,10 @@ public class CreateIndexDDL implements SqlDDLStatement {
             columnExpression);
 
     return sql;
+  }
+
+  private String formatIndexColumn(int index) {
+    var sortOrder = directions.get(index).isDescending() ? " DESC" : "";
+    return identifierQuoter.quote(columns.get(index)) + sortOrder;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexDefinition.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexDefinition.java
@@ -15,10 +15,13 @@
  */
 package com.datasqrl.plan.global;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.Value;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
 
 @Value
 public class IndexDefinition implements Comparable<IndexDefinition> {
@@ -28,6 +31,7 @@ public class IndexDefinition implements Comparable<IndexDefinition> {
   String tableName;
   List<Integer> columns;
   List<String> columnNames;
+  List<Direction> directions;
   int partitionOffset;
   IndexType type;
 
@@ -37,28 +41,59 @@ public class IndexDefinition implements Comparable<IndexDefinition> {
       List<String> allFieldNames,
       int partitionOffset,
       IndexType type) {
-    Preconditions.checkArgument(
+    this(
+        tableName,
+        columns,
+        allFieldNames,
+        partitionOffset,
+        type,
+        columns.stream().map(column -> Direction.ASCENDING).toList());
+  }
+
+  public IndexDefinition(
+      String tableName,
+      List<Integer> columns,
+      List<String> allFieldNames,
+      int partitionOffset,
+      IndexType type,
+      List<Direction> directions) {
+
+    checkArgument(
         type.isPartitioned() ^ partitionOffset < 0,
         "Index must be partitioned XOR partition offset must be negative: %s | %s",
         type,
         partitionOffset);
-    Preconditions.checkArgument(
+
+    checkArgument(
         partitionOffset <= columns.size(),
         "Invalid partition offset: %s | %s",
         partitionOffset,
         columns.size());
+
+    checkArgument(
+        columns.size() == directions.size(),
+        "Number of index column directions must match number of columns: %s | %s",
+        columns.size(),
+        directions.size());
+
     this.tableName = tableName;
     this.columns = columns;
     this.partitionOffset = partitionOffset;
     this.columnNames = columns.stream().map(allFieldNames::get).collect(Collectors.toList());
     this.type = type;
+    this.directions = directions;
   }
 
   private IndexDefinition(
-      String tableName, List<Integer> columns, List<String> columnNames, IndexType type) {
+      String tableName,
+      List<Integer> columns,
+      List<String> columnNames,
+      List<Direction> directions,
+      IndexType type) {
     this.tableName = tableName;
     this.columns = columns;
     this.columnNames = columnNames;
+    this.directions = directions;
     this.partitionOffset = -1;
     this.type = type;
   }
@@ -68,12 +103,19 @@ public class IndexDefinition implements Comparable<IndexDefinition> {
         + "_"
         + type.name().toLowerCase()
         + "_"
-        + columns.stream().map(i -> "c" + i).collect(Collectors.joining());
+        + IntStream.range(0, columns.size())
+            .mapToObj(i -> "c" + columns.get(i) + (directions.get(i).isDescending() ? "d" : ""))
+            .collect(Collectors.joining());
   }
 
   public static IndexDefinition getPrimaryKeyIndex(
       String tableId, List<Integer> primaryKeys, List<String> pkNames) {
-    return new IndexDefinition(tableId, primaryKeys, pkNames, IndexType.BTREE);
+    return new IndexDefinition(
+        tableId,
+        primaryKeys,
+        pkNames,
+        primaryKeys.stream().map(column -> Direction.ASCENDING).toList(),
+        IndexType.BTREE);
   }
 
   public int numEqualityColumnsRequired() {

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexSelector.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexSelector.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.EqualsAndHashCode.Include;
@@ -111,28 +110,32 @@ public class IndexSelector {
 
   public Optional<List<IndexDefinition>> getIndexHints(
       String tableName, TableAnalysis tableAnalysis) {
+
     var hints = tableAnalysis.getHints();
-    List<IndexHint> indexHints =
-        hints.getHints(IndexHint.class).collect(Collectors.toUnmodifiableList());
-    if (!indexHints.isEmpty()) {
-      return Optional.of(
-          indexHints.stream()
-              .filter(idxHint -> idxHint.getIndexType() != null) // filter out no-index hints
-              .filter(idxHint -> config.supportedIndexTypes().contains(idxHint.getIndexType()))
-              .map(
-                  idxHint ->
-                      new IndexDefinition(
-                          tableName,
-                          idxHint.getColumnIndexes(),
-                          tableAnalysis.getRowType().getFieldNames(),
-                          idxHint.getIndexType().isPartitioned()
-                              ? idxHint.getColumnNames().size()
-                              : -1,
-                          idxHint.getIndexType()))
-              .collect(Collectors.toUnmodifiableList()));
-    } else {
+    var indexHints = hints.getHints(IndexHint.class).toList();
+
+    if (indexHints.isEmpty()) {
       return Optional.empty();
     }
+
+    var indexDefinitions =
+        indexHints.stream()
+            .filter(idxHint -> idxHint.getIndexType() != null) // filter out no-index hints
+            .filter(idxHint -> config.supportedIndexTypes().contains(idxHint.getIndexType()))
+            .map(
+                idxHint ->
+                    new IndexDefinition(
+                        tableName,
+                        idxHint.getColumnIndexes(),
+                        tableAnalysis.getRowType().getFieldNames(),
+                        idxHint.getIndexType().isPartitioned()
+                            ? idxHint.getColumnNames().size()
+                            : -1,
+                        idxHint.getIndexType(),
+                        idxHint.getDirections()))
+            .toList();
+
+    return Optional.of(indexDefinitions);
   }
 
   private Map<IndexDefinition, Double> optimizeIndexes(
@@ -192,7 +195,7 @@ public class IndexSelector {
     // Determine all index candidates
     Set<IndexDefinition> candidates = new LinkedHashSet<>();
     indexes.forEach(idx -> candidates.addAll(generateIndexCandidates(idx)));
-    Function<QueryIndexSummary, Double> initialCost = idx -> idx.getBaseCost();
+    Function<QueryIndexSummary, Double> initialCost = QueryIndexSummary::getBaseCost;
     if (config.hasPrimaryKeyIndex() && table.getAnalysis().getPrimaryKey().isDefined()) {
       // The baseline cost is the cost of doing the lookup with the primary key index
       // we need to use the primary key on the physical table (i.e. from the statement)

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexType.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/IndexType.java
@@ -32,8 +32,6 @@ public enum IndexType {
   /**
    * A general index covers comparison operators and can cover multiple columns. If it is not a
    * general index, it is a function index that has a specific indexing method.
-   *
-   * @return
    */
   public boolean isGeneralIndex() {
     return this == HASH || this == BTREE || this == PBTREE;
@@ -41,6 +39,10 @@ public enum IndexType {
 
   public boolean isPartitioned() {
     return this == PBTREE;
+  }
+
+  public boolean supportsSortOrder() {
+    return this == BTREE || this == PBTREE;
   }
 
   public static Optional<IndexType> fromName(String name) {

--- a/sqrl-planner/src/main/java/com/datasqrl/plan/global/QueryIndexSummary.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/plan/global/QueryIndexSummary.java
@@ -53,18 +53,13 @@ public class QueryIndexSummary {
   private static final QueryIndexSummary EMPTY =
       new QueryIndexSummary(null, Set.of(), Set.of(), Set.of(), 1.0);
 
-  public static final String INDEX_NAME = "_index_";
-
   @Include NamedTable table;
   @Include Set<Integer> equalityColumns;
   @Include Set<Integer> inequalityColumns;
   @Include Set<IndexableFunctionCall> functionCalls;
 
-  // TODO: add support for sort orders
-  // List<IndexableSort> sorts;
-
   /** Keeps track of the relative frequency of query conjunctions as we reduce them */
-  double count = 1.0;
+  double count;
 
   public static List<QueryIndexSummary> ofFilter(
       @NonNull NamedTable table, RexNode filter, SqrlRexUtil rexUtil) {
@@ -104,16 +99,22 @@ public class QueryIndexSummary {
   }
 
   public static Optional<QueryIndexSummary> ofSort(@NonNull NamedTable table, RexNode node) {
-    if (node instanceof RexCall call) {
-      var idxFinder = new IndexableFinder();
-      call.accept(idxFinder);
-      if (idxFinder.isIndexable && idxFinder.idxCall != null) {
-        return Optional.of(
-            new QueryIndexSummary(
-                table, Set.of(), Set.of(), ImmutableSet.of(idxFinder.idxCall), 1.0));
-      }
+    if (node instanceof RexInputRef inputRef) {
+      return ofSort(table, inputRef.getIndex());
     }
-    return Optional.empty();
+
+    if (!(node instanceof RexCall call)) {
+      return Optional.empty();
+    }
+
+    var idxFinder = new IndexableFinder();
+    call.accept(idxFinder);
+    if (!idxFinder.isIndexable || idxFinder.idxCall == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new QueryIndexSummary(table, Set.of(), Set.of(), ImmutableSet.of(idxFinder.idxCall), 1.0));
   }
 
   public static Optional<QueryIndexSummary> ofSort(@NonNull NamedTable table, int columnIndex) {
@@ -151,11 +152,11 @@ public class QueryIndexSummary {
       // See which of the indexable function calls are covered
       List<IndexableFunctionCall> coveredCalls = new ArrayList<>();
       Set<Integer> indexCols = ImmutableSet.copyOf(indexDef.getColumns());
-      for (IndexableFunctionCall fcall : this.functionCalls) {
-        var function = fcall.function();
+      for (IndexableFunctionCall fnCall : this.functionCalls) {
+        var function = fnCall.function();
         if (function.getSupportedIndexes().contains(indexType)
-            && indexCols.containsAll(fcall.columnIndexes())) {
-          coveredCalls.add(fcall);
+            && indexCols.containsAll(fnCall.columnIndexes())) {
+          coveredCalls.add(fnCall);
         }
       }
       if (coveredCalls.isEmpty()) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/hint/IndexHint.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/hint/IndexHint.java
@@ -21,8 +21,10 @@ import com.datasqrl.planner.parser.ParsedObject;
 import com.datasqrl.planner.parser.SqrlHint;
 import com.datasqrl.planner.parser.StatementParserException;
 import com.google.auto.service.AutoService;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
 
 /**
  * Explicitly assign an index to a table that's persisted to a database engine. Overwrites the
@@ -34,11 +36,16 @@ public class IndexHint extends ColumnNamesHint {
   public static final String HINT_NAME = "index";
 
   private final IndexType indexType;
+  private final List<Direction> directions;
 
   protected IndexHint(
-      ParsedObject<SqrlHint> source, IndexType indexType, List<String> columnsNames) {
+      ParsedObject<SqrlHint> source,
+      IndexType indexType,
+      List<String> columnsNames,
+      List<Direction> directions) {
     super(source, Type.DAG, columnsNames);
     this.indexType = indexType;
+    this.directions = directions;
   }
 
   @AutoService(Factory.class)
@@ -48,9 +55,10 @@ public class IndexHint extends ColumnNamesHint {
     public PlannerHint create(ParsedObject<SqrlHint> source) {
       var arguments = source.get().options();
       if (arguments == null || arguments.isEmpty()) {
-        return new IndexHint(source, null, List.of()); // no hint
+        return new IndexHint(source, null, List.of(), List.of()); // no hint
       }
-      if (arguments.size() <= 1) {
+
+      if (arguments.size() == 1) {
         throw new StatementParserException(
             ErrorLabel.GENERIC,
             source.getFileLocation(),
@@ -64,12 +72,73 @@ public class IndexHint extends ColumnNamesHint {
             "Unknown index type: %s",
             arguments.get(0));
       }
-      return new IndexHint(source, optIndex.get(), arguments.subList(1, arguments.size()));
+      var indexType = optIndex.get();
+      var columns = parseColumns(source, indexType, arguments.subList(1, arguments.size()));
+
+      return new IndexHint(source, indexType, columns.names(), columns.directions());
     }
 
     @Override
     public String getName() {
       return HINT_NAME;
     }
+
+    private static ParsedColumns parseColumns(
+        ParsedObject<SqrlHint> source, IndexType indexType, List<String> arguments) {
+
+      var columnNames = new ArrayList<String>();
+      var directions = new ArrayList<Direction>();
+
+      for (var argument : arguments) {
+        var terms = argument.trim().split("\\s+");
+
+        if (argument.isBlank() || terms.length > 2) {
+          throw invalidColumnSpecification(source, argument);
+        }
+
+        columnNames.add(terms[0]);
+
+        Direction direction = Direction.ASCENDING;
+        if (terms.length > 1) {
+          direction = parseDirection(source, argument, terms[1]);
+        }
+
+        if (direction.isDescending() && !indexType.supportsSortOrder()) {
+          throw new StatementParserException(
+              ErrorLabel.GENERIC,
+              source.getFileLocation(),
+              "Descending index columns are only supported for BTREE and PBTREE indexes.");
+        }
+
+        directions.add(direction);
+      }
+
+      return new ParsedColumns(columnNames, directions);
+    }
+
+    private static Direction parseDirection(
+        ParsedObject<SqrlHint> source, String argument, String direction) {
+
+      if ("asc".equalsIgnoreCase(direction)) {
+        return Direction.ASCENDING;
+      }
+
+      if ("desc".equalsIgnoreCase(direction)) {
+        return Direction.DESCENDING;
+      }
+
+      throw invalidColumnSpecification(source, argument);
+    }
+
+    private static StatementParserException invalidColumnSpecification(
+        ParsedObject<SqrlHint> source, String argument) {
+      return new StatementParserException(
+          ErrorLabel.GENERIC,
+          source.getFileLocation(),
+          "Invalid index column specification: %s. Expected a column name optionally followed by ASC or DESC.",
+          argument);
+    }
+
+    private record ParsedColumns(List<String> names, List<Direction> directions) {}
   }
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/plan/global/IndexSelectorTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/plan/global/IndexSelectorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.plan.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.plan.global.IndexSelector.NamedTable;
+import com.datasqrl.planner.analyzer.TableAnalysis;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.junit.jupiter.api.Test;
+
+class IndexSelectorTest {
+
+  @Test
+  void givenProjectedColumnSort_whenSummarize_thenIdentifiesColumn() {
+    var fieldType = mock(RelDataType.class);
+    var field = mock(RelDataTypeField.class);
+    when(field.getType()).thenReturn(fieldType);
+    var rowType = mock(RelDataType.class);
+    when(rowType.getFieldList()).thenReturn(List.of(field));
+
+    var summary =
+        QueryIndexSummary.ofSort(
+                new NamedTable("orders", "orders", null, null), RexInputRef.of(0, rowType))
+            .orElseThrow();
+
+    assertThat(summary.getInequalityColumns()).containsExactly(0);
+  }
+
+  @Test
+  void givenSort_whenGenerateIndexCandidates_thenBtreeUsesDefaultSortOrder() {
+    var rowType = mock(RelDataType.class);
+    when(rowType.getFieldNames()).thenReturn(List.of("col_a"));
+    var relNode = mock(RelNode.class);
+    when(relNode.getRowType()).thenReturn(rowType);
+    var tableAnalysis =
+        TableAnalysis.builder()
+            .objectIdentifier(ObjectIdentifier.of("datasqrl", "public", "orders"))
+            .collapsedRelnode(relNode)
+            .originalRelnode(relNode)
+            .build();
+    var table = new NamedTable("orders", "orders", tableAnalysis, null);
+    var summary = new QueryIndexSummary(table, Set.of(), Set.of(0), Set.of(), 1.0);
+    var config = mock(IndexSelectorConfig.class);
+    when(config.supportedIndexTypes()).thenReturn(EnumSet.of(IndexType.BTREE));
+    when(config.maxIndexColumns(IndexType.BTREE)).thenReturn(1);
+
+    var candidates = new IndexSelector(null, config, Map.of()).generateIndexCandidates(summary);
+
+    assertThat(candidates)
+        .singleElement()
+        .satisfies(
+            index -> {
+              assertThat(index.getColumns()).containsExactly(0);
+              assertThat(index.getDirections()).containsExactly(Direction.ASCENDING);
+            });
+  }
+}

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/hint/IndexHintTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/hint/IndexHintTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.hint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datasqrl.error.ErrorLocation.FileLocation;
+import com.datasqrl.plan.global.IndexType;
+import com.datasqrl.planner.parser.ParsedObject;
+import com.datasqrl.planner.parser.SqrlHint;
+import com.datasqrl.planner.parser.StatementParserException;
+import java.util.List;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.junit.jupiter.api.Test;
+
+class IndexHintTest {
+
+  private final IndexHint.IndexHintFactory factory = new IndexHint.IndexHintFactory();
+
+  @Test
+  void givenDescendingIndexColumn_whenCreate_thenRetainsSortDirections() {
+    var parsedHint =
+        SqrlHint.parse(
+                new ParsedObject<>(
+                    "index(BTREE, col_a DESC, col_b asc, col_c)", FileLocation.START))
+            .get(0);
+
+    var hint = (IndexHint) factory.create(parsedHint);
+
+    assertThat(hint.getIndexType()).isEqualTo(IndexType.BTREE);
+    assertThat(hint.getColumnNames()).containsExactly("col_a", "col_b", "col_c");
+    assertThat(hint.getDirections())
+        .containsExactly(Direction.DESCENDING, Direction.ASCENDING, Direction.ASCENDING);
+  }
+
+  @Test
+  void givenInvalidIndexColumnDirection_whenCreate_thenThrows() {
+    var hint =
+        new ParsedObject<>(
+            new SqrlHint("index", List.of("BTREE", "col_a sideways")), FileLocation.START);
+
+    assertThatThrownBy(() -> factory.create(hint))
+        .isInstanceOf(StatementParserException.class)
+        .hasMessageContaining("Expected a column name optionally followed by ASC or DESC");
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/indexHints.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/indexHints.sqrl
@@ -9,7 +9,7 @@ MyOrdersIndexHash := SELECT * FROM _Orders WHERE id > 10;
 /*+index */
 MyOrdersNoIndex := SELECT * FROM _Orders WHERE id > 10;
 
-/*+index(btree, time, id), index(hash, customerid) */
+/*+index(btree, time DESC, id), index(hash, customerid) */
 MyOrdersTwoIndex := SELECT * FROM _Orders WHERE id > 10;
 
 MyOrdersNoHint := SELECT * FROM _Orders WHERE id > 10;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -631,9 +631,9 @@ END
       "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersIndexHash_2_hash_c1\" ON \"MyOrdersIndexHash_2\" USING hash (\"customerid\")"
     },
     {
-      "name" : "MyOrdersTwoIndex_5_btree_c2c0",
+      "name" : "MyOrdersTwoIndex_5_btree_c2dc0",
       "type" : "INDEX",
-      "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersTwoIndex_5_btree_c2c0\" ON \"MyOrdersTwoIndex_5\" USING btree (\"time\",\"id\")"
+      "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersTwoIndex_5_btree_c2dc0\" ON \"MyOrdersTwoIndex_5\" USING btree (\"time\" DESC,\"id\")"
     },
     {
       "name" : "MyOrdersTwoIndex_5_hash_c1",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -626,9 +626,9 @@ END
       "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersIndexHash_2_hash_c1\" ON \"MyOrdersIndexHash_2\" USING hash (\"customerid\")"
     },
     {
-      "name" : "MyOrdersTwoIndex_5_btree_c2c0",
+      "name" : "MyOrdersTwoIndex_5_btree_c2dc0",
       "type" : "INDEX",
-      "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersTwoIndex_5_btree_c2c0\" ON \"MyOrdersTwoIndex_5\" USING btree (\"time\",\"id\")"
+      "sql" : "CREATE INDEX IF NOT EXISTS \"MyOrdersTwoIndex_5_btree_c2dc0\" ON \"MyOrdersTwoIndex_5\" USING btree (\"time\" DESC,\"id\")"
     },
     {
       "name" : "MyOrdersTwoIndex_5_hash_c1",


### PR DESCRIPTION
## Summary

Adds sort-order support for JDBC index hints and propagates Calcite sort direction into generated B-tree index candidates.

## Key Changes

- Supports index hints such as `/*+ index(BTREE, col_a DESC, col_b) */`.
- Adds index-column directions to `IndexDefinition`.
- Adds sort metadata to `QueryIndexSummary`.
- Preserves Calcite `RelFieldCollation.Direction` when selecting indexes for limited sorted queries.
- Generates distinct index names for descending columns.
- Emits `DESC` in PostgreSQL `CREATE INDEX` DDL.
- Adds `IndexType.supportsSortOrder()` to centralize index capability checks.
- Rejects descending columns for index types that do not support sort order.
- Adds parser, index-selector, and PostgreSQL DDL tests.