### PR TITLE
feat: Expose remaining graphql-java ParserOptions settings in vertx-config.json

### DIFF
--- a/sqrl-cli/src/main/resources/templates/server-config.json
+++ b/sqrl-cli/src/main/resources/templates/server-config.json
@@ -183,7 +183,12 @@
     "maxCharacters" : 1048576,
     "maxTokens" : 15000,
     "maxWhitespaceTokens" : 200000,
-    "maxRuleDepth" : 500
+    "maxRuleDepth" : 500,
+    "captureIgnoredChars" : null,
+    "captureSourceLocation" : null,
+    "captureLineComments" : null,
+    "readerTrackData" : null,
+    "redactTokenParserErrorMessages" : null
   },
   "jwtAuth" : null,
   "oauthConfig" : null,

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
@@ -25,19 +25,10 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Overrides for everything graphql-java exposes on {@link ParserOptions} when parsing incoming
- * GraphQL documents. The four limits guard against Denial Of Service attacks; exceeding any of them
- * aborts parsing with a "To prevent Denial Of Service attacks, parsing has been cancelled" error.
+ * Config overrides for graphql-java {@link ParserOptions}. The four limits protect against
+ * denial-of-service attacks. Boxed values preserve each parser's default when unset.
  *
- * <p>Every setting is a boxed type rather than a primitive so that "not specified" is
- * representable. graphql-java does not use the same value for every kind of parsing — {@code
- * captureLineComments}, for instance, defaults to {@code true} for generic parsing but {@code
- * false} for operations — so this class holds only what the user actually set and leaves the rest
- * to graphql-java's own default for the parser being configured. Behaviour is therefore unchanged
- * when the {@code graphQLParserConfig} section is absent from {@code vertx-config.json}.
- *
- * <p>{@code parsingListener} is deliberately not exposed: it takes a callback implementation, which
- * cannot be expressed in a config file.
+ * <p>{@code parsingListener} is excluded because a callback cannot be represented in configuration.
  */
 @Getter
 @Setter
@@ -58,12 +49,7 @@ public class GraphQLParserConfig {
   private Boolean readerTrackData;
   private Boolean redactTokenParserErrorMessages;
 
-  /**
-   * Applies this configuration to the JVM-wide graphql-java parser defaults. Both the generic and
-   * the operation defaults are updated because query parsing resolves its options from {@link
-   * ParserOptions#getDefaultOperationParserOptions()}. SDL parsing keeps its own, much higher
-   * defaults and is deliberately left untouched.
-   */
+  /** Applies overrides to the JVM-wide generic and operation parser defaults, not SDL defaults. */
   public void applyParserConfig() {
     if (!hasOverrides()) {
       return;

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
@@ -17,6 +17,7 @@ package com.datasqrl.server.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import graphql.parser.ParserOptions;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,18 +25,16 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Everything graphql-java exposes on {@link ParserOptions} for parsing incoming GraphQL documents.
+ * Overrides for everything graphql-java exposes on {@link ParserOptions} when parsing incoming
+ * GraphQL documents. The four limits guard against Denial Of Service attacks; exceeding any of them
+ * aborts parsing with a "To prevent Denial Of Service attacks, parsing has been cancelled" error.
  *
- * <p>The four limits guard against Denial Of Service attacks; exceeding any of them aborts parsing
- * with a "To prevent Denial Of Service attacks, parsing has been cancelled" error. Their defaults
- * mirror graphql-java's own constants.
- *
- * <p>The remaining flags are {@link Boolean} rather than {@code boolean} because graphql-java does
- * not use the same value for every kind of parsing — {@code captureLineComments}, for instance,
- * defaults to {@code true} for generic parsing but {@code false} for operations. Leaving one unset
- * (null) keeps whatever graphql-java itself defaults to for the parser being configured, so
- * behaviour is unchanged when the {@code graphQLParserConfig} section is absent from {@code
- * vertx-config.json}.
+ * <p>Every setting is a boxed type rather than a primitive so that "not specified" is
+ * representable. graphql-java does not use the same value for every kind of parsing — {@code
+ * captureLineComments}, for instance, defaults to {@code true} for generic parsing but {@code
+ * false} for operations — so this class holds only what the user actually set and leaves the rest
+ * to graphql-java's own default for the parser being configured. Behaviour is therefore unchanged
+ * when the {@code graphQLParserConfig} section is absent from {@code vertx-config.json}.
  *
  * <p>{@code parsingListener} is deliberately not exposed: it takes a callback implementation, which
  * cannot be expressed in a config file.
@@ -48,10 +47,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GraphQLParserConfig {
 
-  private int maxCharacters = ParserOptions.MAX_QUERY_CHARACTERS;
-  private int maxTokens = ParserOptions.MAX_QUERY_TOKENS;
-  private int maxWhitespaceTokens = ParserOptions.MAX_WHITESPACE_TOKENS;
-  private int maxRuleDepth = ParserOptions.MAX_RULE_DEPTH;
+  private Integer maxCharacters;
+  private Integer maxTokens;
+  private Integer maxWhitespaceTokens;
+  private Integer maxRuleDepth;
 
   private Boolean captureIgnoredChars;
   private Boolean captureSourceLocation;
@@ -66,7 +65,7 @@ public class GraphQLParserConfig {
    * defaults and is deliberately left untouched.
    */
   public void applyParserConfig() {
-    if (isDefault()) {
+    if (!hasOverrides()) {
       return;
     }
 
@@ -80,42 +79,36 @@ public class GraphQLParserConfig {
     ParserOptions.setDefaultOperationParserOptions(updatedOperationParserOptions);
   }
 
-  private boolean isDefault() {
-    return maxCharacters == ParserOptions.MAX_QUERY_CHARACTERS
-        && maxTokens == ParserOptions.MAX_QUERY_TOKENS
-        && maxWhitespaceTokens == ParserOptions.MAX_WHITESPACE_TOKENS
-        && maxRuleDepth == ParserOptions.MAX_RULE_DEPTH
-        && captureIgnoredChars == null
-        && captureSourceLocation == null
-        && captureLineComments == null
-        && readerTrackData == null
-        && redactTokenParserErrorMessages == null;
+  private boolean hasOverrides() {
+    return maxCharacters != null
+        || maxTokens != null
+        || maxWhitespaceTokens != null
+        || maxRuleDepth != null
+        || captureIgnoredChars != null
+        || captureSourceLocation != null
+        || captureLineComments != null
+        || readerTrackData != null
+        || redactTokenParserErrorMessages != null;
   }
 
   private ParserOptions withCustomConfig(ParserOptions options) {
     return options.transform(
         builder -> {
-          builder
-              .maxCharacters(maxCharacters)
-              .maxTokens(maxTokens)
-              .maxWhitespaceTokens(maxWhitespaceTokens)
-              .maxRuleDepth(maxRuleDepth);
-
-          if (captureIgnoredChars != null) {
-            builder.captureIgnoredChars(captureIgnoredChars);
-          }
-          if (captureSourceLocation != null) {
-            builder.captureSourceLocation(captureSourceLocation);
-          }
-          if (captureLineComments != null) {
-            builder.captureLineComments(captureLineComments);
-          }
-          if (readerTrackData != null) {
-            builder.readerTrackData(readerTrackData);
-          }
-          if (redactTokenParserErrorMessages != null) {
-            builder.redactTokenParserErrorMessages(redactTokenParserErrorMessages);
-          }
+          applyIfSet(maxCharacters, builder::maxCharacters);
+          applyIfSet(maxTokens, builder::maxTokens);
+          applyIfSet(maxWhitespaceTokens, builder::maxWhitespaceTokens);
+          applyIfSet(maxRuleDepth, builder::maxRuleDepth);
+          applyIfSet(captureIgnoredChars, builder::captureIgnoredChars);
+          applyIfSet(captureSourceLocation, builder::captureSourceLocation);
+          applyIfSet(captureLineComments, builder::captureLineComments);
+          applyIfSet(readerTrackData, builder::readerTrackData);
+          applyIfSet(redactTokenParserErrorMessages, builder::redactTokenParserErrorMessages);
         });
+  }
+
+  private static <T> void applyIfSet(T value, Consumer<T> setter) {
+    if (value != null) {
+      setter.accept(value);
+    }
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/GraphQLParserConfig.java
@@ -20,19 +20,30 @@ import graphql.parser.ParserOptions;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Safety limits graphql-java applies while parsing incoming GraphQL documents. Exceeding any of
- * them aborts parsing with a "To prevent Denial Of Service attacks, parsing has been cancelled"
- * error.
+ * Everything graphql-java exposes on {@link ParserOptions} for parsing incoming GraphQL documents.
  *
- * <p>Defaults mirror graphql-java's own defaults, so behaviour is unchanged when the {@code
- * graphQLParserConfig} section is absent from {@code vertx-config.json}.
+ * <p>The four limits guard against Denial Of Service attacks; exceeding any of them aborts parsing
+ * with a "To prevent Denial Of Service attacks, parsing has been cancelled" error. Their defaults
+ * mirror graphql-java's own constants.
+ *
+ * <p>The remaining flags are {@link Boolean} rather than {@code boolean} because graphql-java does
+ * not use the same value for every kind of parsing — {@code captureLineComments}, for instance,
+ * defaults to {@code true} for generic parsing but {@code false} for operations. Leaving one unset
+ * (null) keeps whatever graphql-java itself defaults to for the parser being configured, so
+ * behaviour is unchanged when the {@code graphQLParserConfig} section is absent from {@code
+ * vertx-config.json}.
+ *
+ * <p>{@code parsingListener} is deliberately not exposed: it takes a callback implementation, which
+ * cannot be expressed in a config file.
  */
 @Getter
 @Setter
 @NoArgsConstructor
+@ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Slf4j
 public class GraphQLParserConfig {
@@ -42,9 +53,15 @@ public class GraphQLParserConfig {
   private int maxWhitespaceTokens = ParserOptions.MAX_WHITESPACE_TOKENS;
   private int maxRuleDepth = ParserOptions.MAX_RULE_DEPTH;
 
+  private Boolean captureIgnoredChars;
+  private Boolean captureSourceLocation;
+  private Boolean captureLineComments;
+  private Boolean readerTrackData;
+  private Boolean redactTokenParserErrorMessages;
+
   /**
-   * Applies these limits to the JVM-wide graphql-java parser defaults. Both the generic and the
-   * operation defaults are updated because query parsing resolves its options from {@link
+   * Applies this configuration to the JVM-wide graphql-java parser defaults. Both the generic and
+   * the operation defaults are updated because query parsing resolves its options from {@link
    * ParserOptions#getDefaultOperationParserOptions()}. SDL parsing keeps its own, much higher
    * defaults and is deliberately left untouched.
    */
@@ -53,12 +70,7 @@ public class GraphQLParserConfig {
       return;
     }
 
-    log.info(
-        "Applying custom GraphQL parser limits: maxCharacters={}, maxTokens={}, maxWhitespaceTokens={}, maxRuleDepth={}",
-        maxCharacters,
-        maxTokens,
-        maxWhitespaceTokens,
-        maxRuleDepth);
+    log.info("Applying custom GraphQL parser config: {}", this);
 
     var updatedParserOptions = withCustomConfig(ParserOptions.getDefaultParserOptions());
     ParserOptions.setDefaultParserOptions(updatedParserOptions);
@@ -72,16 +84,38 @@ public class GraphQLParserConfig {
     return maxCharacters == ParserOptions.MAX_QUERY_CHARACTERS
         && maxTokens == ParserOptions.MAX_QUERY_TOKENS
         && maxWhitespaceTokens == ParserOptions.MAX_WHITESPACE_TOKENS
-        && maxRuleDepth == ParserOptions.MAX_RULE_DEPTH;
+        && maxRuleDepth == ParserOptions.MAX_RULE_DEPTH
+        && captureIgnoredChars == null
+        && captureSourceLocation == null
+        && captureLineComments == null
+        && readerTrackData == null
+        && redactTokenParserErrorMessages == null;
   }
 
   private ParserOptions withCustomConfig(ParserOptions options) {
     return options.transform(
-        builder ->
-            builder
-                .maxCharacters(maxCharacters)
-                .maxTokens(maxTokens)
-                .maxWhitespaceTokens(maxWhitespaceTokens)
-                .maxRuleDepth(maxRuleDepth));
+        builder -> {
+          builder
+              .maxCharacters(maxCharacters)
+              .maxTokens(maxTokens)
+              .maxWhitespaceTokens(maxWhitespaceTokens)
+              .maxRuleDepth(maxRuleDepth);
+
+          if (captureIgnoredChars != null) {
+            builder.captureIgnoredChars(captureIgnoredChars);
+          }
+          if (captureSourceLocation != null) {
+            builder.captureSourceLocation(captureSourceLocation);
+          }
+          if (captureLineComments != null) {
+            builder.captureLineComments(captureLineComments);
+          }
+          if (readerTrackData != null) {
+            builder.readerTrackData(readerTrackData);
+          }
+          if (redactTokenParserErrorMessages != null) {
+            builder.redactTokenParserErrorMessages(redactTokenParserErrorMessages);
+          }
+        });
   }
 }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/GraphQLParserConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/GraphQLParserConfigTest.java
@@ -47,6 +47,49 @@ class GraphQLParserConfigTest {
     assertThat(config.getMaxTokens()).isEqualTo(ParserOptions.MAX_QUERY_TOKENS);
     assertThat(config.getMaxWhitespaceTokens()).isEqualTo(ParserOptions.MAX_WHITESPACE_TOKENS);
     assertThat(config.getMaxRuleDepth()).isEqualTo(ParserOptions.MAX_RULE_DEPTH);
+    assertThat(config.getCaptureIgnoredChars()).isNull();
+    assertThat(config.getCaptureSourceLocation()).isNull();
+    assertThat(config.getCaptureLineComments()).isNull();
+    assertThat(config.getReaderTrackData()).isNull();
+    assertThat(config.getRedactTokenParserErrorMessages()).isNull();
+  }
+
+  @Test
+  void given_customFlags_when_appliedToParserDefaults_then_bothParserDefaultsAreUpdated() {
+    var config = new GraphQLParserConfig();
+    config.setCaptureIgnoredChars(true);
+    config.setCaptureSourceLocation(false);
+    config.setCaptureLineComments(true);
+    config.setReaderTrackData(false);
+    config.setRedactTokenParserErrorMessages(true);
+
+    config.applyParserConfig();
+
+    for (var options :
+        new ParserOptions[] {
+          ParserOptions.getDefaultParserOptions(), ParserOptions.getDefaultOperationParserOptions()
+        }) {
+      assertThat(options.isCaptureIgnoredChars()).isTrue();
+      assertThat(options.isCaptureSourceLocation()).isFalse();
+      assertThat(options.isCaptureLineComments()).isTrue();
+      assertThat(options.isReaderTrackData()).isFalse();
+      assertThat(options.isRedactTokenParserErrorMessages()).isTrue();
+    }
+  }
+
+  /**
+   * graphql-java defaults {@code captureLineComments} to true for generic parsing but false for
+   * operations, so an unset flag must not flatten that difference.
+   */
+  @Test
+  void given_unsetFlags_when_limitsAreApplied_then_graphQlJavaFlagDefaultsAreKeptPerParser() {
+    var config = new GraphQLParserConfig();
+    config.setMaxTokens(45_000);
+
+    config.applyParserConfig();
+
+    assertThat(ParserOptions.getDefaultParserOptions().isCaptureLineComments()).isTrue();
+    assertThat(ParserOptions.getDefaultOperationParserOptions().isCaptureLineComments()).isFalse();
   }
 
   @Test

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/GraphQLParserConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/GraphQLParserConfigTest.java
@@ -40,13 +40,13 @@ class GraphQLParserConfigTest {
   }
 
   @Test
-  void given_newConfig_when_created_then_limitsMatchGraphQlJavaDefaults() {
+  void given_newConfig_when_created_then_nothingIsOverridden() {
     var config = new GraphQLParserConfig();
 
-    assertThat(config.getMaxCharacters()).isEqualTo(ParserOptions.MAX_QUERY_CHARACTERS);
-    assertThat(config.getMaxTokens()).isEqualTo(ParserOptions.MAX_QUERY_TOKENS);
-    assertThat(config.getMaxWhitespaceTokens()).isEqualTo(ParserOptions.MAX_WHITESPACE_TOKENS);
-    assertThat(config.getMaxRuleDepth()).isEqualTo(ParserOptions.MAX_RULE_DEPTH);
+    assertThat(config.getMaxCharacters()).isNull();
+    assertThat(config.getMaxTokens()).isNull();
+    assertThat(config.getMaxWhitespaceTokens()).isNull();
+    assertThat(config.getMaxRuleDepth()).isNull();
     assertThat(config.getCaptureIgnoredChars()).isNull();
     assertThat(config.getCaptureSourceLocation()).isNull();
     assertThat(config.getCaptureLineComments()).isNull();
@@ -90,6 +90,20 @@ class GraphQLParserConfigTest {
 
     assertThat(ParserOptions.getDefaultParserOptions().isCaptureLineComments()).isTrue();
     assertThat(ParserOptions.getDefaultOperationParserOptions().isCaptureLineComments()).isFalse();
+  }
+
+  @Test
+  void given_unsetLimits_when_flagIsApplied_then_graphQlJavaLimitDefaultsAreKept() {
+    var config = new GraphQLParserConfig();
+    config.setCaptureIgnoredChars(true);
+
+    config.applyParserConfig();
+
+    var applied = ParserOptions.getDefaultOperationParserOptions();
+    assertThat(applied.getMaxCharacters()).isEqualTo(ParserOptions.MAX_QUERY_CHARACTERS);
+    assertThat(applied.getMaxTokens()).isEqualTo(ParserOptions.MAX_QUERY_TOKENS);
+    assertThat(applied.getMaxWhitespaceTokens()).isEqualTo(ParserOptions.MAX_WHITESPACE_TOKENS);
+    assertThat(applied.getMaxRuleDepth()).isEqualTo(ParserOptions.MAX_RULE_DEPTH);
   }
 
   @Test
@@ -145,7 +159,7 @@ class GraphQLParserConfigTest {
   }
 
   @Test
-  void given_defaultLimits_when_appliedToParserDefaults_then_parserDefaultsAreUnchanged() {
+  void given_noOverrides_when_appliedToParserDefaults_then_parserDefaultsAreUnchanged() {
     var operationDefaults = ParserOptions.getDefaultOperationParserOptions();
 
     new GraphQLParserConfig().applyParserConfig();

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
@@ -77,7 +77,12 @@ class ServerConfigTest {
             .put("maxCharacters", 2_000_000)
             .put("maxTokens", 45_000)
             .put("maxWhitespaceTokens", 400_000)
-            .put("maxRuleDepth", 700));
+            .put("maxRuleDepth", 700)
+            .put("captureIgnoredChars", true)
+            .put("captureSourceLocation", false)
+            .put("captureLineComments", true)
+            .put("readerTrackData", false)
+            .put("redactTokenParserErrorMessages", true));
 
     var kafkaMutationConfig = MAPPER.createObjectNode();
     kafkaMutationConfig.put("bootstrap.servers", "localhost:9092");
@@ -111,6 +116,11 @@ class ServerConfigTest {
     assertThat(serverConfig.getGraphQLParserConfig().getMaxTokens()).isEqualTo(45_000);
     assertThat(serverConfig.getGraphQLParserConfig().getMaxWhitespaceTokens()).isEqualTo(400_000);
     assertThat(serverConfig.getGraphQLParserConfig().getMaxRuleDepth()).isEqualTo(700);
+    assertThat(serverConfig.getGraphQLParserConfig().getCaptureIgnoredChars()).isTrue();
+    assertThat(serverConfig.getGraphQLParserConfig().getCaptureSourceLocation()).isFalse();
+    assertThat(serverConfig.getGraphQLParserConfig().getCaptureLineComments()).isTrue();
+    assertThat(serverConfig.getGraphQLParserConfig().getReaderTrackData()).isFalse();
+    assertThat(serverConfig.getGraphQLParserConfig().getRedactTokenParserErrorMessages()).isTrue();
     assertThat(serverConfig.getKafkaMutationConfig()).isNotNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNotNull();
   }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
@@ -18,7 +18,6 @@ package com.datasqrl.server.config;
 import static com.datasqrl.util.JsonUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import graphql.parser.ParserOptions;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -42,8 +41,7 @@ class ServerConfigTest {
     assertThat(serverConfig.getGraphQLTailSampleTracingConfig()).isNotNull();
     assertThat(serverConfig.getGraphQLTailSampleTracingConfig().isEnabled()).isFalse();
     assertThat(serverConfig.getGraphQLParserConfig()).isNotNull();
-    assertThat(serverConfig.getGraphQLParserConfig().getMaxTokens())
-        .isEqualTo(ParserOptions.MAX_QUERY_TOKENS);
+    assertThat(serverConfig.getGraphQLParserConfig().getMaxTokens()).isNull();
     assertThat(serverConfig.getKafkaMutationConfig()).isNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNull();
   }


### PR DESCRIPTION
Follow-up to #2276, which exposed only the four integer limits of graphql-java's `ParserOptions`. This adds the remaining settings that sit alongside them.

## Change

`graphQLParserConfig` now covers everything `ParserOptions.Builder` exposes:

```json
"graphQLParserConfig" : {
  "maxCharacters" : 1048576,
  "maxTokens" : 15000,
  "maxWhitespaceTokens" : 200000,
  "maxRuleDepth" : 500,
  "captureIgnoredChars" : null,
  "captureSourceLocation" : null,
  "captureLineComments" : null,
  "readerTrackData" : null,
  "redactTokenParserErrorMessages" : null
}
```

The five new flags are `Boolean`, not `boolean`, and default to null. That is deliberate: graphql-java does **not** use one value across all parsers. Dumping the 26.0 defaults:

| setting | generic | operation | sdl |
| --- | --- | --- | --- |
| `captureIgnoredChars` | false | false | false |
| `captureSourceLocation` | true | true | true |
| `captureLineComments` | **true** | **false** | true |
| `readerTrackData` | true | true | true |
| `redactTokenParserErrorMessages` | false | false | false |

`captureLineComments` differs between generic and operation parsing, so baking a single primitive default into the config would silently flip operation parsing to `true` for every deployment. A null flag is left untouched, preserving whatever graphql-java defaults to for the parser being configured; a non-null flag is applied to both. Behaviour is unchanged when the section is absent or left at its defaults.

`parsingListener` is the one builder setting not exposed — it takes a callback implementation, which cannot be expressed in a config file.

## Testing

- `GraphQLParserConfigTest` — new cases for the flags being applied to both parser defaults, and for unset flags preserving the generic-vs-operation `captureLineComments` split rather than flattening it.
- `ServerConfigTest` — the flags deserialize from the config section.
- `ServerConfigTemplateTest` — template round-trip with the new nullable keys.
- `ServerFunctionContainerIT` re-run against freshly built `:local` images, so the server is verified to still start and parse with the new nullable keys present in `vertx-config.json`.

Full `mvn test` is green.
