### PR TITLE
ci: Optimize JDK setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,15 +81,29 @@ commands:
             EOF
 
   install-jdk:
-    description: "Install OpenJDK 17"
+    description: "Provision Eclipse Temurin 17"
     steps:
       - run:
-          name: Install OpenJDK 17
+          name: Provision Eclipse Temurin 17
           command: |
-                   sudo apt-get update && sudo apt-get install -y openjdk-17-jdk
-                   sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
-                   sudo update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-amd64/bin/javac
-                   java -version
+            JDK_IMAGE=eclipse-temurin:17-jdk-noble@sha256:30df3b90dc99b30e663c44e74c42f0a942360718b189558e1fe6692504c69a17
+            JAVA_HOME="$HOME/.jdk/temurin-17"
+            JDK_CONTAINER="temurin-jdk-$$"
+
+            trap 'docker rm -f "$JDK_CONTAINER" >/dev/null 2>&1 || true' EXIT
+            docker create --name "$JDK_CONTAINER" "$JDK_IMAGE" >/dev/null
+            rm -rf "$JAVA_HOME"
+            mkdir -p "$JAVA_HOME"
+            docker cp "$JDK_CONTAINER:/opt/java/openjdk/." "$JAVA_HOME"
+            docker rm "$JDK_CONTAINER" >/dev/null
+            trap - EXIT
+
+            echo "export JAVA_HOME=$JAVA_HOME" >> "$BASH_ENV"
+            echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> "$BASH_ENV"
+            export JAVA_HOME
+            export PATH="$JAVA_HOME/bin:$PATH"
+            java -version
+            javac -version
 
   determine-version:
     description: "Derive TAG_SUFFIX and REGISTRY"


### PR DESCRIPTION
Replace runtime apt installation of OpenJDK 17 on machine jobs with extraction from the pinned Eclipse Temurin image. This avoids `apt` index updates while preserving Java 17 for Maven.

Those `apt` updates sometimes took almost 20 mins, compared to a couple seconds after this change.