### PR TITLE
fix: Add `INSERT` statements to DAG planning

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -146,10 +146,12 @@ import org.springframework.stereotype.Component;
 @Lazy
 public class SqlScriptPlanner {
 
+  private static final String INSERT_SUFFIX = "_in";
   private static final String EXPORT_SUFFIX = "_ex";
   private static final String ACCESS_FUNCTION_SUFFIX = "__access";
 
   private final AtomicInteger exportTableCounter = new AtomicInteger(0);
+  private final AtomicInteger insertTableCounter = new AtomicInteger(0);
 
   private final ErrorCollector errorCollector;
 
@@ -572,10 +574,7 @@ public class SqlScriptPlanner {
                 hintsAndDocs)
             .ifPresent(tableAnalysis -> addSourceToDag(tableAnalysis, hintsAndDocs, sqrlEnv));
       } else if (node instanceof RichSqlInsert insert) {
-        /*TODO: We are not currently adding these to the DAG (and hence no analysis/visualization based on the DAG)
-        We would need to analyze the query and pull out the sources to make that happen. However, for now
-        we are only doing this for FlinkSQL compatibility, so this may be fine. */
-        sqrlEnv.insertInto(insert);
+        addInsert(insert, hintsAndDocs, sqrlEnv, errors);
       } else if (node instanceof SqlAlterTable || node instanceof SqlAlterView) {
         errors.fatal(
             "Renaming or altering tables is not supported. Rename them directly in the script or IMPORT AS.");
@@ -1151,6 +1150,40 @@ public class SqlScriptPlanner {
       }
     }
     dagBuilder.addExport(exportNode, inputNode);
+  }
+
+  private void addInsert(
+      RichSqlInsert insert,
+      HintsAndDoc hintsAndDocs,
+      Sqrl2FlinkSQLTranslator sqrlEnv,
+      ErrorCollector errors) {
+
+    var sinkTableId = sqrlEnv.getInsertTarget(insert);
+    var sinkTable = sqrlEnv.getTableLookup().lookupSourceTable(sinkTableId);
+    errors.checkFatal(sinkTable != null, "Could not find INSERT target table: %s", sinkTableId);
+
+    var inputTable =
+        sqrlEnv.analyzeInsertQuery(
+            insert.getSource(),
+            scriptContext.toIdentifier(
+                sinkTableId.getObjectName() + INSERT_SUFFIX + insertTableCounter.incrementAndGet()),
+            hintsAndDocs,
+            errors);
+    var inputNode =
+        new TableNode(
+            inputTable,
+            getStageAnalysis(inputTable, determineStages(tableStages, hintsAndDocs.hints())));
+    dagBuilder.add(inputNode);
+    dagBuilder.addExport(
+        new ExportNode(
+            getSourceSinkStageAnalysis(),
+            NamePath.of(sinkTableId.toList().toArray(String[]::new)),
+            sqrlEnv.currentBatch(),
+            Optional.empty(),
+            Optional.of(sinkTableId),
+            sinkTable.getSourceSinkTable(),
+            Optional.of(insert)),
+        inputNode);
   }
 
   /**

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -125,7 +125,6 @@ import org.apache.flink.table.catalog.Column.ComputedColumn;
 import org.apache.flink.table.catalog.Column.MetadataColumn;
 import org.apache.flink.table.catalog.Column.PhysicalColumn;
 import org.apache.flink.table.catalog.ObjectIdentifier;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.operations.Operation;
@@ -167,6 +166,7 @@ import org.apache.flink.table.types.DataType;
 public class Sqrl2FlinkSQLTranslator {
 
   private static final String SCHEMA_SUFFIX = "__schema";
+  private static final String TEMP_VIEW_SUFFIX = "__view";
   private static final String DATATYPE_PARSING_PREFIX =
       "CREATE TEMPORARY TABLE __sqrlinternal_types( ";
 
@@ -503,6 +503,34 @@ public class Sqrl2FlinkSQLTranslator {
     return tableAnalysis;
   }
 
+  /** Analyzes a query executed directly by an INSERT statement. */
+  public TableAnalysis analyzeInsertQuery(
+      SqlNode query, ObjectIdentifier identifier, HintsAndDoc hintsAndDoc, ErrorCollector errors) {
+    var flinkPlanner = validatorSupplier.get();
+    var relRoot = toRelRoot(query, flinkPlanner);
+    var analyzer =
+        new SQRLLogicalPlanAnalyzer(
+            relRoot.project(),
+            tableLookup,
+            identifier.getObjectName(),
+            getRelBuilder(flinkPlanner),
+            flinkPlanner
+                .getOrCreateSqlValidator()
+                .getCatalogReader()
+                .unwrap(CalciteCatalogReader.class),
+            errors);
+    return analyzer
+        .analyze(hintsAndDoc)
+        .tableAnalysis()
+        .objectIdentifier(identifier)
+        .originalSql(RelToFlinkSql.convertToString(query))
+        .build();
+  }
+
+  public ObjectIdentifier getInsertTarget(RichSqlInsert insert) {
+    return qualifyIdentifier((SqlIdentifier) insert.getTargetTableID());
+  }
+
   private SqlNode removeSort(SqlNode sqlNode) {
     if (sqlNode instanceof SqlOrderBy by) {
       return by.query;
@@ -759,8 +787,6 @@ public class Sqrl2FlinkSQLTranslator {
         viewName, FlinkSqlNodes.selectAllFromTable(FlinkSqlNodes.identifier(id)));
   }
 
-  private static final String TEMP_VIEW_SUFFIX = "__view";
-
   private ObjectIdentifier qualifyIdentifier(SqlIdentifier identifier) {
     var names = identifier.names;
     var size = names.size();
@@ -888,7 +914,7 @@ public class Sqrl2FlinkSQLTranslator {
     validateMutationHints(tableOp, mutationBuilder);
 
     // Create table analysis
-    var flinkSchema = ((ResolvedCatalogTable) tableOp.getCatalogTable()).getResolvedSchema();
+    var flinkSchema = tableOp.getCatalogTable().getResolvedSchema();
     // Map primary key
     var pk =
         flinkSchema
@@ -973,8 +999,8 @@ public class Sqrl2FlinkSQLTranslator {
     planBuilder.addInsert(FlinkSqlNodes.createInsert(selectQuery, sinkTableId), batchIdx);
   }
 
-  public void insertInto(RichSqlInsert insert) {
-    planBuilder.addInsert(insert, null);
+  public void insertInto(RichSqlInsert insert, int batchIdx) {
+    planBuilder.addInsert(insert, batchIdx);
   }
 
   public void nextBatch() {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
@@ -17,7 +17,6 @@ package com.datasqrl.planner.dag;
 
 import com.datasqrl.canonicalizer.NamePath;
 import com.datasqrl.config.EngineType;
-import com.datasqrl.config.PackageJson;
 import com.datasqrl.datatype.DataTypeMapping;
 import com.datasqrl.datatype.DataTypeMapping.Direction;
 import com.datasqrl.engine.EngineFeature;
@@ -103,7 +102,6 @@ public class DAGPlanner {
 
   private final ExecutionPipeline pipeline;
   private final ErrorCollector errors;
-  private final PackageJson packageJson;
 
   /**
    * Eliminates unreachable nodes from the DAG and determines all viable execution stages for each
@@ -239,10 +237,17 @@ public class DAGPlanner {
                     } else {
                       // Special case, we sink directly to table
                       targetTable = exportNode.getCreatedSinkTable().get();
-                      sqrlEnv.insertInto(
-                          sqrlEnv.getTableScan(node.getIdentifier().objectIdentifier()).build(),
-                          targetTable,
-                          exportNode.getBatchIndex());
+                      exportNode
+                          .getOriginalInsert()
+                          .ifPresentOrElse(
+                              insert -> sqrlEnv.insertInto(insert, exportNode.getBatchIndex()),
+                              () ->
+                                  sqrlEnv.insertInto(
+                                      sqrlEnv
+                                          .getTableScan(node.getIdentifier().objectIdentifier())
+                                          .build(),
+                                      targetTable,
+                                      exportNode.getBatchIndex()));
                       continue;
                     }
                   } else { // We are sinking into another engine

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/nodes/ExportNode.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/nodes/ExportNode.java
@@ -23,6 +23,7 @@ import com.datasqrl.planner.tables.SourceSinkTableAnalysis;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
+import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
 /** Represents an EXPORT statement in the DAG */
@@ -35,6 +36,7 @@ public class ExportNode extends PipelineNode {
   private final Optional<ExecutionStage> sinkTo;
   private final Optional<ObjectIdentifier> createdSinkTable;
   private final Optional<SourceSinkTableAnalysis> sinkTableAnalysis;
+  private final Optional<RichSqlInsert> originalInsert;
 
   public ExportNode(
       Map<ExecutionStage, StageAnalysis> stageAnalysis,
@@ -43,12 +45,31 @@ public class ExportNode extends PipelineNode {
       Optional<ExecutionStage> sinkTo,
       Optional<ObjectIdentifier> createdSinkTable,
       Optional<SourceSinkTableAnalysis> sinkTableAnalysis) {
+    this(
+        stageAnalysis,
+        sinkPath,
+        batchIndex,
+        sinkTo,
+        createdSinkTable,
+        sinkTableAnalysis,
+        Optional.empty());
+  }
+
+  public ExportNode(
+      Map<ExecutionStage, StageAnalysis> stageAnalysis,
+      NamePath sinkPath,
+      int batchIndex,
+      Optional<ExecutionStage> sinkTo,
+      Optional<ObjectIdentifier> createdSinkTable,
+      Optional<SourceSinkTableAnalysis> sinkTableAnalysis,
+      Optional<RichSqlInsert> originalInsert) {
     super("export", stageAnalysis);
     this.sinkPath = sinkPath;
     this.batchIndex = batchIndex;
     this.sinkTo = sinkTo;
     this.createdSinkTable = createdSinkTable;
     this.sinkTableAnalysis = sinkTableAnalysis;
+    this.originalInsert = originalInsert;
   }
 
   public Optional<Map<String, String>> getConnectorConfig() {

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/DAGPlannerTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/DAGPlannerTest.java
@@ -78,7 +78,7 @@ public class DAGPlannerTest {
   @Disabled
   @Test
   void specificScript() {
-    var script = SCRIPT_DIR.resolve("comprehensiveTest.sqrl");
+    var script = SCRIPT_DIR.resolve("insertInto.sqrl");
     scripts(script);
   }
 

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/insertIntoMutation.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/insertIntoMutation.sqrl
@@ -1,0 +1,15 @@
+IMPORT ecommerceTs.customer;
+
+CustomerForApi := SELECT * FROM Customer;
+
+/*+engine(kafka) */
+CREATE TABLE CustomerCount (
+    customerid BIGINT,
+    numEntries BIGINT,
+    PRIMARY KEY (customerid) NOT ENFORCED
+);
+
+INSERT INTO CustomerCount
+    SELECT customerid, COUNT(*) AS numEntries
+    FROM Customer
+    GROUP BY customerid;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -37,6 +37,36 @@ WITH (
   'path' = 'file:/mock',
   'source.monitor-interval' = '10 sec'
 )
+=== customer_id_count
+ID:          default_catalog.default_database.customer_id_count
+Type:        export
+Stage:       flink
+Connector:   blackhole
+---
+Inputs:
+ - default_catalog.default_database.customer_id_count_in1
+
+=== customer_id_count_in1
+ID:          default_catalog.default_database.customer_id_count_in1
+Type:        state
+Stage:       flink
+Primary key: customerid
+Timestamp:   -
+Row count:   ~1e7
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - numEntries: BIGINT NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Plan:
+LogicalAggregate(group=[{0}], numEntries=[COUNT()])
+  LogicalProject(customerid=[$0])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
+FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
+GROUP BY `Customer`.`customerid`
 >>>flink-sql-no-functions.sql
 CREATE TABLE `Customer` (
   `customerid` BIGINT NOT NULL,
@@ -79,14 +109,14 @@ WITH (
   'username' = '${POSTGRES_USERNAME}'
 );
 EXECUTE STATEMENT SET BEGIN
-INSERT INTO `customer_id_count`
-SELECT `customerid`, COUNT(*) AS `numEntries`
-FROM `Customer`
-GROUP BY `customerid`
-;
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+;
+INSERT INTO `customer_id_count`
+SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
+FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
+GROUP BY `Customer`.`customerid`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -1,0 +1,650 @@
+>>>pipeline_explain.txt
+=== Customer
+ID:          default_catalog.default_database.Customer
+Type:        stream
+Stage:       flink
+Primary key: customerid, lastUpdated
+Timestamp:   timestamp
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer__base
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
+  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE TABLE `Customer` (
+  `customerid` BIGINT NOT NULL,
+  `email` STRING NOT NULL,
+  `name` STRING NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
+  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+)
+=== CustomerCount
+ID:          default_catalog.default_database.CustomerCount
+Type:        state
+Stage:       flink
+Primary key: customerid
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - numEntries: BIGINT
+Inputs:
+ - default_catalog.default_database.CustomerCount__base
+Plan:
+LogicalTableScan(table=[[default_catalog, default_database, CustomerCount]])
+SQL:
+CREATE TABLE `CustomerCount` (
+  `customerid` BIGINT NOT NULL,
+  `numEntries` BIGINT,
+  PRIMARY KEY (`customerid`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'upsert-kafka-safe',
+  'key.format' = 'flexible-json',
+  'properties.auto.offset.reset' = 'earliest',
+  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
+  'properties.compression.type' = 'zstd',
+  'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'topic' = 'kafka-mutation-CustomerCount',
+  'value.fields-include' = 'ALL',
+  'value.format' = 'flexible-json'
+)
+=== CustomerCount
+ID:          default_catalog.default_database.CustomerCount
+Type:        export
+Stage:       flink
+Connector:   upsert-kafka-safe
+---
+Inputs:
+ - default_catalog.default_database.CustomerCount_in1
+
+=== CustomerCount_in1
+ID:          default_catalog.default_database.CustomerCount_in1
+Type:        state
+Stage:       flink
+Primary key: customerid
+Timestamp:   -
+Row count:   ~1e7
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - numEntries: BIGINT NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Plan:
+LogicalAggregate(group=[{0}], numEntries=[COUNT()])
+  LogicalProject(customerid=[$0])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
+FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
+GROUP BY `Customer`.`customerid`
+=== CustomerForApi
+ID:          default_catalog.default_database.CustomerForApi
+Type:        stream
+Stage:       flink
+Primary key: customerid, lastUpdated
+Timestamp:   timestamp
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
+  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `CustomerForApi` AS  SELECT * FROM Customer;
+
+>>>flink-sql-no-functions.sql
+CREATE TABLE `Customer` (
+  `customerid` BIGINT NOT NULL,
+  `email` STRING NOT NULL,
+  `name` STRING NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), TIMESTAMP '1970-01-01 00:00:00.000'),
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
+  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE VIEW `CustomerForApi`
+AS
+SELECT *
+FROM `Customer`;
+CREATE TABLE `CustomerCount` (
+  `customerid` BIGINT,
+  `numEntries` BIGINT,
+  PRIMARY KEY (`customerid`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'upsert-kafka-safe',
+  'key.format' = 'flexible-json',
+  'properties.auto.offset.reset' = 'earliest',
+  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
+  'properties.compression.type' = 'zstd',
+  'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'topic' = 'kafka-mutation-CustomerCount',
+  'value.fields-include' = 'ALL',
+  'value.format' = 'flexible-json'
+);
+CREATE TABLE `Customer_1` (
+  `customerid` BIGINT NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Customer_1',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `CustomerCount_2` (
+  `customerid` BIGINT NOT NULL,
+  `numEntries` BIGINT,
+  PRIMARY KEY (`customerid`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'CustomerCount_2',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `CustomerForApi_3` (
+  `customerid` BIGINT NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'CustomerForApi_3',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`Customer_1`
+SELECT *
+FROM `default_catalog`.`default_database`.`Customer`
+;
+INSERT INTO `default_catalog`.`default_database`.`CustomerCount_2`
+SELECT *
+FROM `default_catalog`.`default_database`.`CustomerCount`
+;
+INSERT INTO `CustomerCount`
+SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
+FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
+GROUP BY `Customer`.`customerid`
+;
+INSERT INTO `default_catalog`.`default_database`.`CustomerForApi_3`
+SELECT *
+FROM `default_catalog`.`default_database`.`CustomerForApi`
+;
+END
+>>>kafka.json
+{
+  "topics" : [
+    {
+      "topicName" : "kafka-mutation-CustomerCount",
+      "tableName" : "CustomerCount",
+      "format" : "flexible-json",
+      "numPartitions" : 1,
+      "replicationFactor" : 3,
+      "type" : "MUTATION",
+      "messageKeys" : [
+        "customerid"
+      ],
+      "messageSchema" : "",
+      "config" : {
+        "cleanup.policy" : "compact"
+      }
+    }
+  ],
+  "testRunnerTopics" : [ ]
+}
+>>>postgres.json
+{
+  "statements" : [
+    {
+      "name" : "Customer_1",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"Customer_1\" (\"customerid\" BIGINT NOT NULL, \"email\" TEXT NOT NULL, \"name\" TEXT NOT NULL, \"lastUpdated\" BIGINT NOT NULL, \"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY (\"customerid\",\"lastUpdated\"))",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ],
+      "primaryKey" : [
+        "customerid",
+        "lastUpdated"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CustomerCount_2",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CustomerCount_2\" (\"customerid\" BIGINT NOT NULL, \"numEntries\" BIGINT, PRIMARY KEY (\"customerid\"))",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "numEntries",
+          "type" : "BIGINT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "customerid"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CustomerForApi_3",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CustomerForApi_3\" (\"customerid\" BIGINT NOT NULL, \"email\" TEXT NOT NULL, \"name\" TEXT NOT NULL, \"lastUpdated\" BIGINT NOT NULL, \"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY (\"customerid\",\"lastUpdated\"))",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ],
+      "primaryKey" : [
+        "customerid",
+        "lastUpdated"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "Customer",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"Customer\"(\"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\") AS SELECT *\nFROM \"Customer_1\"",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ]
+    },
+    {
+      "name" : "CustomerCount",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CustomerCount\"(\"customerid\", \"numEntries\") AS SELECT *\nFROM \"CustomerCount_2\"",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "numEntries",
+          "type" : "BIGINT",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "CustomerForApi",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CustomerForApi\"(\"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\") AS SELECT *\nFROM \"CustomerForApi_3\"",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ]
+    }
+  ],
+  "standaloneExtensionStatements" : [ ]
+}
+>>>vertx.json
+{
+  "models" : {
+    "v1" : {
+      "queries" : [
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "Customer",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"Customer_1\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CustomerCount",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"CustomerCount_2\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CustomerForApi",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"CustomerForApi_3\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        }
+      ],
+      "mutations" : [
+        {
+          "type" : "kafka",
+          "fieldName" : "CustomerCount",
+          "returnList" : false,
+          "topic" : "kafka-mutation-CustomerCount",
+          "keyColumns" : [
+            "customerid"
+          ],
+          "computedColumns" : { },
+          "transactional" : false,
+          "sinkConfig" : { }
+        }
+      ],
+      "subscriptions" : [ ],
+      "operations" : [
+        {
+          "function" : {
+            "name" : "GetCustomer",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}"
+        },
+        {
+          "function" : {
+            "name" : "GetCustomerCount",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "query CustomerCount($limit: Int = 10, $offset: Int = 0) {\nCustomerCount(limit: $limit, offset: $offset) {\ncustomerid\nnumEntries\n}\n\n}",
+            "queryName" : "CustomerCount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerCount{?offset,limit}"
+        },
+        {
+          "function" : {
+            "name" : "GetCustomerForApi",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "query CustomerForApi($limit: Int = 10, $offset: Int = 0) {\nCustomerForApi(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerForApi",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerForApi{?offset,limit}"
+        },
+        {
+          "function" : {
+            "name" : "AddCustomerCount",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "numEntries" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [
+                "customerid"
+              ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "mutation CustomerCount($customerid: Long!, $numEntries: Long) {\nCustomerCount(event: { customerid: $customerid, numEntries: $numEntries }) {\ncustomerid\nnumEntries\n}\n\n}",
+            "queryName" : "CustomerCount",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/CustomerCount"
+        }
+      ],
+      "schema" : {
+        "type" : "string",
+        "schema" : "type Customer {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype CustomerCount {\n  customerid: Long!\n  numEntries: Long\n}\n\ninput CustomerCountInput {\n  customerid: Long!\n  numEntries: Long\n}\n\ntype CustomerCountResultOutput {\n  customerid: Long!\n  numEntries: Long\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Mutation {\n  CustomerCount(event: CustomerCountInput!): CustomerCountResultOutput!\n}\n\ntype Query {\n  Customer(limit: Int = 10, offset: Int = 0): [Customer!]\n  CustomerCount(limit: Int = 10, offset: Int = 0): [CustomerCount!]\n  CustomerForApi(limit: Int = 10, offset: Int = 0): [Customer!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+      }
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
@@ -28,6 +28,78 @@
     "fields.val.min" : "1"
   }
 }, {
+  "id" : "default_catalog.default_database.TableA",
+  "name" : "TableA",
+  "type" : "export",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.TableA_in1" ],
+  "connector" : {
+    "connector" : "print"
+  }
+}, {
+  "id" : "default_catalog.default_database.TableA_in1",
+  "name" : "TableA_in1",
+  "type" : "stream",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.Src" ],
+  "annotations" : [ ],
+  "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
+  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "timestamp" : "-",
+  "schema" : [ {
+    "name" : "val",
+    "type" : "INTEGER NOT NULL"
+  } ],
+  "row_count" : "~1e8"
+}, {
+  "id" : "default_catalog.default_database.TableB",
+  "name" : "TableB",
+  "type" : "export",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.TableB_in2" ],
+  "connector" : {
+    "connector" : "print"
+  }
+}, {
+  "id" : "default_catalog.default_database.TableB_in2",
+  "name" : "TableB_in2",
+  "type" : "stream",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.Src" ],
+  "annotations" : [ ],
+  "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
+  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "timestamp" : "-",
+  "schema" : [ {
+    "name" : "val",
+    "type" : "INTEGER NOT NULL"
+  } ],
+  "row_count" : "~1e8"
+}, {
+  "id" : "default_catalog.default_database.TableC",
+  "name" : "TableC",
+  "type" : "export",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.TableC_in3" ],
+  "connector" : {
+    "connector" : "print"
+  }
+}, {
+  "id" : "default_catalog.default_database.TableC_in3",
+  "name" : "TableC_in3",
+  "type" : "stream",
+  "stage" : "flink",
+  "inputs" : [ "default_catalog.default_database.Src" ],
+  "annotations" : [ ],
+  "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
+  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "timestamp" : "-",
+  "schema" : [ {
+    "name" : "val",
+    "type" : "INTEGER NOT NULL"
+  } ],
+  "row_count" : "~1e8"
+}, {
   "id" : "tables.sinks.SinkA",
   "name" : "SinkA",
   "type" : "export",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-only-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-only-compile-package.txt
@@ -1,4 +1,42 @@
 >>>pipeline_explain.txt
+=== Customer
+ID:          default_catalog.default_database.Customer
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   lastUpdated
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer__base
+
+=== customer_id_count
+ID:          default_catalog.default_database.customer_id_count
+Type:        export
+Stage:       flink
+Connector:   print
+---
+Inputs:
+ - default_catalog.default_database.customer_id_count_in1
+
+=== customer_id_count_in1
+ID:          default_catalog.default_database.customer_id_count_in1
+Type:        state
+Stage:       flink
+Primary key: customerid
+Timestamp:   -
+Row count:   ~1e7
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - numEntries: BIGINT NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
 
 >>>flink-sql-no-functions.sql
 CREATE TABLE `Customer` (
@@ -36,8 +74,8 @@ WITH (
 );
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `customer_id_count`
-SELECT `customerid`, COUNT(*) AS `numEntries`
-FROM `Customer`
-GROUP BY `customerid`
+SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
+FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
+GROUP BY `Customer`.`customerid`
 ;
 END

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
@@ -12,6 +12,72 @@ Schema:
 Inputs:
  - default_catalog.default_database.Src__base
 
+=== TableA
+ID:          default_catalog.default_database.TableA
+Type:        export
+Stage:       flink
+Connector:   print
+---
+Inputs:
+ - default_catalog.default_database.TableA_in1
+
+=== TableA_in1
+ID:          default_catalog.default_database.TableA_in1
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - val: INTEGER NOT NULL
+Inputs:
+ - default_catalog.default_database.Src
+
+=== TableB
+ID:          default_catalog.default_database.TableB
+Type:        export
+Stage:       flink
+Connector:   print
+---
+Inputs:
+ - default_catalog.default_database.TableB_in2
+
+=== TableB_in2
+ID:          default_catalog.default_database.TableB_in2
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - val: INTEGER NOT NULL
+Inputs:
+ - default_catalog.default_database.Src
+
+=== TableC
+ID:          default_catalog.default_database.TableC
+Type:        export
+Stage:       flink
+Connector:   print
+---
+Inputs:
+ - default_catalog.default_database.TableC_in3
+
+=== TableC_in3
+ID:          default_catalog.default_database.TableC_in3
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - val: INTEGER NOT NULL
+Inputs:
+ - default_catalog.default_database.Src
+
 === SinkA
 ID:          tables.sinks.SinkA
 Type:        export
@@ -61,13 +127,13 @@ WITH (
   'connector' = 'print'
 );
 EXECUTE STATEMENT SET BEGIN
-INSERT INTO `TableA`
-SELECT *
-FROM `Src`
-;
 INSERT INTO `default_catalog`.`default_database`.`SinkA_ex1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Src`
+;
+INSERT INTO `TableA`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
 ;
 END
 >>>flink-sql-no-functions-1.sql
@@ -107,13 +173,13 @@ WITH (
   'connector' = 'print'
 );
 EXECUTE STATEMENT SET BEGIN
-INSERT INTO `TableB`
-SELECT *
-FROM `Src`
-;
 INSERT INTO `default_catalog`.`default_database`.`SinkB_ex2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Src`
+;
+INSERT INTO `TableB`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
 ;
 END
 >>>flink-sql-no-functions-2.sql
@@ -160,8 +226,8 @@ WITH (
 );
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `TableC`
-SELECT *
-FROM `Src`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
 ;
 END
 >>>flink-sql-no-functions.sql
@@ -207,28 +273,28 @@ WITH (
   'connector' = 'print'
 );
 EXECUTE STATEMENT SET BEGIN
-INSERT INTO `TableA`
-SELECT *
-FROM `Src`
-;
 INSERT INTO `default_catalog`.`default_database`.`SinkA_ex1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
+INSERT INTO `TableA`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
+;
 END;
 EXECUTE STATEMENT SET BEGIN
-INSERT INTO `TableB`
-SELECT *
-FROM `Src`
-;
 INSERT INTO `default_catalog`.`default_database`.`SinkB_ex2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
+INSERT INTO `TableB`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
+;
 END;
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `TableC`
-SELECT *
-FROM `Src`
+SELECT `Src`.`val`
+FROM `default_catalog`.`default_database`.`Src` AS `Src`
 ;
 END


### PR DESCRIPTION
## Key Changes
- Model Flink SQL `INSERT` statements as DAG export nodes with source lineage.
- Preserve the original `RichSqlInsert` for execution, retaining target columns and modifiers.
- Move `INSERT` enqueueing into `DAGPlanner` for deterministic statement-set ordering.
- Add mutation-table INSERT regression coverage and update affected snapshots.

Fixes #1921 