### PR TITLE
feat: Execute standalone extension statements in local runner

### DIFF
--- a/sqrl-cli/Dockerfile.base
+++ b/sqrl-cli/Dockerfile.base
@@ -22,6 +22,7 @@ RUN apt-get update \
             postgresql-${POSTGRES_VERSION} \
             postgresql-contrib-${POSTGRES_VERSION} \
             postgresql-${POSTGRES_VERSION}-pgvector \
+            postgresql-${POSTGRES_VERSION}-partman \
     && curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | bash \
     && apt-get install -y --no-install-recommends redpanda \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/DatasqrlRun.java
@@ -313,6 +313,26 @@ public class DatasqrlRun {
           assert false : e.getMessage();
         }
       }
+      // Extension statements manage the lifecycle of extension-backed tables (e.g. pg_partman
+      // creates the partitions of ttl() tables); without them partitioned parents have no
+      // partitions and every insert fails. Failures are non-fatal so plans still run against
+      // a Postgres that lacks the extension.
+      for (var jdbcStmt : postgresPlanOpt.get().standaloneExtensionStatements()) {
+        log.info(
+            "Executing standalone extension statement {} of type {}",
+            jdbcStmt.name(),
+            jdbcStmt.type());
+        try (Statement stmt = connection.createStatement()) {
+          stmt.execute(jdbcStmt.sql());
+        } catch (Exception e) {
+          log.warn(
+              "Failed to execute standalone extension statement '{}'. The required Postgres"
+                  + " extension may not be installed; extension-managed features will be"
+                  + " unavailable.",
+              jdbcStmt.name(),
+              e);
+        }
+      }
     }
   }
 

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/DatasqrlRunTest.java
@@ -15,15 +15,25 @@
  */
 package com.datasqrl.cli;
 
+import static com.datasqrl.env.EnvVariableNames.POSTGRES_JDBC_URL;
+import static com.datasqrl.env.EnvVariableNames.POSTGRES_PASSWORD;
+import static com.datasqrl.env.EnvVariableNames.POSTGRES_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.datasqrl.config.PackageJson;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -33,6 +43,7 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 
 class DatasqrlRunTest {
 
@@ -108,6 +119,121 @@ class DatasqrlRunTest {
         .thenReturn("file:///nonexistent-dir");
 
     assertThat(underTest.getLastSavepoint()).isEmpty();
+  }
+
+  @Test
+  void givenPlanWithStandaloneExtensionStatements_whenRun_thenExecutesThemAfterRegularStatements()
+      throws Exception {
+    var run = givenRunStoppingAfterPostgresInit();
+    var connection =
+        givenPostgresPlan(
+            """
+        {
+          "statements": [
+            {"name": "my_table", "type": "TABLE", "sql": "CREATE TABLE my_table (id INT)"}
+          ],
+          "standaloneExtensionStatements": [
+            {"name": "partman", "type": "EXTENSION", "sql": "CREATE EXTENSION pg_partman"},
+            {"name": "partman_parent", "type": "EXTENSION", "sql": "SELECT create_parent()"}
+          ]
+        }
+        """);
+    var statement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    try (MockedStatic<DriverManager> driverManagerMocked = mockStatic(DriverManager.class)) {
+      driverManagerMocked
+          .when(() -> DriverManager.getConnection("jdbc:postgresql://localhost/db", "user", "pw"))
+          .thenReturn(connection);
+
+      assertThatThrownBy(run::run).hasMessageContaining("NON_EXISTING_ENV_VAR");
+    }
+
+    var order = inOrder(statement);
+    order.verify(statement).execute("CREATE TABLE my_table (id INT)");
+    order.verify(statement).execute("CREATE EXTENSION pg_partman");
+    order.verify(statement).execute("SELECT create_parent()");
+  }
+
+  @Test
+  void givenFailingStandaloneExtensionStatement_whenRun_thenContinuesNonFatally() throws Exception {
+    var run = givenRunStoppingAfterPostgresInit();
+    var connection =
+        givenPostgresPlan(
+            """
+        {
+          "statements": [
+            {"name": "my_table", "type": "TABLE", "sql": "CREATE TABLE my_table (id INT)"}
+          ],
+          "standaloneExtensionStatements": [
+            {"name": "partman", "type": "EXTENSION", "sql": "CREATE EXTENSION pg_partman"},
+            {"name": "partman_parent", "type": "EXTENSION", "sql": "SELECT create_parent()"}
+          ]
+        }
+        """);
+    var statement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(statement);
+    when(statement.execute(anyString()))
+        .thenReturn(true)
+        .thenThrow(new SQLException("extension \"pg_partman\" is not available"))
+        .thenReturn(true);
+
+    try (MockedStatic<DriverManager> driverManagerMocked = mockStatic(DriverManager.class)) {
+      driverManagerMocked
+          .when(() -> DriverManager.getConnection("jdbc:postgresql://localhost/db", "user", "pw"))
+          .thenReturn(connection);
+
+      // reaching the Flink sentinel error proves the extension failure did not abort the run
+      assertThatThrownBy(run::run).hasMessageContaining("NON_EXISTING_ENV_VAR");
+    }
+
+    var order = inOrder(statement);
+    order.verify(statement).execute("CREATE EXTENSION pg_partman");
+    order.verify(statement).execute("SELECT create_parent()");
+  }
+
+  @Test
+  void givenPlanWithoutPostgresJson_whenRun_thenSkipsDatabaseConnection() throws Exception {
+    var run = givenRunStoppingAfterPostgresInit();
+
+    try (MockedStatic<DriverManager> driverManagerMocked = mockStatic(DriverManager.class)) {
+      assertThatThrownBy(run::run).hasMessageContaining("NON_EXISTING_ENV_VAR");
+
+      driverManagerMocked.verifyNoInteractions();
+    }
+  }
+
+  /**
+   * The returned instance runs Postgres init for real, then fails at the Flink stage on a missing
+   * env var, so tests can drive {@code initPostgres()} through the public {@code run()} method
+   * alone.
+   */
+  private DatasqrlRun givenRunStoppingAfterPostgresInit() throws Exception {
+    var planDir = tempDir.resolve("plan");
+    Files.createDirectories(planDir);
+    Files.writeString(
+        planDir.resolve("flink-sql.sql"),
+        "CREATE TABLE t (id INT) WITH ('connector' = 'datagen', 'id' = '${NON_EXISTING_ENV_VAR}');\n");
+
+    var realFlinkConfig = new Configuration();
+    realFlinkConfig.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+
+    var sqrlConfig = mock(PackageJson.class, RETURNS_DEEP_STUBS);
+    when(sqrlConfig.getCompilerConfig().compileFlinkPlan()).thenReturn(false);
+
+    return DatasqrlRun.nonBlocking(planDir, sqrlConfig, realFlinkConfig, env);
+  }
+
+  private Connection givenPostgresPlan(String postgresJson) throws Exception {
+    var planDir = tempDir.resolve("plan");
+    Files.createDirectories(planDir);
+    Files.writeString(planDir.resolve("postgres.json"), postgresJson);
+
+    env.put(POSTGRES_JDBC_URL, "jdbc:postgresql://localhost/db");
+    env.put(POSTGRES_USERNAME, "user");
+    env.put(POSTGRES_PASSWORD, "pw");
+
+    return mock(Connection.class);
   }
 
   @Test


### PR DESCRIPTION
## What was done
- `DatasqrlRun.initPostgres` now executes the plan's `standaloneExtensionStatements` (e.g. the pg_partman `CREATE EXTENSION` + `create_parent` block) after the regular statements, non-fatally: a failure logs a warning and the run continues, so a Postgres without the extension behaves exactly as before.
- Install `postgresql-${POSTGRES_VERSION}-partman` in the sqrl-cli base image so `run`/`test` can actually create the extension locally.

## Why it was done
- Tables with a `ttl()` hint are emitted as `PARTITION BY RANGE` parents with no inline default partition (pg_partman owns their lifecycle), but the local runner never executed the partman block — leaving the parent with zero partitions, so every insert fails with `no partition of relation ... found for row`. This made `sqrl test`/`sqrl run` unusable for any project using `ttl()` on a Postgres table.
- Validated end-to-end against DataSQRL/cloud-backend metrics: with this image the runner logs `Executing standalone extension statement partman of type EXTENSION`, historical test fixtures land in the partman DEFAULT partition, and all 14 snapshot tests pass.
