### PR TITLE
feat: Add configurable view namespace for Spark SQL and Redshift engines

### DIFF
--- a/documentation/docs/configuration-engine/iceberg-query.md
+++ b/documentation/docs/configuration-engine/iceberg-query.md
@@ -86,8 +86,28 @@ Snowflake is a cloud-based analytic database query engine that can read Iceberg 
 
 ### Spark SQL (`sparksql`)
 
-Spark SQL generates Spark SQL definitions for Iceberg tables. Enable it by adding `"sparksql"` to `enabled-engines`. It has no engine-specific configuration options.
+Spark SQL generates Spark SQL definitions for Iceberg tables. Enable it by adding `"sparksql"` to `enabled-engines`.
+
+#### Configuration Options
+
+| Key             | Type       | Default   | Description                                                  |
+|-----------------|------------|-----------|--------------------------------------------------------------|
+| `view-catalog`  | **string** | -         | Catalog that contains generated views                        |
+| `view-database` | **string** | `default` | Database that contains generated views when a catalog is set |
+
+When configured, generated view names are qualified as `catalog.database.view`. Setting only `view-database` qualifies views as `database.view` in the current catalog.
+Setting `view-catalog` without `view-database` uses Spark SQL's `default` database.
 
 ### Redshift (`redshift`)
 
-Redshift generates Amazon Redshift SQL definitions for Iceberg tables. Enable it by adding `"redshift"` to `enabled-engines`. It has no engine-specific configuration options.
+Redshift generates Amazon Redshift SQL definitions for Iceberg tables. Enable it by adding `"redshift"` to `enabled-engines`.
+
+#### Configuration Options
+
+| Key             | Type       | Default  | Description                                                   |
+|-----------------|------------|----------|---------------------------------------------------------------|
+| `view-database` | **string** | -        | Database that contains generated views                        |
+| `view-schema`   | **string** | `public` | Schema that contains generated views when a database is set   |
+
+When configured, generated view names are qualified as `database.schema.view`. Setting only `view-schema` qualifies views as `schema.view` in the current database.
+Setting `view-database` without `view-schema` uses Redshift's `public` schema.

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
@@ -242,6 +242,10 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
     return sqlConverters.convert(createView);
   }
 
+  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
+    return new SqlIdentifier(viewName, SqlParserPos.ZERO);
+  }
+
   protected Set<DatabaseTypeExtension> extractTypeExtensions(
       Stream<RelNode> relNodes, List<DatabaseTypeExtension> extensions) {
     return relNodes
@@ -299,7 +303,7 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
       RelDataType rowType,
       SqlNode sqlNode,
       Documented.Documentation documentation) {
-    var viewNameIdentifier = new SqlIdentifier(viewName, SqlParserPos.ZERO);
+    var viewNameIdentifier = getViewStatementIdentifier(viewName);
     var columnList =
         new SqlNodeList(
             rowType.getFieldList().stream()

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftEngine.java
@@ -38,6 +38,6 @@ public class RedshiftEngine extends AbstractJDBCShallowQueryEngine {
 
   @Override
   public JdbcStatementFactory getStatementFactory() {
-    return new RedshiftStatementFactory();
+    return new RedshiftStatementFactory(engineConfig);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
@@ -16,23 +16,45 @@
 package com.datasqrl.engine.database.relational;
 
 import com.datasqrl.calcite.Dialect;
+import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.ddl.GenericCreateTableDdlFactory;
 import com.datasqrl.plan.global.IndexDefinition;
 import com.datasqrl.planner.hint.DataTypeHint;
+import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.dialect.RedshiftSqlDialect;
+import org.apache.calcite.sql.parser.SqlParserPos;
 
 public class RedshiftStatementFactory extends AbstractJdbcStatementFactory {
 
-  public RedshiftStatementFactory() {
+  private final EngineConfig engineConfig;
+
+  public RedshiftStatementFactory(EngineConfig engineConfig) {
     super(Dialect.REDSHIFT, new GenericCreateTableDdlFactory(RedshiftSqlDialect.DEFAULT));
+    this.engineConfig = engineConfig;
   }
 
   @Override
   protected SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint) {
     return RedshiftSqlDialect.DEFAULT.getCastSpec(type);
+  }
+
+  @Override
+  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
+    var names = new ArrayList<String>();
+    var database = engineConfig.getSettingOptional("view-database");
+    if (database.isPresent()) {
+      names.add(database.get());
+      names.add(engineConfig.getSettingOptional("view-schema").orElse("public"));
+    } else {
+      engineConfig.getSettingOptional("view-schema").ifPresent(names::add);
+    }
+    names.add(viewName);
+
+    return new SqlIdentifier(names, SqlParserPos.ZERO);
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlEngine.java
@@ -38,6 +38,6 @@ public class SparkSqlEngine extends AbstractJDBCShallowQueryEngine {
 
   @Override
   public JdbcStatementFactory getStatementFactory() {
-    return new SparkSqlStatementFactory();
+    return new SparkSqlStatementFactory(engineConfig);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
@@ -17,22 +17,43 @@ package com.datasqrl.engine.database.relational;
 
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.calcite.dialect.ExtendedSparkSqlDialect;
+import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.ddl.GenericCreateTableDdlFactory;
 import com.datasqrl.plan.global.IndexDefinition;
 import com.datasqrl.planner.hint.DataTypeHint;
+import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
 
 public class SparkSqlStatementFactory extends AbstractJdbcStatementFactory {
 
-  public SparkSqlStatementFactory() {
+  private final EngineConfig engineConfig;
+
+  public SparkSqlStatementFactory(EngineConfig engineConfig) {
     super(Dialect.SPARK_SQL, new GenericCreateTableDdlFactory(ExtendedSparkSqlDialect.DEFAULT));
+    this.engineConfig = engineConfig;
   }
 
   @Override
   protected SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint) {
     return ExtendedSparkSqlDialect.DEFAULT.getCastSpec(type);
+  }
+
+  @Override
+  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
+    var names = new ArrayList<String>();
+    var catalog = engineConfig.getSettingOptional("view-catalog");
+    if (catalog.isPresent()) {
+      names.add(catalog.get());
+      names.add(engineConfig.getSettingOptional("view-database").orElse("default"));
+    } else {
+      engineConfig.getSettingOptional("view-database").ifPresent(names::add);
+    }
+    names.add(viewName);
+    return new SqlIdentifier(names, SqlParserPos.ZERO);
   }
 
   @Override

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -189,6 +189,21 @@
       "type": "object",
       "minProperties": 1,
       "properties": {
+        "flink": {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "config": {
+              "type": "object",
+              "minProperties": 1
+            },
+            "deployment": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
         "duckdb": {
           "type": "object",
           "properties": {
@@ -208,17 +223,26 @@
           "additionalProperties": false,
           "required": ["url"]
         },
-        "flink": {
+        "redshift": {
           "type": "object",
-          "minProperties": 1,
           "properties": {
-            "config": {
-              "type": "object",
-              "minProperties": 1
+            "view-database": {
+              "type": "string"
             },
-            "deployment": {
-              "type": "object",
-              "additionalProperties": true
+            "view-schema": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "sparksql": {
+          "type": "object",
+          "properties": {
+            "view-catalog": {
+              "type": "string"
+            },
+            "view-database": {
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.config.PackageJson.EngineConfig;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ViewStatementIdentifierTest {
+
+  @Test
+  void givenDefaultStatementFactory_whenGettingViewIdentifier_thenReturnsViewNameOnly() {
+    var factory = new PostgresStatementFactory(1);
+
+    assertThat(factory.getViewStatementIdentifier("Orders").names).containsExactly("Orders");
+  }
+
+  @Test
+  void givenSparkViewLocation_whenGettingViewIdentifier_thenPrependsCatalogAndDatabase() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getSettingOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
+    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
+    var factory = new SparkSqlStatementFactory(engineConfig);
+
+    assertThat(factory.getViewStatementIdentifier("Orders").names)
+        .containsExactly("spark_catalog", "analytics", "Orders");
+  }
+
+  @Test
+  void givenSparkViewCatalogWithoutDatabase_whenGettingViewIdentifier_thenUsesDefaultDatabase() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getSettingOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
+    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.empty());
+    var factory = new SparkSqlStatementFactory(engineConfig);
+
+    assertThat(factory.getViewStatementIdentifier("Orders").names)
+        .containsExactly("spark_catalog", "default", "Orders");
+  }
+
+  @Test
+  void givenRedshiftViewLocation_whenGettingViewIdentifier_thenPrependsDatabaseAndSchema() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getSettingOptional("view-schema")).thenReturn(Optional.of("reporting"));
+    var factory = new RedshiftStatementFactory(engineConfig);
+
+    assertThat(factory.getViewStatementIdentifier("Orders").names)
+        .containsExactly("analytics", "reporting", "Orders");
+  }
+
+  @Test
+  void givenRedshiftViewDatabaseWithoutSchema_whenGettingViewIdentifier_thenUsesPublicSchema() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getSettingOptional("view-schema")).thenReturn(Optional.empty());
+    var factory = new RedshiftStatementFactory(engineConfig);
+
+    assertThat(factory.getViewStatementIdentifier("Orders").names)
+        .containsExactly("analytics", "public", "Orders");
+  }
+}


### PR DESCRIPTION
## Key Changes
- Add a protected view-identifier hook to JDBC statement factories, preserving the existing single-part view name by default.
- Pass Spark SQL and Redshift engine configuration into their statement factories.
- Support qualified view names for shallow query engines:
  - Spark SQL: `view-catalog.view-database.view-name`
  - Redshift: `view-database.view-schema.view-name`
- Default missing qualification components when a higher-level component is configured:
  - Spark SQL defaults `view-database` to `default` when `view-catalog` is set.
  - Redshift defaults `view-schema` to `public` when `view-database` is set.
- Add focused coverage for default, Spark SQL, and Redshift view identifier construction.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>