### PR TITLE
feat: Generate and serve OpenAPI deployment artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
     <mockito.version>4.8.0</mockito.version>
     <mustache.version>0.9.14</mustache.version>
     <openai-gpt3-java.version>0.18.2</openai-gpt3-java.version>
+    <openapi-diff.version>2.1.7</openapi-diff.version>
     <opencsv.version>5.12.0</opencsv.version>
     <picocli.version>4.7.7</picocli.version>
     <postgres.version>42.7.13</postgres.version>

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -103,7 +103,8 @@ public class CompilationProcess {
       apiVersions.forEach(
           api -> {
             var model = serverModelManager.generateGraphQLModel(api, serverPlan);
-            var generatedOpenApi = serverModelManager.generateOpenApiJson(api, model);
+            var generatedOpenApi =
+                serverModelManager.generateOpenApiJson(api, model, serverPlan.getServerConfig());
 
             serverPlan.getModels().put(api.version(), model);
             serverPlan

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.compile;
 
+import static com.datasqrl.server.openapi.OpenApiService.OPENAPI_JSON_ARTIFACT_NAME_SUFFIX_TEMPLATE;
+
 import com.datasqrl.config.GraphqlSourceLoader;
 import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.WorkspacePaths;
@@ -33,10 +35,7 @@ import com.datasqrl.planner.SqlScriptPlanner;
 import com.datasqrl.planner.Sqrl2FlinkSQLTranslator;
 import com.datasqrl.planner.dag.DAGPlanner;
 import com.datasqrl.planner.dag.plan.MutationDatabase;
-import com.datasqrl.server.GenerateServerModel;
-import com.datasqrl.server.config.OpenApiConfig;
-import com.datasqrl.server.config.ServletConfig;
-import com.datasqrl.server.openapi.OpenApiService;
+import com.datasqrl.server.ServerModelManager;
 import com.datasqrl.util.ServiceLoaderDiscovery;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,9 +57,9 @@ public class CompilationProcess {
   private final WorkspacePaths workspacePaths;
   private final MainScript mainScript;
   private final PackageJson config;
-  private final GenerateServerModel generateServerModel;
-  private final DagWriter writeDeploymentArtifactsHook;
+  private final DagWriter dagWriter;
   private final GraphqlSourceLoader graphqlSourceLoader;
+  private final ServerModelManager serverModelManager;
   private final ExecutionGoal executionGoal;
   private final ErrorCollector errors;
 
@@ -76,7 +75,7 @@ public class CompilationProcess {
     var dag = dagPlanner.optimize(dagBuilder.getDag());
     var physicalPlan = dagPlanner.assemble(dag, environment);
     var mutationDatabase = physicalPlan.getMutationDatabase();
-    writeDeploymentArtifactsHook.run(dag, planner.getCompleteScript().toString(), mutationDatabase);
+    dagWriter.run(dag, planner.getCompleteScript().toString(), mutationDatabase);
 
     TestPlan testPlan = null;
     // There can only be a single server plan
@@ -93,32 +92,26 @@ public class CompilationProcess {
       var loadResult = graphqlSourceLoader.load(serverPlan);
       var apiVersions = new ArrayList<>(loadResult.apiVersions());
 
-      loadResult.inferredSchema().ifPresent(writeDeploymentArtifactsHook::writeInferredSchema);
+      loadResult.inferredSchema().ifPresent(dagWriter::writeInferredSchema);
 
-      // Data model (GraphQL schema) Voyager page; latest API version when multi-version.
       if (!apiVersions.isEmpty()) {
         Collections.sort(apiVersions);
-        writeDeploymentArtifactsHook.writeDataModelVisual(
+        dagWriter.writeDataModelVisual(
             apiVersions.get(apiVersions.size() - 1).schema().getDefinition());
       }
 
       apiVersions.forEach(
           api -> {
-            var model = generateServerModel.generateGraphQLModel(api, serverPlan);
-            var openApiService =
-                new OpenApiService(
-                    new OpenApiConfig(),
-                    model,
-                    api.version(),
-                    new ServletConfig().getRestEndpoint(api.version()));
+            var model = serverModelManager.generateGraphQLModel(api, serverPlan);
+            var generatedOpenApi = serverModelManager.generateOpenApiJson(api, model);
 
             serverPlan.getModels().put(api.version(), model);
             serverPlan
                 .getDeploymentArtifacts()
                 .add(
                     new DeploymentArtifact(
-                        '-' + api.version() + "-openapi.json",
-                        openApiService.generateOpenApiJson()));
+                        String.format(OPENAPI_JSON_ARTIFACT_NAME_SUFFIX_TEMPLATE, api.version()),
+                        generatedOpenApi));
           });
 
       // create test artifact

--- a/sqrl-planner/pom.xml
+++ b/sqrl-planner/pom.xml
@@ -37,6 +37,11 @@
       <groupId>com.datasqrl</groupId>
       <artifactId>sqrl-server-vertx-base</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.openapitools.openapidiff</groupId>
+      <artifactId>openapi-diff-core</artifactId>
+      <version>${openapi-diff.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
@@ -131,6 +131,10 @@ public interface PackageJson {
     String getSchema();
 
     List<String> getOperations();
+
+    default Optional<String> getOpenApi() {
+      return Optional.empty();
+    }
   }
 
   interface EnginesConfig {

--- a/sqrl-planner/src/main/java/com/datasqrl/config/ScriptApiConfigImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/ScriptApiConfigImpl.java
@@ -17,6 +17,7 @@ package com.datasqrl.config;
 
 import com.datasqrl.config.PackageJson.ScriptApiConfig;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -37,5 +38,10 @@ public class ScriptApiConfigImpl implements ScriptApiConfig {
   @Override
   public List<String> getOperations() {
     return sqrlConfig.asList("operations", String.class).get();
+  }
+
+  @Override
+  public Optional<String> getOpenApi() {
+    return sqrlConfig.asString("openapi").getOptional();
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/server/GenericJavaServerEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/server/GenericJavaServerEngine.java
@@ -55,15 +55,17 @@ public abstract class GenericJavaServerEngine extends ExecutionEngine.Base imple
     validateFunctions(serverPlan.functions());
 
     var execFnPlan = serverPlan.execFnFactory().getPlan();
+    var serverConfig = serverConfig();
     var artifacts = new ArrayList<DeploymentArtifact>();
-    artifacts.add(new DeploymentArtifact("-config.json", serverConfig()));
+    artifacts.add(new DeploymentArtifact("-config.json", toJson(serverConfig)));
 
     if (!execFnPlan.functions().isEmpty()) {
       artifacts.add(new DeploymentArtifact("-exec-functions.ser", execFnPlan));
       artifacts.add(new DeploymentArtifact("-exec-functions.json", execFnPlan, ArtifactType.JSON));
     }
 
-    return new ServerPhysicalPlan(serverPlan.functions(), serverPlan.mutations(), artifacts);
+    return new ServerPhysicalPlan(
+        serverPlan.functions(), serverPlan.mutations(), artifacts, serverConfig);
   }
 
   private void validateFunctions(List<SqrlTableFunction> functions) {
@@ -77,9 +79,13 @@ public abstract class GenericJavaServerEngine extends ExecutionEngine.Base imple
   }
 
   @SneakyThrows
-  private String serverConfig() {
-    var mergedConfig = mergeConfigs(readDefaultConfig(), engineConfig.getConfig());
-    return JsonUtils.MAPPER.copy().writer(new PrettyPrinter()).writeValueAsString(mergedConfig);
+  private ServerConfig serverConfig() {
+    return mergeConfigs(readDefaultConfig(), engineConfig.getConfig());
+  }
+
+  @SneakyThrows
+  private String toJson(ServerConfig serverConfig) {
+    return JsonUtils.MAPPER.copy().writer(new PrettyPrinter()).writeValueAsString(serverConfig);
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/server/ServerPhysicalPlan.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/server/ServerPhysicalPlan.java
@@ -19,6 +19,7 @@ import com.datasqrl.engine.EnginePhysicalPlan;
 import com.datasqrl.planner.analyzer.TableAnalysis;
 import com.datasqrl.planner.dag.plan.MutationTable;
 import com.datasqrl.planner.tables.SqrlTableFunction;
+import com.datasqrl.server.config.ServerConfig;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.LinkedHashMap;
@@ -41,6 +42,9 @@ public class ServerPhysicalPlan implements EnginePhysicalPlan {
 
   /** Additional server configuration */
   @JsonIgnore final List<DeploymentArtifact> deploymentArtifacts;
+
+  /** Merged server configuration used to generate deployment artifacts. */
+  @JsonIgnore final ServerConfig serverConfig;
 
   /**
    * The generated API for the server. This gets generated after the planning and is added to the

--- a/sqrl-planner/src/main/java/com/datasqrl/server/ServerModelManager.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/server/ServerModelManager.java
@@ -16,25 +16,33 @@
 package com.datasqrl.server;
 
 import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.WorkspacePaths;
 import com.datasqrl.engine.server.ServerPhysicalPlan;
 import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.server.config.OpenApiConfig;
+import com.datasqrl.server.config.ServletConfig;
 import com.datasqrl.server.converter.GraphQLSchemaConverter;
 import com.datasqrl.server.converter.GraphQLSchemaConverterConfig;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.graphql.RootGraphQLModel.StringSchema;
+import com.datasqrl.server.openapi.OpenApiService;
 import com.datasqrl.server.operation.ApiOperation;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import lombok.AllArgsConstructor;
+import org.openapitools.openapidiff.core.OpenApiCompare;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.springframework.stereotype.Component;
 
 /** Generates the model for the server */
 @Component
 @AllArgsConstructor
-public class GenerateServerModel {
+public class ServerModelManager {
 
-  private final PackageJson configuration;
-  private final ErrorCollector errorCollector;
+  private final PackageJson packageConfig;
+  private final WorkspacePaths workspacePaths;
   private final GraphQLSchemaConverter converter;
+  private final ErrorCollector errors;
 
   /**
    * Generates the {@link RootGraphQLModel} from the server plan and defined operations
@@ -45,26 +53,23 @@ public class GenerateServerModel {
    */
   public RootGraphQLModel generateGraphQLModel(ApiSources api, ServerPhysicalPlan serverPlan) {
     var graphqlModelGenerator =
-        new GraphqlModelGenerator(
-            serverPlan.getFunctions(), serverPlan.getMutations(), errorCollector);
+        new GraphqlModelGenerator(serverPlan.getFunctions(), serverPlan.getMutations(), errors);
     graphqlModelGenerator.walkAPISource(api.schema());
     serverPlan.getPagedRowTimeTables().addAll(graphqlModelGenerator.getPagedRowTimeTables());
     var schema = StringSchema.builder().schema(api.schema().getDefinition()).build();
     var graphSchema = converter.getSchema(schema.getSchema());
-    var apiConfig = configuration.getCompilerConfig().getApiConfig();
+    var apiConfig = packageConfig.getCompilerConfig().getApiConfig();
     var converterConfig =
         GraphQLSchemaConverterConfig.builder()
             .addPrefix(apiConfig.isAddOperationsPrefix())
             .maxDepth(apiConfig.getMaxResultDepth())
             .protocols(apiConfig.getProtocols())
             .build();
-    var localErrors =
-        errorCollector.withScript(api.schema().getPath(), api.schema().getDefinition());
+    var localErrors = errors.withScript(api.schema().getPath(), api.schema().getDefinition());
     var definedOperations = new ArrayList<ApiOperation>();
     // First, convert all explicitly defined operations, preserving the original order
     for (var operationFile : api.operations()) {
-      localErrors =
-          errorCollector.withScript(operationFile.getPath(), operationFile.getDefinition());
+      localErrors = errors.withScript(operationFile.getPath(), operationFile.getDefinition());
       try {
         definedOperations.addAll(
             converter.convertOperations(
@@ -83,6 +88,7 @@ public class GenerateServerModel {
     }
     // Third, distincting preserves only the first operation by id
     var dedupedOperations = definedOperations.stream().distinct().toList();
+
     return RootGraphQLModel.builder()
         .queries(graphqlModelGenerator.getQueryCoords())
         .mutations(graphqlModelGenerator.getMutations())
@@ -90,5 +96,51 @@ public class GenerateServerModel {
         .operations(dedupedOperations)
         .schema(schema)
         .build();
+  }
+
+  public String generateOpenApiJson(ApiSources api, RootGraphQLModel model) {
+    var openApiService =
+        new OpenApiService(
+            new OpenApiConfig(),
+            model,
+            api.version(),
+            new ServletConfig().getRestEndpoint(api.version()));
+
+    var generatedOpenApi = openApiService.generateOpenApiJson();
+    validateOpenApiJsonIfNeeded(api.version(), generatedOpenApi);
+
+    return generatedOpenApi;
+  }
+
+  private void validateOpenApiJsonIfNeeded(String apiVersion, String generatedOpenApi) {
+    var configuredOpenApiOpt =
+        packageConfig.getScriptConfig().getScriptApiConfigs().stream()
+            .filter(apiConfig -> apiConfig.getVersion().equals(apiVersion))
+            .findFirst()
+            .flatMap(PackageJson.ScriptApiConfig::getOpenApi);
+
+    if (configuredOpenApiOpt.isEmpty()) {
+      return;
+    }
+
+    var configuredOpenApi = configuredOpenApiOpt.get();
+    final ChangedOpenApi diff;
+    try {
+      var configuredOpenApiPath = workspacePaths.buildDir().resolve(configuredOpenApiOpt.get());
+      var configuredOpenApiContent = Files.readString(configuredOpenApiPath);
+
+      diff = OpenApiCompare.fromContents(configuredOpenApiContent, generatedOpenApi);
+
+    } catch (Exception e) {
+      throw errors.exception(
+          "Failed to compare generated OpenAPI specification with %s: %s",
+          configuredOpenApi, e.getMessage());
+    }
+
+    errors.checkFatal(
+        !diff.isIncompatible(),
+        "The generated OpenAPI specification is not backwards compatible with %s: %s",
+        configuredOpenApi,
+        diff);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/server/ServerModelManager.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/server/ServerModelManager.java
@@ -19,19 +19,22 @@ import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.WorkspacePaths;
 import com.datasqrl.engine.server.ServerPhysicalPlan;
 import com.datasqrl.error.ErrorCollector;
-import com.datasqrl.server.config.OpenApiConfig;
-import com.datasqrl.server.config.ServletConfig;
+import com.datasqrl.server.config.ServerConfig;
 import com.datasqrl.server.converter.GraphQLSchemaConverter;
 import com.datasqrl.server.converter.GraphQLSchemaConverterConfig;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.graphql.RootGraphQLModel.StringSchema;
 import com.datasqrl.server.openapi.OpenApiService;
 import com.datasqrl.server.operation.ApiOperation;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import lombok.AllArgsConstructor;
 import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+import org.openapitools.openapidiff.core.output.ConsoleRender;
 import org.springframework.stereotype.Component;
 
 /** Generates the model for the server */
@@ -98,13 +101,14 @@ public class ServerModelManager {
         .build();
   }
 
-  public String generateOpenApiJson(ApiSources api, RootGraphQLModel model) {
+  public String generateOpenApiJson(
+      ApiSources api, RootGraphQLModel model, ServerConfig serverConfig) {
     var openApiService =
         new OpenApiService(
-            new OpenApiConfig(),
+            serverConfig.getOpenApiConfig(),
             model,
             api.version(),
-            new ServletConfig().getRestEndpoint(api.version()));
+            serverConfig.getServletConfig().getRestEndpoint(api.version()));
 
     var generatedOpenApi = openApiService.generateOpenApiJson();
     validateOpenApiJsonIfNeeded(api.version(), generatedOpenApi);
@@ -113,20 +117,20 @@ public class ServerModelManager {
   }
 
   private void validateOpenApiJsonIfNeeded(String apiVersion, String generatedOpenApi) {
-    var configuredOpenApiOpt =
+    var configuredFilenameOpt =
         packageConfig.getScriptConfig().getScriptApiConfigs().stream()
             .filter(apiConfig -> apiConfig.getVersion().equals(apiVersion))
             .findFirst()
             .flatMap(PackageJson.ScriptApiConfig::getOpenApi);
 
-    if (configuredOpenApiOpt.isEmpty()) {
+    if (configuredFilenameOpt.isEmpty()) {
       return;
     }
 
-    var configuredOpenApi = configuredOpenApiOpt.get();
+    var configuredFilename = configuredFilenameOpt.get();
     final ChangedOpenApi diff;
     try {
-      var configuredOpenApiPath = workspacePaths.buildDir().resolve(configuredOpenApiOpt.get());
+      var configuredOpenApiPath = workspacePaths.buildDir().resolve(configuredFilenameOpt.get());
       var configuredOpenApiContent = Files.readString(configuredOpenApiPath);
 
       diff = OpenApiCompare.fromContents(configuredOpenApiContent, generatedOpenApi);
@@ -134,13 +138,21 @@ public class ServerModelManager {
     } catch (Exception e) {
       throw errors.exception(
           "Failed to compare generated OpenAPI specification with %s: %s",
-          configuredOpenApi, e.getMessage());
+          configuredFilename, e.getMessage());
     }
 
     errors.checkFatal(
         !diff.isIncompatible(),
         "The generated OpenAPI specification is not backwards compatible with %s: %s",
-        configuredOpenApi,
-        diff);
+        configuredFilename,
+        renderOpenApiDiff(diff));
+  }
+
+  private String renderOpenApiDiff(ChangedOpenApi diff) {
+    var output = new ByteArrayOutputStream();
+    // The renderer closes the writer
+    new ConsoleRender().render(diff, new OutputStreamWriter(output, StandardCharsets.UTF_8));
+
+    return output.toString(StandardCharsets.UTF_8);
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
@@ -140,7 +140,7 @@ public class GraphQLSchemaConverter {
               endLocation.getColumn());
       GraphQLQuery query = new GraphQLQuery(queryString, fctDef.getName(), opDef.getOperation());
       ApiOperation.ApiOperationBuilder builder = ApiOperation.getBuilder(fctDef, query);
-      builder.result(toResultDefinition(schema, opDef));
+      builder.resultDefinition(toResultDefinition(schema, opDef));
       config.setProtocolSupport(builder);
       applyApiArgs(toArgMap(opDef.getDirectives()), builder);
       functions.add(builder.build());
@@ -344,7 +344,7 @@ public class GraphQLSchemaConverter {
     GraphQLQuery apiQuery =
         new GraphQLQuery(queryHeader.toString(), fieldDef.getName(), operationType);
     ApiOperation.ApiOperationBuilder builder = ApiOperation.getBuilder(funcDef, apiQuery);
-    builder.result(toResultDefinition(schema, apiQuery));
+    builder.resultDefinition(toResultDefinition(schema, apiQuery));
     config.setProtocolSupport(builder);
     applyApiArgs(toArgMap(fieldDef.getDirective("api")), builder);
     return builder.build();

--- a/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/server/converter/GraphQLSchemaConverter.java
@@ -25,6 +25,7 @@ import com.datasqrl.server.operation.FunctionDefinition.Parameters;
 import com.datasqrl.server.operation.GraphQLQuery;
 import com.datasqrl.server.operation.McpMethodType;
 import com.datasqrl.server.operation.RestMethodType;
+import com.datasqrl.server.operation.ResultDefinition;
 import com.datasqrl.server.operation.ResultFormat;
 import com.google.common.base.Preconditions;
 import graphql.language.BooleanValue;
@@ -33,10 +34,12 @@ import graphql.language.Definition;
 import graphql.language.Directive;
 import graphql.language.Document;
 import graphql.language.EnumValue;
+import graphql.language.Field;
 import graphql.language.ListType;
 import graphql.language.NonNullType;
 import graphql.language.OperationDefinition;
 import graphql.language.OperationDefinition.Operation;
+import graphql.language.SelectionSet;
 import graphql.language.SourceLocation;
 import graphql.language.StringValue;
 import graphql.language.Type;
@@ -49,6 +52,7 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
@@ -67,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,6 +140,7 @@ public class GraphQLSchemaConverter {
               endLocation.getColumn());
       GraphQLQuery query = new GraphQLQuery(queryString, fctDef.getName(), opDef.getOperation());
       ApiOperation.ApiOperationBuilder builder = ApiOperation.getBuilder(fctDef, query);
+      builder.result(toResultDefinition(schema, opDef));
       config.setProtocolSupport(builder);
       applyApiArgs(toArgMap(opDef.getDirectives()), builder);
       functions.add(builder.build());
@@ -246,7 +252,7 @@ public class GraphQLSchemaConverter {
             input -> {
               if (config.getOperationFilter().test(input.op(), input.fieldDefinition().getName())) {
                 try {
-                  ApiOperation op = convert(input.op(), input.fieldDefinition(), config);
+                  ApiOperation op = convert(input.op(), input.fieldDefinition(), config, schema);
                   return Stream.of(op);
                 } catch (Exception e) {
                   log.info(
@@ -318,7 +324,8 @@ public class GraphQLSchemaConverter {
   private ApiOperation convert(
       Operation operationType,
       GraphQLFieldDefinition fieldDef,
-      GraphQLSchemaConverterConfig config) {
+      GraphQLSchemaConverterConfig config,
+      GraphQLSchema schema) {
     FunctionDefinition funcDef =
         initializeFunctionDefinition(
             config.getFunctionName(fieldDef.getName(), operationType), fieldDef.getDescription());
@@ -337,6 +344,7 @@ public class GraphQLSchemaConverter {
     GraphQLQuery apiQuery =
         new GraphQLQuery(queryHeader.toString(), fieldDef.getName(), operationType);
     ApiOperation.ApiOperationBuilder builder = ApiOperation.getBuilder(funcDef, apiQuery);
+    builder.result(toResultDefinition(schema, apiQuery));
     config.setProtocolSupport(builder);
     applyApiArgs(toArgMap(fieldDef.getDirective("api")), builder);
     return builder.build();
@@ -403,6 +411,83 @@ public class GraphQLSchemaConverter {
       case "Boolean" -> "boolean";
       case "ID" -> "string"; // Typically treated as a string in JSON Schema
       default -> "string"; // We assume that type can be cast from string.
+    };
+  }
+
+  private ResultDefinition toResultDefinition(GraphQLSchema schema, OperationDefinition operation) {
+    var rootType =
+        switch (operation.getOperation()) {
+          case QUERY -> schema.getQueryType();
+          case MUTATION -> schema.getMutationType();
+          case SUBSCRIPTION -> schema.getSubscriptionType();
+        };
+    var rootField =
+        operation.getSelectionSet().getSelectionsOfType(Field.class).stream()
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Operation must select a root field"));
+    var fieldDefinition = rootType.getFieldDefinition(rootField.getName());
+    if (fieldDefinition == null) {
+      throw new IllegalArgumentException("Unknown root field: " + rootField.getName());
+    }
+    return toResultDefinition(fieldDefinition.getType(), rootField.getSelectionSet());
+  }
+
+  private ResultDefinition toResultDefinition(GraphQLSchema schema, GraphQLQuery query) {
+    var operation =
+        new Parser()
+            .parseDocument(query.query())
+            .getDefinitionsOfType(OperationDefinition.class)
+            .get(0);
+    return toResultDefinition(schema, operation);
+  }
+
+  private ResultDefinition toResultDefinition(GraphQLOutputType type, SelectionSet selectionSet) {
+    if (type instanceof GraphQLNonNull nonNullType) {
+      return toResultDefinition((GraphQLOutputType) nonNullType.getWrappedType(), selectionSet);
+    }
+    if (type instanceof GraphQLList listType) {
+      return ResultDefinition.builder()
+          .type("array")
+          .items(toResultDefinition((GraphQLOutputType) listType.getWrappedType(), selectionSet))
+          .build();
+    }
+    if (type instanceof GraphQLScalarType scalarType) {
+      return ResultDefinition.builder()
+          .type(convertScalarTypeToJsonType(scalarType))
+          .format(convertScalarTypeToFormat(scalarType))
+          .build();
+    }
+    if (type instanceof GraphQLEnumType enumType) {
+      return ResultDefinition.builder()
+          .type("string")
+          .enumValues(
+              enumType.getValues().stream()
+                  .map(GraphQLEnumValueDefinition::getName)
+                  .collect(Collectors.toSet()))
+          .build();
+    }
+    if (type instanceof GraphQLFieldsContainer fieldsContainer) {
+      var properties = new LinkedHashMap<String, ResultDefinition>();
+      if (selectionSet != null) {
+        for (var field : selectionSet.getSelectionsOfType(Field.class)) {
+          var fieldDefinition = fieldsContainer.getFieldDefinition(field.getName());
+          if (fieldDefinition != null) {
+            var result = toResultDefinition(fieldDefinition.getType(), field.getSelectionSet());
+            result.setDescription(fieldDefinition.getDescription());
+            properties.put(field.getAlias() == null ? field.getName() : field.getAlias(), result);
+          }
+        }
+      }
+      return ResultDefinition.builder().type("object").properties(properties).build();
+    }
+    return ResultDefinition.builder().type("object").build();
+  }
+
+  private String convertScalarTypeToFormat(GraphQLScalarType scalarType) {
+    return switch (scalarType.getName()) {
+      case "Date" -> "date";
+      case "DateTime", "DateTimeISO", "Timestamp" -> "date-time";
+      default -> null;
     };
   }
 

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -137,6 +137,9 @@
                 "operations": {
                   "type": "array",
                   "items": { "type": "string" }
+                },
+                "openapi": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false,

--- a/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
@@ -40,6 +40,7 @@ class PackageJsonSchemaTest {
         "validPackageWithUrls.json",
         "onlyVersionFieldExists.json",
         "scriptApiVersion.json",
+        "scriptApiWithOpenApi.json",
         "compilerEndpointsOpsOnly.json",
         "validFlinkDeployment.json",
         "validPostgresDeployment.json",

--- a/sqrl-planner/src/test/java/com/datasqrl/config/ScriptApiConfigImplTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/ScriptApiConfigImplTest.java
@@ -65,4 +65,15 @@ class ScriptApiConfigImplTest {
     assertThat(scriptApiConfig.getSchema()).isEqualTo("my-schema");
     assertThat(scriptApiConfig.getOperations()).containsExactly("op1", "op2");
   }
+
+  @Test
+  void givenOpenApiSpec_whenGetOpenApi_thenReturnsSpecPath() {
+    var v1 = config.getSubConfig("v1");
+    v1.setProperty("schema", "my-schema");
+    v1.setProperty("openapi", "openapi.json");
+
+    var scriptApiConfig = new ScriptApiConfigImpl(v1);
+
+    assertThat(scriptApiConfig.getOpenApi()).contains("openapi.json");
+  }
 }

--- a/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
@@ -192,7 +192,7 @@ public class GraphQLSchemaConverterTest {
             GraphQLSchemaConverterConfig.DEFAULT,
             schema);
 
-    var result = operations.get(0).getResult();
+    var result = operations.get(0).getResultDefinition();
     assertThat(result.getType()).isEqualTo("object");
     assertThat(result.getProperties().get("id").getType()).isEqualTo("integer");
     assertThat(result.getProperties().get("observedAt").getFormat()).isEqualTo("date-time");

--- a/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/converter/GraphQLSchemaConverterTest.java
@@ -171,6 +171,33 @@ public class GraphQLSchemaConverterTest {
     assertThat(payloadSchema.has("type")).isFalse();
   }
 
+  @Test
+  void givenOperationWithNestedResult_whenConvertOperations_thenCreatesResultDefinition() {
+    var schema =
+        underTest.getSchema(
+            """
+            scalar DateTime
+            type Query {
+              reading: Reading!
+            }
+            type Reading {
+              id: Int!
+              observedAt: DateTime
+            }
+            """);
+
+    var operations =
+        underTest.convertOperations(
+            "query Reading { reading { id observedAt } }",
+            GraphQLSchemaConverterConfig.DEFAULT,
+            schema);
+
+    var result = operations.get(0).getResult();
+    assertThat(result.getType()).isEqualTo("object");
+    assertThat(result.getProperties().get("id").getType()).isEqualTo("integer");
+    assertThat(result.getProperties().get("observedAt").getFormat()).isEqualTo("date-time");
+  }
+
   @ParameterizedTest
   @MethodSource("scalarTypeToJsonTypeProvider")
   void givenScalarType_whenConvertToJsonType_thenReturnsExpectedJsonType(

--- a/sqrl-planner/src/test/resources/config/package/scriptApiWithOpenApi.json
+++ b/sqrl-planner/src/test/resources/config/package/scriptApiWithOpenApi.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink"],
+  "script": {
+    "main": "example.sqrl",
+    "api": {
+      "v1": {
+        "schema": "schema.graphqls",
+        "openapi": "openapi.json"
+      }
+    }
+  }
+}

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/creditcard-rewards.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/creditcard-rewards.txt
@@ -1,4 +1,9 @@
 [ {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query Rewards($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!) {\nRewards(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\ncardNo\ncardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
+    "queryName" : "Rewards"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns all the rewards that a customer has earned in the given time period",
@@ -22,7 +27,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "amount" : {
@@ -55,15 +62,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query Rewards($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!) {\nRewards(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\ncardNo\ncardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
-    "queryName" : "Rewards"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/Rewards{?customerid,fromTime,toTime}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query RewardsByWeek($customerid: Int!, $limit: Int = 12, $offset: Int = 0) {\nRewardsByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\ntimeWeek\ntotal_reward\n}\n\n}",
+    "queryName" : "RewardsByWeek"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the total awards a customer earned by week starting from the most recent week.",
@@ -87,7 +92,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "customerid" : {
@@ -105,15 +112,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query RewardsByWeek($customerid: Int!, $limit: Int = 12, $offset: Int = 0) {\nRewardsByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\ntimeWeek\ntotal_reward\n}\n\n}",
-    "queryName" : "RewardsByWeek"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/RewardsByWeek{?offset,customerid,limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query TotalReward($customerid: Int!) {\nTotalReward(customerid: $customerid) {\ncustomerid\ntotal_reward\nsince_time\n}\n\n}",
+    "queryName" : "TotalReward"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the total amount of rewards the customer has earned to date and the time since when they eared rewards",
@@ -129,7 +134,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "customerid" : {
         "type" : "integer"
@@ -144,15 +151,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query TotalReward($customerid: Int!) {\nTotalReward(customerid: $customerid) {\ncustomerid\ntotal_reward\nsince_time\n}\n\n}",
-    "queryName" : "TotalReward"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/TotalReward{?customerid}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query PotentialRewards($customerid: Int!, $cardType: String!, $fromTime: DateTime!, $toTime: DateTime!) {\nPotentialRewards(customerid: $customerid, cardType: $cardType, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\nrewardCardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
+    "queryName" : "PotentialRewards"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns all the potential rewards a customer could have earned in the given time period for the given card type. Use this function to show customers the rewards they would have earned if they had the given card.",
@@ -180,7 +185,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "amount" : {
@@ -210,15 +217,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query PotentialRewards($customerid: Int!, $cardType: String!, $fromTime: DateTime!, $toTime: DateTime!) {\nPotentialRewards(customerid: $customerid, cardType: $cardType, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\nrewardCardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
-    "queryName" : "PotentialRewards"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/PotentialRewards{?customerid,cardType,fromTime,toTime}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query PotentialRewardsByWeek($customerid: Int!, $cardType: String!, $limit: Int = 12, $offset: Int = 0) {\nPotentialRewardsByWeek(customerid: $customerid, cardType: $cardType, limit: $limit, offset: $offset) {\ncustomerid\ncardType\ntimeWeek\ntotal_reward\n}\n\n}",
+    "queryName" : "PotentialRewardsByWeek"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the total awards a customer could have earned for a given card type by week starting from the most recent week. Use this function to show the customer what their reward earnings would have looked like, if they had a given card.",
@@ -246,7 +251,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "cardType" : {
@@ -267,15 +274,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query PotentialRewardsByWeek($customerid: Int!, $cardType: String!, $limit: Int = 12, $offset: Int = 0) {\nPotentialRewardsByWeek(customerid: $customerid, cardType: $cardType, limit: $limit, offset: $offset) {\ncustomerid\ncardType\ntimeWeek\ntotal_reward\n}\n\n}",
-    "queryName" : "PotentialRewardsByWeek"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/PotentialRewardsByWeek{?offset,customerid,cardType,limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query TotalPotentialReward($customerid: Int!) {\nTotalPotentialReward(customerid: $customerid) {\ncustomerid\ncardType\ntotal_reward\nsince_time\n}\n\n}",
+    "queryName" : "TotalPotentialReward"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the total amount of rewards the customer could have earned for each type of credit card the customer does not yet have. Use this function to determine which credit card type to recommend to a customer.",
@@ -291,7 +296,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "cardType" : {
@@ -312,12 +319,5 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query TotalPotentialReward($customerid: Int!) {\nTotalPotentialReward(customerid: $customerid) {\ncustomerid\ncardType\ntotal_reward\nsince_time\n}\n\n}",
-    "queryName" : "TotalPotentialReward"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/TotalPotentialReward{?customerid}"
 } ]

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/creditcard-rewards.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/creditcard-rewards.txt
@@ -22,6 +22,39 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "amount" : {
+          "type" : "number"
+        },
+        "cardNo" : {
+          "type" : "number"
+        },
+        "cardType" : {
+          "type" : "string"
+        },
+        "customerid" : {
+          "type" : "integer"
+        },
+        "merchantName" : {
+          "type" : "string"
+        },
+        "reward" : {
+          "type" : "number"
+        },
+        "time" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "transactionId" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query Rewards($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!) {\nRewards(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\ncardNo\ncardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
@@ -54,6 +87,24 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "customerid" : {
+          "type" : "integer"
+        },
+        "timeWeek" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "total_reward" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query RewardsByWeek($customerid: Int!, $limit: Int = 12, $offset: Int = 0) {\nRewardsByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\ntimeWeek\ntotal_reward\n}\n\n}",
@@ -77,6 +128,21 @@
       "required" : [ "customerid" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "properties" : {
+      "customerid" : {
+        "type" : "integer"
+      },
+      "since_time" : {
+        "format" : "date-time",
+        "type" : "string"
+      },
+      "total_reward" : {
+        "type" : "number"
+      }
+    },
+    "type" : "object"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -114,6 +180,36 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "amount" : {
+          "type" : "number"
+        },
+        "customerid" : {
+          "type" : "integer"
+        },
+        "merchantName" : {
+          "type" : "string"
+        },
+        "reward" : {
+          "type" : "number"
+        },
+        "rewardCardType" : {
+          "type" : "string"
+        },
+        "time" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "transactionId" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query PotentialRewards($customerid: Int!, $cardType: String!, $fromTime: DateTime!, $toTime: DateTime!) {\nPotentialRewards(customerid: $customerid, cardType: $cardType, fromTime: $fromTime, toTime: $toTime) {\ntransactionId\ncustomerid\nrewardCardType\ntime\namount\nreward\nmerchantName\n}\n\n}",
@@ -150,6 +246,27 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "cardType" : {
+          "type" : "string"
+        },
+        "customerid" : {
+          "type" : "integer"
+        },
+        "timeWeek" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "total_reward" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query PotentialRewardsByWeek($customerid: Int!, $cardType: String!, $limit: Int = 12, $offset: Int = 0) {\nPotentialRewardsByWeek(customerid: $customerid, cardType: $cardType, limit: $limit, offset: $offset) {\ncustomerid\ncardType\ntimeWeek\ntotal_reward\n}\n\n}",
@@ -173,6 +290,27 @@
       "required" : [ "customerid" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "cardType" : {
+          "type" : "string"
+        },
+        "customerid" : {
+          "type" : "integer"
+        },
+        "since_time" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "total_reward" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/law_enforcement.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/law_enforcement.txt
@@ -1,4 +1,9 @@
 [ {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query BoloDetails($make: String!, $model: String, $limit: Int = 10, $offset: Int = 0) {\nBoloDetails(make: $make, model: $model, limit: $limit, offset: $offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\n\n}",
+    "queryName" : "BoloDetails"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Fetches Bolo details with specified vehicle characteristics.",
@@ -26,7 +31,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "bolo_id" : {
@@ -72,15 +79,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query BoloDetails($make: String!, $model: String, $limit: Int = 10, $offset: Int = 0) {\nBoloDetails(make: $make, model: $model, limit: $limit, offset: $offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\n\n}",
-    "queryName" : "BoloDetails"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/BoloDetails{?offset,limit,model,make}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query Driver($license_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$vehicles_limit: Int = 10, $vehicles_offset: Int = 0$vehicles_bolos_limit: Int = 10, $vehicles_bolos_offset: Int = 0$vehicles_tracking_limit: Int = 10, $vehicles_tracking_offset: Int = 0$warrants_limit: Int = 10, $warrants_offset: Int = 0) {\nDriver(license_number: $license_number, limit: $limit, offset: $offset) {\ndriver_id\nfirst_name\nlast_name\nlicense_number\nlicense_state\ndate_of_birth\nlicense_status\nlicense_expiry_date\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\nvehicles(limit: $vehicles_limit, offset: $vehicles_offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $vehicles_bolos_limit, offset: $vehicles_bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $vehicles_tracking_limit, offset: $vehicles_tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\nwarrants(limit: $warrants_limit, offset: $warrants_offset) {\nwarrant_id\nperson_id\nwarrant_status\ncrime_description\nstate_of_issuance\nissue_date\nlast_updated\n}\n}\n\n}",
+    "queryName" : "Driver"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Retrieves driver information using their license number.",
@@ -134,7 +139,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "bolos" : {
@@ -349,15 +356,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query Driver($license_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$vehicles_limit: Int = 10, $vehicles_offset: Int = 0$vehicles_bolos_limit: Int = 10, $vehicles_bolos_offset: Int = 0$vehicles_tracking_limit: Int = 10, $vehicles_tracking_offset: Int = 0$warrants_limit: Int = 10, $warrants_offset: Int = 0) {\nDriver(license_number: $license_number, limit: $limit, offset: $offset) {\ndriver_id\nfirst_name\nlast_name\nlicense_number\nlicense_state\ndate_of_birth\nlicense_status\nlicense_expiry_date\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\nvehicles(limit: $vehicles_limit, offset: $vehicles_offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $vehicles_bolos_limit, offset: $vehicles_bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $vehicles_tracking_limit, offset: $vehicles_tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\nwarrants(limit: $warrants_limit, offset: $warrants_offset) {\nwarrant_id\nperson_id\nwarrant_status\ncrime_description\nstate_of_issuance\nissue_date\nlast_updated\n}\n}\n\n}",
-    "queryName" : "Driver"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/Driver{?vehicles_tracking_limit,offset,bolos_limit,bolos_offset,vehicles_limit,license_number,vehicles_bolos_limit,vehicles_bolos_offset,warrants_limit,vehicles_tracking_offset,limit,vehicles_offset,warrants_offset}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query Vehicle($registration_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$tracking_limit: Int = 10, $tracking_offset: Int = 0) {\nVehicle(registration_number: $registration_number, limit: $limit, offset: $offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $tracking_limit, offset: $tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\n\n}",
+    "queryName" : "Vehicle"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Retrieves vehicle details using the registration number.",
@@ -393,7 +398,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "bolos" : {
@@ -494,15 +501,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query Vehicle($registration_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$tracking_limit: Int = 10, $tracking_offset: Int = 0) {\nVehicle(registration_number: $registration_number, limit: $limit, offset: $offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $tracking_limit, offset: $tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\n\n}",
-    "queryName" : "Vehicle"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/Vehicle{?offset,registration_number,limit,tracking_limit,bolos_limit,tracking_offset,bolos_offset}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query WarrantsByCrime($crime: String, $limit: Int = 100, $offset: Int = 0) {\nWarrantsByCrime(crime: $crime, limit: $limit, offset: $offset) {\ncrime\nnum_warrants\n}\n\n}",
+    "queryName" : "WarrantsByCrime"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Fetches statistics on warrants filtered by the type of crime.",
@@ -524,7 +529,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "crime" : {
@@ -538,15 +545,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query WarrantsByCrime($crime: String, $limit: Int = 100, $offset: Int = 0) {\nWarrantsByCrime(crime: $crime, limit: $limit, offset: $offset) {\ncrime\nnum_warrants\n}\n\n}",
-    "queryName" : "WarrantsByCrime"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/WarrantsByCrime{?offset,limit,crime}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query WarrantsByState($status: String, $limit: Int = 100, $offset: Int = 0) {\nWarrantsByState(status: $status, limit: $limit, offset: $offset) {\nstate\nstatus\nnum_warrants\n}\n\n}",
+    "queryName" : "WarrantsByState"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Fetches statistics on warrants issued by state filtered by their status.",
@@ -568,7 +573,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "num_warrants" : {
@@ -585,15 +592,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query WarrantsByState($status: String, $limit: Int = 100, $offset: Int = 0) {\nWarrantsByState(status: $status, limit: $limit, offset: $offset) {\nstate\nstatus\nnum_warrants\n}\n\n}",
-    "queryName" : "WarrantsByState"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/WarrantsByState{?offset,limit,status}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query BolosByWeekState($state: String, $limit: Int = 100, $offset: Int = 0) {\nBolosByWeekState(state: $state, limit: $limit, offset: $offset) {\nweek\nstate\nnum_bolos\n}\n\n}",
+    "queryName" : "BolosByWeekState"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Fetches Bolo (be on the lookout) statistics by week filtered by state. It returns the data ordered\nby week starting from the most recent and going backwards from there.",
@@ -617,7 +622,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "num_bolos" : {
@@ -635,15 +642,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query BolosByWeekState($state: String, $limit: Int = 100, $offset: Int = 0) {\nBolosByWeekState(state: $state, limit: $limit, offset: $offset) {\nweek\nstate\nnum_bolos\n}\n\n}",
-    "queryName" : "BolosByWeekState"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/BolosByWeekState{?offset,limit,state}"
 }, {
+  "apiQuery" : {
+    "operationType" : "MUTATION",
+    "query" : "mutation Tracking($plate: String!, $latitude: Float!, $longitude: Float!) {\nTracking(encounter: { plate: $plate, latitude: $latitude, longitude: $longitude }) {\n_uuid\nplate\n}\n\n}",
+    "queryName" : "Tracking"
+  },
   "format" : "JSON",
   "function" : {
     "name" : "AddTracking",
@@ -663,7 +668,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "POST",
+  "resultDefinition" : {
     "properties" : {
       "_uuid" : {
         "type" : "string"
@@ -674,12 +681,5 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "MUTATION",
-    "query" : "mutation Tracking($plate: String!, $latitude: Float!, $longitude: Float!) {\nTracking(encounter: { plate: $plate, latitude: $latitude, longitude: $longitude }) {\n_uuid\nplate\n}\n\n}",
-    "queryName" : "Tracking"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "POST",
   "uriTemplate" : "mutations/Tracking"
 } ]

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/law_enforcement.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/law_enforcement.txt
@@ -26,6 +26,52 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "bolo_id" : {
+          "type" : "string"
+        },
+        "driver_id" : {
+          "type" : "string"
+        },
+        "issue_date" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "last_updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "license_state" : {
+          "type" : "string"
+        },
+        "make" : {
+          "type" : "string"
+        },
+        "model" : {
+          "type" : "string"
+        },
+        "registration_number" : {
+          "type" : "string"
+        },
+        "registration_state" : {
+          "type" : "string"
+        },
+        "status" : {
+          "type" : "string"
+        },
+        "vehicle_id" : {
+          "type" : "string"
+        },
+        "year" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query BoloDetails($make: String!, $model: String, $limit: Int = 10, $offset: Int = 0) {\nBoloDetails(make: $make, model: $model, limit: $limit, offset: $offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\n\n}",
@@ -88,6 +134,221 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "bolos" : {
+          "items" : {
+            "properties" : {
+              "bolo_id" : {
+                "type" : "string"
+              },
+              "driver_id" : {
+                "type" : "string"
+              },
+              "issue_date" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "last_updated" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "license_state" : {
+                "type" : "string"
+              },
+              "make" : {
+                "type" : "string"
+              },
+              "model" : {
+                "type" : "string"
+              },
+              "registration_number" : {
+                "type" : "string"
+              },
+              "registration_state" : {
+                "type" : "string"
+              },
+              "status" : {
+                "type" : "string"
+              },
+              "vehicle_id" : {
+                "type" : "string"
+              },
+              "year" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "date_of_birth" : {
+          "type" : "string"
+        },
+        "driver_id" : {
+          "type" : "string"
+        },
+        "first_name" : {
+          "type" : "string"
+        },
+        "last_name" : {
+          "type" : "string"
+        },
+        "last_updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "license_expiry_date" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "license_number" : {
+          "type" : "string"
+        },
+        "license_state" : {
+          "type" : "string"
+        },
+        "license_status" : {
+          "type" : "string"
+        },
+        "vehicles" : {
+          "items" : {
+            "properties" : {
+              "bolos" : {
+                "items" : {
+                  "properties" : {
+                    "bolo_id" : {
+                      "type" : "string"
+                    },
+                    "driver_id" : {
+                      "type" : "string"
+                    },
+                    "issue_date" : {
+                      "format" : "date-time",
+                      "type" : "string"
+                    },
+                    "last_updated" : {
+                      "format" : "date-time",
+                      "type" : "string"
+                    },
+                    "license_state" : {
+                      "type" : "string"
+                    },
+                    "make" : {
+                      "type" : "string"
+                    },
+                    "model" : {
+                      "type" : "string"
+                    },
+                    "registration_number" : {
+                      "type" : "string"
+                    },
+                    "registration_state" : {
+                      "type" : "string"
+                    },
+                    "status" : {
+                      "type" : "string"
+                    },
+                    "vehicle_id" : {
+                      "type" : "string"
+                    },
+                    "year" : {
+                      "type" : "number"
+                    }
+                  },
+                  "type" : "object"
+                },
+                "type" : "array"
+              },
+              "last_updated" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "make" : {
+                "type" : "string"
+              },
+              "model" : {
+                "type" : "string"
+              },
+              "owner_driver_id" : {
+                "type" : "string"
+              },
+              "registration_expiry" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "registration_number" : {
+                "type" : "string"
+              },
+              "registration_state" : {
+                "type" : "string"
+              },
+              "tracking" : {
+                "items" : {
+                  "properties" : {
+                    "event_time" : {
+                      "format" : "date-time",
+                      "type" : "string"
+                    },
+                    "latitude" : {
+                      "type" : "number"
+                    },
+                    "longitude" : {
+                      "type" : "number"
+                    }
+                  },
+                  "type" : "object"
+                },
+                "type" : "array"
+              },
+              "vehicle_id" : {
+                "type" : "string"
+              },
+              "year" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "warrants" : {
+          "items" : {
+            "properties" : {
+              "crime_description" : {
+                "type" : "string"
+              },
+              "issue_date" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "last_updated" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "person_id" : {
+                "type" : "string"
+              },
+              "state_of_issuance" : {
+                "type" : "string"
+              },
+              "warrant_id" : {
+                "type" : "string"
+              },
+              "warrant_status" : {
+                "type" : "string"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query Driver($license_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$vehicles_limit: Int = 10, $vehicles_offset: Int = 0$vehicles_bolos_limit: Int = 10, $vehicles_bolos_offset: Int = 0$vehicles_tracking_limit: Int = 10, $vehicles_tracking_offset: Int = 0$warrants_limit: Int = 10, $warrants_offset: Int = 0) {\nDriver(license_number: $license_number, limit: $limit, offset: $offset) {\ndriver_id\nfirst_name\nlast_name\nlicense_number\nlicense_state\ndate_of_birth\nlicense_status\nlicense_expiry_date\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\nvehicles(limit: $vehicles_limit, offset: $vehicles_offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $vehicles_bolos_limit, offset: $vehicles_bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $vehicles_tracking_limit, offset: $vehicles_tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\nwarrants(limit: $warrants_limit, offset: $warrants_offset) {\nwarrant_id\nperson_id\nwarrant_status\ncrime_description\nstate_of_issuance\nissue_date\nlast_updated\n}\n}\n\n}",
@@ -132,6 +393,107 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "bolos" : {
+          "items" : {
+            "properties" : {
+              "bolo_id" : {
+                "type" : "string"
+              },
+              "driver_id" : {
+                "type" : "string"
+              },
+              "issue_date" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "last_updated" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "license_state" : {
+                "type" : "string"
+              },
+              "make" : {
+                "type" : "string"
+              },
+              "model" : {
+                "type" : "string"
+              },
+              "registration_number" : {
+                "type" : "string"
+              },
+              "registration_state" : {
+                "type" : "string"
+              },
+              "status" : {
+                "type" : "string"
+              },
+              "vehicle_id" : {
+                "type" : "string"
+              },
+              "year" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "last_updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "make" : {
+          "type" : "string"
+        },
+        "model" : {
+          "type" : "string"
+        },
+        "owner_driver_id" : {
+          "type" : "string"
+        },
+        "registration_expiry" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "registration_number" : {
+          "type" : "string"
+        },
+        "registration_state" : {
+          "type" : "string"
+        },
+        "tracking" : {
+          "items" : {
+            "properties" : {
+              "event_time" : {
+                "format" : "date-time",
+                "type" : "string"
+              },
+              "latitude" : {
+                "type" : "number"
+              },
+              "longitude" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "vehicle_id" : {
+          "type" : "string"
+        },
+        "year" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query Vehicle($registration_number: String!, $limit: Int = 10, $offset: Int = 0$bolos_limit: Int = 10, $bolos_offset: Int = 0$tracking_limit: Int = 10, $tracking_offset: Int = 0) {\nVehicle(registration_number: $registration_number, limit: $limit, offset: $offset) {\nvehicle_id\nregistration_number\nregistration_state\nregistration_expiry\nmake\nmodel\nyear\nowner_driver_id\nlast_updated\nbolos(limit: $bolos_limit, offset: $bolos_offset) {\nbolo_id\nvehicle_id\nissue_date\nstatus\nlast_updated\nmake\nmodel\nyear\nregistration_state\nregistration_number\nlicense_state\ndriver_id\n}\ntracking(limit: $tracking_limit, offset: $tracking_offset) {\nlatitude\nlongitude\nevent_time\n}\n}\n\n}",
@@ -162,6 +524,20 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "crime" : {
+          "type" : "string"
+        },
+        "num_warrants" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query WarrantsByCrime($crime: String, $limit: Int = 100, $offset: Int = 0) {\nWarrantsByCrime(crime: $crime, limit: $limit, offset: $offset) {\ncrime\nnum_warrants\n}\n\n}",
@@ -191,6 +567,23 @@
       "required" : [ ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "num_warrants" : {
+          "type" : "number"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "status" : {
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -224,6 +617,24 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "num_bolos" : {
+          "type" : "number"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "week" : {
+          "format" : "date-time",
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query BolosByWeekState($state: String, $limit: Int = 100, $offset: Int = 0) {\nBolosByWeekState(state: $state, limit: $limit, offset: $offset) {\nweek\nstate\nnum_bolos\n}\n\n}",
@@ -251,6 +662,17 @@
       "required" : [ "plate", "latitude", "longitude" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "properties" : {
+      "_uuid" : {
+        "type" : "string"
+      },
+      "plate" : {
+        "type" : "string"
+      }
+    },
+    "type" : "object"
   },
   "apiQuery" : {
     "operationType" : "MUTATION",

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/nutshop.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/nutshop.txt
@@ -22,6 +22,23 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "total_savings" : {
+          "type" : "number"
+        },
+        "total_spend" : {
+          "type" : "number"
+        },
+        "week" : {
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query SpendingByWeek($customerid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSpendingByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\nweek\ntotal_spend\ntotal_savings\n}\n\n}",
@@ -60,6 +77,86 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "category" : {
+          "type" : "string"
+        },
+        "id" : {
+          "type" : "integer"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "orders" : {
+          "items" : {
+            "properties" : {
+              "customerid" : {
+                "type" : "integer"
+              },
+              "id" : {
+                "type" : "integer"
+              },
+              "items" : {
+                "items" : {
+                  "properties" : {
+                    "discount0" : {
+                      "type" : "number"
+                    },
+                    "quantity" : {
+                      "type" : "integer"
+                    },
+                    "total" : {
+                      "type" : "number"
+                    },
+                    "unit_price" : {
+                      "type" : "number"
+                    }
+                  },
+                  "type" : "object"
+                },
+                "type" : "array"
+              },
+              "timestamp" : {
+                "type" : "string"
+              },
+              "total" : {
+                "properties" : {
+                  "discount" : {
+                    "type" : "number"
+                  },
+                  "price" : {
+                    "type" : "number"
+                  }
+                },
+                "type" : "object"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "sizing" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "updated" : {
+          "type" : "string"
+        },
+        "usda_id" : {
+          "type" : "number"
+        },
+        "weight_in_gram" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query Products($id: Int, $limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10$orders_items_limit: Int = 10) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\norders(limit: $orders_limit) {\nid\ncustomerid\ntimestamp\nitems(limit: $orders_items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\n}\ntotal {\nprice\ndiscount\n}\n}\n}\n\n}",
@@ -94,6 +191,83 @@
       "required" : [ "customerid" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "customerid" : {
+          "type" : "integer"
+        },
+        "id" : {
+          "type" : "integer"
+        },
+        "items" : {
+          "items" : {
+            "properties" : {
+              "discount0" : {
+                "type" : "number"
+              },
+              "product" : {
+                "properties" : {
+                  "category" : {
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "type" : "integer"
+                  },
+                  "name" : {
+                    "type" : "string"
+                  },
+                  "sizing" : {
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "type" : "string"
+                  },
+                  "updated" : {
+                    "type" : "string"
+                  },
+                  "usda_id" : {
+                    "type" : "number"
+                  },
+                  "weight_in_gram" : {
+                    "type" : "number"
+                  }
+                },
+                "type" : "object"
+              },
+              "quantity" : {
+                "type" : "integer"
+              },
+              "total" : {
+                "type" : "number"
+              },
+              "unit_price" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "timestamp" : {
+          "type" : "string"
+        },
+        "total" : {
+          "properties" : {
+            "discount" : {
+              "type" : "number"
+            },
+            "price" : {
+              "type" : "number"
+            }
+          },
+          "type" : "object"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -130,6 +304,83 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "customerid" : {
+          "type" : "integer"
+        },
+        "id" : {
+          "type" : "integer"
+        },
+        "items" : {
+          "items" : {
+            "properties" : {
+              "discount0" : {
+                "type" : "number"
+              },
+              "product" : {
+                "properties" : {
+                  "category" : {
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "type" : "integer"
+                  },
+                  "name" : {
+                    "type" : "string"
+                  },
+                  "sizing" : {
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "type" : "string"
+                  },
+                  "updated" : {
+                    "type" : "string"
+                  },
+                  "usda_id" : {
+                    "type" : "number"
+                  },
+                  "weight_in_gram" : {
+                    "type" : "number"
+                  }
+                },
+                "type" : "object"
+              },
+              "quantity" : {
+                "type" : "integer"
+              },
+              "total" : {
+                "type" : "number"
+              },
+              "unit_price" : {
+                "type" : "number"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "timestamp" : {
+          "type" : "string"
+        },
+        "total" : {
+          "properties" : {
+            "discount" : {
+              "type" : "number"
+            },
+            "price" : {
+              "type" : "number"
+            }
+          },
+          "type" : "object"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query OrdersByTimeRange($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!$items_limit: Int = 10) {\nOrdersByTimeRange(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\nid\ncustomerid\ntimestamp\nitems(limit: $items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n}\ntotal {\nprice\ndiscount\n}\n}\n\n}",
@@ -164,6 +415,66 @@
       "required" : [ "customerid" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "num" : {
+          "type" : "integer"
+        },
+        "product" : {
+          "properties" : {
+            "category" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "integer"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "orders" : {
+              "items" : {
+                "properties" : {
+                  "customerid" : {
+                    "type" : "integer"
+                  },
+                  "id" : {
+                    "type" : "integer"
+                  },
+                  "timestamp" : {
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "type" : "array"
+            },
+            "sizing" : {
+              "type" : "string"
+            },
+            "type" : {
+              "type" : "string"
+            },
+            "updated" : {
+              "type" : "string"
+            },
+            "usda_id" : {
+              "type" : "number"
+            },
+            "weight_in_gram" : {
+              "type" : "number"
+            }
+          },
+          "type" : "object"
+        },
+        "quantity" : {
+          "type" : "integer"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/nutshop.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/nutshop.txt
@@ -1,4 +1,9 @@
 [ {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query SpendingByWeek($customerid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSpendingByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\nweek\ntotal_spend\ntotal_savings\n}\n\n}",
+    "queryName" : "SpendingByWeek"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " Retrieve weekly spending data for a specified customer.",
@@ -22,7 +27,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "total_savings" : {
@@ -39,15 +46,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query SpendingByWeek($customerid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSpendingByWeek(customerid: $customerid, limit: $limit, offset: $offset) {\nweek\ntotal_spend\ntotal_savings\n}\n\n}",
-    "queryName" : "SpendingByWeek"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/SpendingByWeek{?offset,customerid,limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query Products($id: Int, $limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10$orders_items_limit: Int = 10) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\norders(limit: $orders_limit) {\nid\ncustomerid\ntimestamp\nitems(limit: $orders_items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\n}\ntotal {\nprice\ndiscount\n}\n}\n}\n\n}",
+    "queryName" : "Products"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " Retrieve product information with optional filtering by product ID.",
@@ -77,7 +82,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "category" : {
@@ -157,15 +164,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query Products($id: Int, $limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10$orders_items_limit: Int = 10) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\norders(limit: $orders_limit) {\nid\ncustomerid\ntimestamp\nitems(limit: $orders_items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\n}\ntotal {\nprice\ndiscount\n}\n}\n}\n\n}",
-    "queryName" : "Products"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/Products{?orders_limit,offset,limit,id,orders_items_limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query Orders($customerid: Int!, $limit: Int = 10, $offset: Int = 0$items_limit: Int = 10) {\nOrders(customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntimestamp\nitems(limit: $items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n}\ntotal {\nprice\ndiscount\n}\n}\n\n}",
+    "queryName" : "Orders"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " Retrieve order information for a specified customer.",
@@ -192,7 +197,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "customerid" : {
@@ -269,15 +276,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query Orders($customerid: Int!, $limit: Int = 10, $offset: Int = 0$items_limit: Int = 10) {\nOrders(customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntimestamp\nitems(limit: $items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n}\ntotal {\nprice\ndiscount\n}\n}\n\n}",
-    "queryName" : "Orders"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/Orders{?offset,customerid,limit,items_limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query OrdersByTimeRange($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!$items_limit: Int = 10) {\nOrdersByTimeRange(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\nid\ncustomerid\ntimestamp\nitems(limit: $items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n}\ntotal {\nprice\ndiscount\n}\n}\n\n}",
+    "queryName" : "OrdersByTimeRange"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Retrieves orders for a given customer within the specified time range",
@@ -304,7 +309,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "customerid" : {
@@ -381,15 +388,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query OrdersByTimeRange($customerid: Int!, $fromTime: DateTime!, $toTime: DateTime!$items_limit: Int = 10) {\nOrdersByTimeRange(customerid: $customerid, fromTime: $fromTime, toTime: $toTime) {\nid\ncustomerid\ntimestamp\nitems(limit: $items_limit) {\nquantity\nunit_price\ndiscount0\ntotal\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n}\ntotal {\nprice\ndiscount\n}\n}\n\n}",
-    "queryName" : "OrdersByTimeRange"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/OrdersByTimeRange{?customerid,fromTime,items_limit,toTime}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query OrderAgain($customerid: Int!, $limit: Int = 10, $offset: Int = 0$product_orders_limit: Int = 10) {\nOrderAgain(customerid: $customerid, limit: $limit, offset: $offset) {\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\norders(limit: $product_orders_limit) {\nid\ncustomerid\ntimestamp\n}\n}\nnum\nquantity\n}\n\n}",
+    "queryName" : "OrderAgain"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " Suggest products for a customer to order again based on their previous orders.",
@@ -416,7 +421,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "num" : {
@@ -476,12 +483,5 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query OrderAgain($customerid: Int!, $limit: Int = 10, $offset: Int = 0$product_orders_limit: Int = 10) {\nOrderAgain(customerid: $customerid, limit: $limit, offset: $offset) {\nproduct {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\norders(limit: $product_orders_limit) {\nid\ncustomerid\ntimestamp\n}\n}\nnum\nquantity\n}\n\n}",
-    "queryName" : "OrderAgain"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/OrderAgain{?offset,customerid,limit,product_orders_limit}"
 } ]

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/rick-morty.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/rick-morty.txt
@@ -1,4 +1,9 @@
 [ {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query character($id: ID!) {\ncharacter(id: $id) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "character"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a specific character by ID",
@@ -13,7 +18,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "created" : {
         "description" : "Time at which the character was created in the database.",
@@ -131,15 +138,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query character($id: ID!) {\ncharacter(id: $id) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "character"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/character{?id}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query characters($page: Int, $name: String, $status: String, $species: String, $type: String, $gender: String) {\ncharacters(page: $page, filter: { name: $name, status: $status, species: $species, type: $type, gender: $gender }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n}\n\n}",
+    "queryName" : "characters"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get the list of all characters",
@@ -169,7 +174,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "info" : {
         "properties" : {
@@ -316,15 +323,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query characters($page: Int, $name: String, $status: String, $species: String, $type: String, $gender: String) {\ncharacters(page: $page, filter: { name: $name, status: $status, species: $species, type: $type, gender: $gender }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n}\n\n}",
-    "queryName" : "characters"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/characters{?gender,species,name,page,type,status}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query charactersByIds($ids: [ID!]!) {\ncharactersByIds(ids: $ids) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "charactersByIds"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a list of characters selected by ids",
@@ -342,7 +347,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "created" : {
@@ -463,15 +470,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query charactersByIds($ids: [ID!]!) {\ncharactersByIds(ids: $ids) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "charactersByIds"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/charactersByIds{?ids}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query location($id: ID!) {\nlocation(id: $id) {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "location"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a specific locations by ID",
@@ -486,7 +491,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "NONE",
+  "restMethod" : "NONE",
+  "resultDefinition" : {
     "properties" : {
       "created" : {
         "description" : "Time at which the location was created in the database.",
@@ -581,15 +588,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query location($id: ID!) {\nlocation(id: $id) {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "location"
-  },
-  "mcpMethod" : "NONE",
-  "restMethod" : "NONE",
   "uriTemplate" : "queries/location{?id}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query locations($page: Int, $name: String, $type: String, $dimension: String) {\nlocations(page: $page, filter: { name: $name, type: $type, dimension: $dimension }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
+    "queryName" : "locations"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get the list of all locations",
@@ -613,7 +618,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "info" : {
         "properties" : {
@@ -708,15 +715,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query locations($page: Int, $name: String, $type: String, $dimension: String) {\nlocations(page: $page, filter: { name: $name, type: $type, dimension: $dimension }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
-    "queryName" : "locations"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/locations{?name,page,type,dimension}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query locationsByIds($ids: [ID!]!) {\nlocationsByIds(ids: $ids) {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "locationsByIds"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a list of locations selected by ids",
@@ -734,7 +739,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "POST",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "created" : {
@@ -832,15 +839,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query locationsByIds($ids: [ID!]!) {\nlocationsByIds(ids: $ids) {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "locationsByIds"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "POST",
   "uriTemplate" : "queries/locationsByIds{?ids}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query episode($id: ID!) {\nepisode(id: $id) {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "episode"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a specific episode by ID",
@@ -855,7 +860,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "air_date" : {
         "description" : "The air date of the episode.",
@@ -973,15 +980,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query episode($id: ID!) {\nepisode(id: $id) {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "episode"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/episode{?id}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query episodes($page: Int, $name: String, $episode: String) {\nepisodes(page: $page, filter: { name: $name, episode: $episode }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
+    "queryName" : "episodes"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get the list of all episodes",
@@ -1002,7 +1007,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "properties" : {
       "info" : {
         "properties" : {
@@ -1097,15 +1104,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query episodes($page: Int, $name: String, $episode: String) {\nepisodes(page: $page, filter: { name: $name, episode: $episode }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
-    "queryName" : "episodes"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/episodes{?name,episode,page}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query episodesByIds($ids: [ID!]!) {\nepisodesByIds(ids: $ids) {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\ncreated\n}\ncreated\n}\n\n}",
+    "queryName" : "episodesByIds"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Get a list of episodes selected by ids",
@@ -1123,7 +1128,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "air_date" : {
@@ -1244,12 +1251,5 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query episodesByIds($ids: [ID!]!) {\nepisodesByIds(ids: $ids) {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\ncreated\n}\ncreated\n}\n\n}",
-    "queryName" : "episodesByIds"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/episodesByIds{?ids}"
 } ]

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/rick-morty.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/rick-morty.txt
@@ -13,6 +13,124 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "properties" : {
+      "created" : {
+        "description" : "Time at which the character was created in the database.",
+        "type" : "string"
+      },
+      "episode" : {
+        "description" : "Episodes in which this character appeared.",
+        "items" : {
+          "properties" : {
+            "air_date" : {
+              "description" : "The air date of the episode.",
+              "type" : "string"
+            },
+            "created" : {
+              "description" : "Time at which the episode was created in the database.",
+              "type" : "string"
+            },
+            "episode" : {
+              "description" : "The code of the episode.",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the episode.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the episode.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "gender" : {
+        "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+        "type" : "string"
+      },
+      "id" : {
+        "description" : "The id of the character.",
+        "type" : "string"
+      },
+      "image" : {
+        "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+        "type" : "string"
+      },
+      "location" : {
+        "description" : "The character's last known location",
+        "properties" : {
+          "created" : {
+            "description" : "Time at which the location was created in the database.",
+            "type" : "string"
+          },
+          "dimension" : {
+            "description" : "The dimension in which the location is located.",
+            "type" : "string"
+          },
+          "id" : {
+            "description" : "The id of the location.",
+            "type" : "string"
+          },
+          "name" : {
+            "description" : "The name of the location.",
+            "type" : "string"
+          },
+          "type" : {
+            "description" : "The type of the location.",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "name" : {
+        "description" : "The name of the character.",
+        "type" : "string"
+      },
+      "origin" : {
+        "description" : "The character's origin location",
+        "properties" : {
+          "created" : {
+            "description" : "Time at which the location was created in the database.",
+            "type" : "string"
+          },
+          "dimension" : {
+            "description" : "The dimension in which the location is located.",
+            "type" : "string"
+          },
+          "id" : {
+            "description" : "The id of the location.",
+            "type" : "string"
+          },
+          "name" : {
+            "description" : "The name of the location.",
+            "type" : "string"
+          },
+          "type" : {
+            "description" : "The type of the location.",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "species" : {
+        "description" : "The species of the character.",
+        "type" : "string"
+      },
+      "status" : {
+        "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+        "type" : "string"
+      },
+      "type" : {
+        "description" : "The type or subspecies of the character.",
+        "type" : "string"
+      }
+    },
+    "type" : "object"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query character($id: ID!) {\ncharacter(id: $id) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
@@ -51,6 +169,153 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "properties" : {
+      "info" : {
+        "properties" : {
+          "count" : {
+            "description" : "The length of the response.",
+            "type" : "integer"
+          },
+          "next" : {
+            "description" : "Number of the next page (if it exists)",
+            "type" : "integer"
+          },
+          "pages" : {
+            "description" : "The amount of pages.",
+            "type" : "integer"
+          },
+          "prev" : {
+            "description" : "Number of the previous page (if it exists)",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "results" : {
+        "items" : {
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the character was created in the database.",
+              "type" : "string"
+            },
+            "episode" : {
+              "description" : "Episodes in which this character appeared.",
+              "items" : {
+                "properties" : {
+                  "air_date" : {
+                    "description" : "The air date of the episode.",
+                    "type" : "string"
+                  },
+                  "created" : {
+                    "description" : "Time at which the episode was created in the database.",
+                    "type" : "string"
+                  },
+                  "episode" : {
+                    "description" : "The code of the episode.",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the episode.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the episode.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "type" : "array"
+            },
+            "gender" : {
+              "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the character.",
+              "type" : "string"
+            },
+            "image" : {
+              "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+              "type" : "string"
+            },
+            "location" : {
+              "description" : "The character's last known location",
+              "properties" : {
+                "created" : {
+                  "description" : "Time at which the location was created in the database.",
+                  "type" : "string"
+                },
+                "dimension" : {
+                  "description" : "The dimension in which the location is located.",
+                  "type" : "string"
+                },
+                "id" : {
+                  "description" : "The id of the location.",
+                  "type" : "string"
+                },
+                "name" : {
+                  "description" : "The name of the location.",
+                  "type" : "string"
+                },
+                "type" : {
+                  "description" : "The type of the location.",
+                  "type" : "string"
+                }
+              },
+              "type" : "object"
+            },
+            "name" : {
+              "description" : "The name of the character.",
+              "type" : "string"
+            },
+            "origin" : {
+              "description" : "The character's origin location",
+              "properties" : {
+                "created" : {
+                  "description" : "Time at which the location was created in the database.",
+                  "type" : "string"
+                },
+                "dimension" : {
+                  "description" : "The dimension in which the location is located.",
+                  "type" : "string"
+                },
+                "id" : {
+                  "description" : "The id of the location.",
+                  "type" : "string"
+                },
+                "name" : {
+                  "description" : "The name of the location.",
+                  "type" : "string"
+                },
+                "type" : {
+                  "description" : "The type of the location.",
+                  "type" : "string"
+                }
+              },
+              "type" : "object"
+            },
+            "species" : {
+              "description" : "The species of the character.",
+              "type" : "string"
+            },
+            "status" : {
+              "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+              "type" : "string"
+            },
+            "type" : {
+              "description" : "The type or subspecies of the character.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      }
+    },
+    "type" : "object"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query characters($page: Int, $name: String, $status: String, $species: String, $type: String, $gender: String) {\ncharacters(page: $page, filter: { name: $name, status: $status, species: $species, type: $type, gender: $gender }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n}\n\n}",
@@ -77,6 +342,127 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "created" : {
+          "description" : "Time at which the character was created in the database.",
+          "type" : "string"
+        },
+        "episode" : {
+          "description" : "Episodes in which this character appeared.",
+          "items" : {
+            "properties" : {
+              "air_date" : {
+                "description" : "The air date of the episode.",
+                "type" : "string"
+              },
+              "created" : {
+                "description" : "Time at which the episode was created in the database.",
+                "type" : "string"
+              },
+              "episode" : {
+                "description" : "The code of the episode.",
+                "type" : "string"
+              },
+              "id" : {
+                "description" : "The id of the episode.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "The name of the episode.",
+                "type" : "string"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "gender" : {
+          "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+          "type" : "string"
+        },
+        "id" : {
+          "description" : "The id of the character.",
+          "type" : "string"
+        },
+        "image" : {
+          "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+          "type" : "string"
+        },
+        "location" : {
+          "description" : "The character's last known location",
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the location was created in the database.",
+              "type" : "string"
+            },
+            "dimension" : {
+              "description" : "The dimension in which the location is located.",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the location.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the location.",
+              "type" : "string"
+            },
+            "type" : {
+              "description" : "The type of the location.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "name" : {
+          "description" : "The name of the character.",
+          "type" : "string"
+        },
+        "origin" : {
+          "description" : "The character's origin location",
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the location was created in the database.",
+              "type" : "string"
+            },
+            "dimension" : {
+              "description" : "The dimension in which the location is located.",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the location.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the location.",
+              "type" : "string"
+            },
+            "type" : {
+              "description" : "The type of the location.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "species" : {
+          "description" : "The species of the character.",
+          "type" : "string"
+        },
+        "status" : {
+          "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+          "type" : "string"
+        },
+        "type" : {
+          "description" : "The type or subspecies of the character.",
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query charactersByIds($ids: [ID!]!) {\ncharactersByIds(ids: $ids) {\nid\nname\nstatus\nspecies\ntype\ngender\norigin {\nid\nname\ntype\ndimension\ncreated\n}\nlocation {\nid\nname\ntype\ndimension\ncreated\n}\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\n\n}",
@@ -99,6 +485,101 @@
       "required" : [ "id" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "properties" : {
+      "created" : {
+        "description" : "Time at which the location was created in the database.",
+        "type" : "string"
+      },
+      "dimension" : {
+        "description" : "The dimension in which the location is located.",
+        "type" : "string"
+      },
+      "id" : {
+        "description" : "The id of the location.",
+        "type" : "string"
+      },
+      "name" : {
+        "description" : "The name of the location.",
+        "type" : "string"
+      },
+      "residents" : {
+        "description" : "List of characters who have been last seen in the location.",
+        "items" : {
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the character was created in the database.",
+              "type" : "string"
+            },
+            "episode" : {
+              "description" : "Episodes in which this character appeared.",
+              "items" : {
+                "properties" : {
+                  "air_date" : {
+                    "description" : "The air date of the episode.",
+                    "type" : "string"
+                  },
+                  "created" : {
+                    "description" : "Time at which the episode was created in the database.",
+                    "type" : "string"
+                  },
+                  "episode" : {
+                    "description" : "The code of the episode.",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the episode.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the episode.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "type" : "array"
+            },
+            "gender" : {
+              "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the character.",
+              "type" : "string"
+            },
+            "image" : {
+              "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the character.",
+              "type" : "string"
+            },
+            "species" : {
+              "description" : "The species of the character.",
+              "type" : "string"
+            },
+            "status" : {
+              "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+              "type" : "string"
+            },
+            "type" : {
+              "description" : "The type or subspecies of the character.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "type" : {
+        "description" : "The type of the location.",
+        "type" : "string"
+      }
+    },
+    "type" : "object"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -132,6 +613,101 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "properties" : {
+      "info" : {
+        "properties" : {
+          "count" : {
+            "description" : "The length of the response.",
+            "type" : "integer"
+          },
+          "next" : {
+            "description" : "Number of the next page (if it exists)",
+            "type" : "integer"
+          },
+          "pages" : {
+            "description" : "The amount of pages.",
+            "type" : "integer"
+          },
+          "prev" : {
+            "description" : "Number of the previous page (if it exists)",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "results" : {
+        "items" : {
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the location was created in the database.",
+              "type" : "string"
+            },
+            "dimension" : {
+              "description" : "The dimension in which the location is located.",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the location.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the location.",
+              "type" : "string"
+            },
+            "residents" : {
+              "description" : "List of characters who have been last seen in the location.",
+              "items" : {
+                "properties" : {
+                  "created" : {
+                    "description" : "Time at which the character was created in the database.",
+                    "type" : "string"
+                  },
+                  "gender" : {
+                    "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the character.",
+                    "type" : "string"
+                  },
+                  "image" : {
+                    "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the character.",
+                    "type" : "string"
+                  },
+                  "species" : {
+                    "description" : "The species of the character.",
+                    "type" : "string"
+                  },
+                  "status" : {
+                    "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "description" : "The type or subspecies of the character.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "type" : "array"
+            },
+            "type" : {
+              "description" : "The type of the location.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      }
+    },
+    "type" : "object"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query locations($page: Int, $name: String, $type: String, $dimension: String) {\nlocations(page: $page, filter: { name: $name, type: $type, dimension: $dimension }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
@@ -158,6 +734,104 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "created" : {
+          "description" : "Time at which the location was created in the database.",
+          "type" : "string"
+        },
+        "dimension" : {
+          "description" : "The dimension in which the location is located.",
+          "type" : "string"
+        },
+        "id" : {
+          "description" : "The id of the location.",
+          "type" : "string"
+        },
+        "name" : {
+          "description" : "The name of the location.",
+          "type" : "string"
+        },
+        "residents" : {
+          "description" : "List of characters who have been last seen in the location.",
+          "items" : {
+            "properties" : {
+              "created" : {
+                "description" : "Time at which the character was created in the database.",
+                "type" : "string"
+              },
+              "episode" : {
+                "description" : "Episodes in which this character appeared.",
+                "items" : {
+                  "properties" : {
+                    "air_date" : {
+                      "description" : "The air date of the episode.",
+                      "type" : "string"
+                    },
+                    "created" : {
+                      "description" : "Time at which the episode was created in the database.",
+                      "type" : "string"
+                    },
+                    "episode" : {
+                      "description" : "The code of the episode.",
+                      "type" : "string"
+                    },
+                    "id" : {
+                      "description" : "The id of the episode.",
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "description" : "The name of the episode.",
+                      "type" : "string"
+                    }
+                  },
+                  "type" : "object"
+                },
+                "type" : "array"
+              },
+              "gender" : {
+                "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+                "type" : "string"
+              },
+              "id" : {
+                "description" : "The id of the character.",
+                "type" : "string"
+              },
+              "image" : {
+                "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+                "type" : "string"
+              },
+              "name" : {
+                "description" : "The name of the character.",
+                "type" : "string"
+              },
+              "species" : {
+                "description" : "The species of the character.",
+                "type" : "string"
+              },
+              "status" : {
+                "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+                "type" : "string"
+              },
+              "type" : {
+                "description" : "The type or subspecies of the character.",
+                "type" : "string"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "type" : {
+          "description" : "The type of the location.",
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query locationsByIds($ids: [ID!]!) {\nlocationsByIds(ids: $ids) {\nid\nname\ntype\ndimension\nresidents {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\nepisode {\nid\nname\nair_date\nepisode\ncreated\n}\ncreated\n}\ncreated\n}\n\n}",
@@ -180,6 +854,124 @@
       "required" : [ "id" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "properties" : {
+      "air_date" : {
+        "description" : "The air date of the episode.",
+        "type" : "string"
+      },
+      "characters" : {
+        "description" : "List of characters who have been seen in the episode.",
+        "items" : {
+          "properties" : {
+            "created" : {
+              "description" : "Time at which the character was created in the database.",
+              "type" : "string"
+            },
+            "gender" : {
+              "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the character.",
+              "type" : "string"
+            },
+            "image" : {
+              "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+              "type" : "string"
+            },
+            "location" : {
+              "description" : "The character's last known location",
+              "properties" : {
+                "created" : {
+                  "description" : "Time at which the location was created in the database.",
+                  "type" : "string"
+                },
+                "dimension" : {
+                  "description" : "The dimension in which the location is located.",
+                  "type" : "string"
+                },
+                "id" : {
+                  "description" : "The id of the location.",
+                  "type" : "string"
+                },
+                "name" : {
+                  "description" : "The name of the location.",
+                  "type" : "string"
+                },
+                "type" : {
+                  "description" : "The type of the location.",
+                  "type" : "string"
+                }
+              },
+              "type" : "object"
+            },
+            "name" : {
+              "description" : "The name of the character.",
+              "type" : "string"
+            },
+            "origin" : {
+              "description" : "The character's origin location",
+              "properties" : {
+                "created" : {
+                  "description" : "Time at which the location was created in the database.",
+                  "type" : "string"
+                },
+                "dimension" : {
+                  "description" : "The dimension in which the location is located.",
+                  "type" : "string"
+                },
+                "id" : {
+                  "description" : "The id of the location.",
+                  "type" : "string"
+                },
+                "name" : {
+                  "description" : "The name of the location.",
+                  "type" : "string"
+                },
+                "type" : {
+                  "description" : "The type of the location.",
+                  "type" : "string"
+                }
+              },
+              "type" : "object"
+            },
+            "species" : {
+              "description" : "The species of the character.",
+              "type" : "string"
+            },
+            "status" : {
+              "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+              "type" : "string"
+            },
+            "type" : {
+              "description" : "The type or subspecies of the character.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "created" : {
+        "description" : "Time at which the episode was created in the database.",
+        "type" : "string"
+      },
+      "episode" : {
+        "description" : "The code of the episode.",
+        "type" : "string"
+      },
+      "id" : {
+        "description" : "The id of the episode.",
+        "type" : "string"
+      },
+      "name" : {
+        "description" : "The name of the episode.",
+        "type" : "string"
+      }
+    },
+    "type" : "object"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -210,6 +1002,101 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "properties" : {
+      "info" : {
+        "properties" : {
+          "count" : {
+            "description" : "The length of the response.",
+            "type" : "integer"
+          },
+          "next" : {
+            "description" : "Number of the next page (if it exists)",
+            "type" : "integer"
+          },
+          "pages" : {
+            "description" : "The amount of pages.",
+            "type" : "integer"
+          },
+          "prev" : {
+            "description" : "Number of the previous page (if it exists)",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "results" : {
+        "items" : {
+          "properties" : {
+            "air_date" : {
+              "description" : "The air date of the episode.",
+              "type" : "string"
+            },
+            "characters" : {
+              "description" : "List of characters who have been seen in the episode.",
+              "items" : {
+                "properties" : {
+                  "created" : {
+                    "description" : "Time at which the character was created in the database.",
+                    "type" : "string"
+                  },
+                  "gender" : {
+                    "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the character.",
+                    "type" : "string"
+                  },
+                  "image" : {
+                    "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the character.",
+                    "type" : "string"
+                  },
+                  "species" : {
+                    "description" : "The species of the character.",
+                    "type" : "string"
+                  },
+                  "status" : {
+                    "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "description" : "The type or subspecies of the character.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "type" : "array"
+            },
+            "created" : {
+              "description" : "Time at which the episode was created in the database.",
+              "type" : "string"
+            },
+            "episode" : {
+              "description" : "The code of the episode.",
+              "type" : "string"
+            },
+            "id" : {
+              "description" : "The id of the episode.",
+              "type" : "string"
+            },
+            "name" : {
+              "description" : "The name of the episode.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "array"
+      }
+    },
+    "type" : "object"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query episodes($page: Int, $name: String, $episode: String) {\nepisodes(page: $page, filter: { name: $name, episode: $episode }) {\ninfo {\ncount\npages\nnext\nprev\n}\nresults {\nid\nname\nair_date\nepisode\ncharacters {\nid\nname\nstatus\nspecies\ntype\ngender\nimage\ncreated\n}\ncreated\n}\n}\n\n}",
@@ -235,6 +1122,127 @@
       "required" : [ "ids" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "air_date" : {
+          "description" : "The air date of the episode.",
+          "type" : "string"
+        },
+        "characters" : {
+          "description" : "List of characters who have been seen in the episode.",
+          "items" : {
+            "properties" : {
+              "created" : {
+                "description" : "Time at which the character was created in the database.",
+                "type" : "string"
+              },
+              "gender" : {
+                "description" : "The gender of the character ('Female', 'Male', 'Genderless' or 'unknown').",
+                "type" : "string"
+              },
+              "id" : {
+                "description" : "The id of the character.",
+                "type" : "string"
+              },
+              "image" : {
+                "description" : "Link to the character's image.\nAll images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars.",
+                "type" : "string"
+              },
+              "location" : {
+                "description" : "The character's last known location",
+                "properties" : {
+                  "created" : {
+                    "description" : "Time at which the location was created in the database.",
+                    "type" : "string"
+                  },
+                  "dimension" : {
+                    "description" : "The dimension in which the location is located.",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the location.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the location.",
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "description" : "The type of the location.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "name" : {
+                "description" : "The name of the character.",
+                "type" : "string"
+              },
+              "origin" : {
+                "description" : "The character's origin location",
+                "properties" : {
+                  "created" : {
+                    "description" : "Time at which the location was created in the database.",
+                    "type" : "string"
+                  },
+                  "dimension" : {
+                    "description" : "The dimension in which the location is located.",
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "The id of the location.",
+                    "type" : "string"
+                  },
+                  "name" : {
+                    "description" : "The name of the location.",
+                    "type" : "string"
+                  },
+                  "type" : {
+                    "description" : "The type of the location.",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              },
+              "species" : {
+                "description" : "The species of the character.",
+                "type" : "string"
+              },
+              "status" : {
+                "description" : "The status of the character ('Alive', 'Dead' or 'unknown').",
+                "type" : "string"
+              },
+              "type" : {
+                "description" : "The type or subspecies of the character.",
+                "type" : "string"
+              }
+            },
+            "type" : "object"
+          },
+          "type" : "array"
+        },
+        "created" : {
+          "description" : "Time at which the episode was created in the database.",
+          "type" : "string"
+        },
+        "episode" : {
+          "description" : "The code of the episode.",
+          "type" : "string"
+        },
+        "id" : {
+          "description" : "The id of the episode.",
+          "type" : "string"
+        },
+        "name" : {
+          "description" : "The name of the episode.",
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/sensors.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/sensors.txt
@@ -21,6 +21,24 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "event_time" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "sensorid" : {
+          "type" : "integer"
+        },
+        "temperature" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query SensorReading($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
@@ -46,6 +64,24 @@
       "required" : [ "temp" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "event_time" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "sensorid" : {
+          "type" : "integer"
+        },
+        "temperature" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",
@@ -78,6 +114,24 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "last_updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "maxTemp" : {
+          "type" : "number"
+        },
+        "sensorid" : {
+          "type" : "integer"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query SensorMaxTempLastMinute($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMinute(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
@@ -109,6 +163,24 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "last_updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "maxTemp" : {
+          "type" : "number"
+        },
+        "sensorid" : {
+          "type" : "integer"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query SensorMaxTemp($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
@@ -134,6 +206,21 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "properties" : {
+      "event_time" : {
+        "format" : "date-time",
+        "type" : "string"
+      },
+      "sensorid" : {
+        "type" : "integer"
+      },
+      "temperature" : {
+        "type" : "number"
+      }
+    },
+    "type" : "object"
+  },
   "apiQuery" : {
     "operationType" : "MUTATION",
     "query" : "mutation AddReading($sensorid: Int!, $temperature: Float!) {\nAddReading(metric: { sensorid: $sensorid, temperature: $temperature }) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
@@ -158,6 +245,20 @@
       "type" : "object"
     }
   },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "sensorid" : {
+          "type" : "integer"
+        },
+        "temperature" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
+  },
   "apiQuery" : {
     "operationType" : "QUERY",
     "query" : "query HighTemps(\n    $temperature: Float!\n) @api(rest: \"none\") {\n    ReadingsAboveTemp(temp: $temperature) {\n        sensorid\n        temperature\n    }\n}\n",
@@ -181,6 +282,20 @@
       "required" : [ "temp" ],
       "type" : "object"
     }
+  },
+  "result" : {
+    "items" : {
+      "properties" : {
+        "sensorid" : {
+          "type" : "integer"
+        },
+        "temperature" : {
+          "type" : "number"
+        }
+      },
+      "type" : "object"
+    },
+    "type" : "array"
   },
   "apiQuery" : {
     "operationType" : "QUERY",

--- a/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/sensors.txt
+++ b/sqrl-planner/src/test/resources/snapshots/com/datasqrl/converter/GraphQLSchemaConverterTest/sensors.txt
@@ -1,4 +1,9 @@
 [ {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query SensorReading($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+    "queryName" : "SensorReading"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the sensor temperature readings for each second by most recent for a given sensor id",
@@ -21,7 +26,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "event_time" : {
@@ -39,15 +46,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query SensorReading($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-    "queryName" : "SensorReading"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/SensorReading{?offset,limit,sensorid}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query ReadingsAboveTemp($temp: Float!, $limit: Int = 10) {\nReadingsAboveTemp(temp: $temp, limit: $limit) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+    "queryName" : "ReadingsAboveTemp"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns all sensor temperature readings above the given temperature",
@@ -65,7 +70,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "event_time" : {
@@ -83,15 +90,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query ReadingsAboveTemp($temp: Float!, $limit: Int = 10) {\nReadingsAboveTemp(temp: $temp, limit: $limit) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-    "queryName" : "ReadingsAboveTemp"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/ReadingsAboveTemp{?temp,limit}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query SensorMaxTempLastMinute($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMinute(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
+    "queryName" : "SensorMaxTempLastMinute"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the maximum temperature recorded by each sensor in the last minute",
@@ -114,7 +119,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "last_updated" : {
@@ -132,15 +139,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query SensorMaxTempLastMinute($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMinute(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
-    "queryName" : "SensorMaxTempLastMinute"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/SensorMaxTempLastMinute{?offset,limit,sensorid}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query SensorMaxTemp($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
+    "queryName" : "SensorMaxTemp"
+  },
   "format" : "JSON",
   "function" : {
     "description" : "Returns the maximum temperature recorded by each sensor",
@@ -163,7 +168,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "last_updated" : {
@@ -181,15 +188,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query SensorMaxTemp($sensorid: Int, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\nlast_updated\n}\n\n}",
-    "queryName" : "SensorMaxTemp"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "queries/SensorMaxTemp{?offset,limit,sensorid}"
 }, {
+  "apiQuery" : {
+    "operationType" : "MUTATION",
+    "query" : "mutation AddReading($sensorid: Int!, $temperature: Float!) {\nAddReading(metric: { sensorid: $sensorid, temperature: $temperature }) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+    "queryName" : "AddReading"
+  },
   "format" : "JSON",
   "function" : {
     "name" : "AddAddReading",
@@ -206,7 +211,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "POST",
+  "resultDefinition" : {
     "properties" : {
       "event_time" : {
         "format" : "date-time",
@@ -221,15 +228,13 @@
     },
     "type" : "object"
   },
-  "apiQuery" : {
-    "operationType" : "MUTATION",
-    "query" : "mutation AddReading($sensorid: Int!, $temperature: Float!) {\nAddReading(metric: { sensorid: $sensorid, temperature: $temperature }) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-    "queryName" : "AddReading"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "POST",
   "uriTemplate" : "mutations/AddReading"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query HighTemps(\n    $temperature: Float!\n) @api(rest: \"none\") {\n    ReadingsAboveTemp(temp: $temperature) {\n        sensorid\n        temperature\n    }\n}\n",
+    "queryName" : "HighTemps"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " Returns all readings with a temperature higher than the provided value",
@@ -245,7 +250,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "NONE",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "sensorid" : {
@@ -259,15 +266,13 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query HighTemps(\n    $temperature: Float!\n) @api(rest: \"none\") {\n    ReadingsAboveTemp(temp: $temperature) {\n        sensorid\n        temperature\n    }\n}\n",
-    "queryName" : "HighTemps"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "NONE",
   "uriTemplate" : "queries/HighTemps{?temperature}"
 }, {
+  "apiQuery" : {
+    "operationType" : "QUERY",
+    "query" : "query HighTemps2(\n    $temp: Float!\n) @api(uri: \"/temp/high{?temp}\") {\n    ReadingsAboveTemp(temp: $temp) {\n        sensorid\n        temperature\n    }\n}\n",
+    "queryName" : "HighTemps2"
+  },
   "format" : "JSON",
   "function" : {
     "description" : " high temperature readings",
@@ -283,7 +288,9 @@
       "type" : "object"
     }
   },
-  "result" : {
+  "mcpMethod" : "TOOL",
+  "restMethod" : "GET",
+  "resultDefinition" : {
     "items" : {
       "properties" : {
         "sensorid" : {
@@ -297,12 +304,5 @@
     },
     "type" : "array"
   },
-  "apiQuery" : {
-    "operationType" : "QUERY",
-    "query" : "query HighTemps2(\n    $temp: Float!\n) @api(uri: \"/temp/high{?temp}\") {\n    ReadingsAboveTemp(temp: $temp) {\n        sensorid\n        temperature\n    }\n}\n",
-    "queryName" : "HighTemps2"
-  },
-  "mcpMethod" : "TOOL",
-  "restMethod" : "GET",
   "uriTemplate" : "/temp/high{?temp}"
 } ]

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
@@ -28,7 +28,6 @@ import lombok.Value;
  * passed to the LLM as a tool and the {@link GraphQLQuery} that is executed.
  */
 @Value
-@Builder
 public class ApiOperation {
 
   @NonNull FunctionDefinition function;
@@ -40,6 +39,7 @@ public class ApiOperation {
   String uriTemplate;
 
   ResultFormat format;
+  @JsonIgnore ResultDefinition result;
 
   public static ApiOperationBuilder getBuilder(FunctionDefinition function, GraphQLQuery apiQuery) {
     return builder()
@@ -52,15 +52,18 @@ public class ApiOperation {
   }
 
   @JsonCreator
+  @Builder
   public ApiOperation(
       @JsonProperty("function") FunctionDefinition function,
       @JsonProperty("query") GraphQLQuery apiQuery,
+      @JsonProperty("result") ResultDefinition result,
       @JsonProperty("mcp") McpMethodType mcpMethod,
       @JsonProperty("rest") RestMethodType restMethod,
       @JsonProperty("uri") String uriTemplate,
       @JsonProperty("format") ResultFormat format) {
     this.function = function;
     this.apiQuery = apiQuery;
+    this.result = result;
     this.mcpMethod = mcpMethod;
     this.restMethod = restMethod;
     this.uriTemplate = uriTemplate;

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
@@ -17,7 +17,6 @@ package com.datasqrl.server.operation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.NonNull;
@@ -39,7 +38,7 @@ public class ApiOperation {
   String uriTemplate;
 
   ResultFormat format;
-  @JsonIgnore ResultDefinition result;
+  ResultDefinition resultDefinition;
 
   public static ApiOperationBuilder getBuilder(FunctionDefinition function, GraphQLQuery apiQuery) {
     return builder()
@@ -54,20 +53,20 @@ public class ApiOperation {
   @JsonCreator
   @Builder
   public ApiOperation(
-      @JsonProperty("function") FunctionDefinition function,
-      @JsonProperty("query") GraphQLQuery apiQuery,
-      @JsonProperty("result") ResultDefinition result,
-      @JsonProperty("mcp") McpMethodType mcpMethod,
-      @JsonProperty("rest") RestMethodType restMethod,
-      @JsonProperty("uri") String uriTemplate,
-      @JsonProperty("format") ResultFormat format) {
+      FunctionDefinition function,
+      GraphQLQuery apiQuery,
+      McpMethodType mcpMethod,
+      RestMethodType restMethod,
+      String uriTemplate,
+      ResultFormat format,
+      ResultDefinition resultDefinition) {
     this.function = function;
     this.apiQuery = apiQuery;
-    this.result = result;
     this.mcpMethod = mcpMethod;
     this.restMethod = restMethod;
     this.uriTemplate = uriTemplate;
     this.format = format;
+    this.resultDefinition = resultDefinition;
   }
 
   /**

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
@@ -17,6 +17,7 @@ package com.datasqrl.server.operation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.NonNull;
@@ -53,13 +54,13 @@ public class ApiOperation {
   @JsonCreator
   @Builder
   public ApiOperation(
-      FunctionDefinition function,
-      GraphQLQuery apiQuery,
-      McpMethodType mcpMethod,
-      RestMethodType restMethod,
-      String uriTemplate,
-      ResultFormat format,
-      ResultDefinition resultDefinition) {
+      @JsonProperty("function") FunctionDefinition function,
+      @JsonProperty("apiQuery") GraphQLQuery apiQuery,
+      @JsonProperty("mcpMethod") McpMethodType mcpMethod,
+      @JsonProperty("restMethod") RestMethodType restMethod,
+      @JsonProperty("uriTemplate") String uriTemplate,
+      @JsonProperty("format") ResultFormat format,
+      @JsonProperty("resultDefinition") ResultDefinition resultDefinition) {
     this.function = function;
     this.apiQuery = apiQuery;
     this.mcpMethod = mcpMethod;

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ApiOperation.java
@@ -28,6 +28,7 @@ import lombok.Value;
  * passed to the LLM as a tool and the {@link GraphQLQuery} that is executed.
  */
 @Value
+@Builder
 public class ApiOperation {
 
   @NonNull FunctionDefinition function;
@@ -52,7 +53,6 @@ public class ApiOperation {
   }
 
   @JsonCreator
-  @Builder
   public ApiOperation(
       @JsonProperty("function") FunctionDefinition function,
       @JsonProperty("apiQuery") GraphQLQuery apiQuery,

--- a/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ResultDefinition.java
+++ b/sqrl-server/sqrl-server-core/src/main/java/com/datasqrl/server/operation/ResultDefinition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server.operation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** JSON Schema-compatible description of the data returned by an API operation. */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResultDefinition {
+
+  private String type;
+  private String format;
+  private String description;
+  private ResultDefinition items;
+  private Map<String, ResultDefinition> properties;
+
+  @JsonProperty("enum")
+  private Set<?> enumValues;
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/AbstractBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/AbstractBridgeVerticle.java
@@ -19,6 +19,7 @@ import com.datasqrl.server.config.ServerConfig;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.operation.ApiOperation;
 import com.datasqrl.server.operation.FunctionDefinition;
+import com.datasqrl.util.JsonUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,7 +36,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -47,8 +47,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Slf4j
 public abstract class AbstractBridgeVerticle extends AbstractVerticle {
-
-  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   // Reusable JSON field names
   protected static final String JSON_ERROR = "error";
@@ -80,8 +78,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
   }
 
   protected Future<ExecutionResult> bridgeRequestToGraphQL(
-      RoutingContext ctx, ApiOperation operation, Map<String, Object> variables)
-      throws ValidationException {
+      RoutingContext ctx, ApiOperation operation, Map<String, Object> variables) {
     // Validate parameters
     validateParameters(variables, operation);
 
@@ -89,8 +86,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
     return executeGraphQLAsync(ctx, operation, variables);
   }
 
-  protected void validateParameters(Map<String, Object> variables, ApiOperation operation)
-      throws ValidationException {
+  protected void validateParameters(Map<String, Object> variables, ApiOperation operation) {
     var parameters = operation.getFunction().getParameters();
     if (parameters == null) {
       return; // No validation required
@@ -105,9 +101,9 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
 
       // Convert the collected variables to a JsonNode
       if (variables == null || variables.isEmpty()) {
-        arguments = OBJECT_MAPPER.readTree("{}");
+        arguments = JsonUtils.MAPPER.readTree("{}");
       } else {
-        arguments = OBJECT_MAPPER.valueToTree(variables);
+        arguments = JsonUtils.MAPPER.valueToTree(variables);
       }
     } catch (JsonProcessingException e) {
       throw new ValidationException("Could not parse parameter JSON:" + e.getMessage());
@@ -124,7 +120,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
   }
 
   protected ObjectMapper getSchemaMapper() {
-    return OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return JsonUtils.MAPPER.copy().setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
   }
 
   protected Future<ExecutionResult> executeGraphQLAsync(
@@ -156,7 +152,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
     return result;
   }
 
-  protected static void extractGetParameters(
+  protected static void extractUriParameters(
       RoutingContext ctx, ApiOperation operation, Map<String, Object> variables) {
     var request = ctx.request();
     var functionParams = operation.getFunction().getParameters();
@@ -167,29 +163,48 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
 
     var properties = functionParams.getProperties();
     var queryParams = request.params();
-    var pathParams = ctx.pathParams();
+
+    for (String key : queryParams.names()) {
+      var argument = properties.get(key);
+      if (argument != null) {
+        variables.put(key, convertParameterValue(queryParams.get(key), argument));
+      }
+    }
 
     // Merge query and path parameters, giving precedence to path params
-    Map<String, String> combinedParams = new HashMap<>();
-    for (String key : queryParams.names()) {
-      combinedParams.put(key, queryParams.get(key));
-    }
-    combinedParams.putAll(pathParams); // path params take precedence
+    extractPathParameters(ctx, operation, variables);
+  }
 
-    for (Map.Entry<String, FunctionDefinition.Argument> entry : properties.entrySet()) {
-      var paramName = entry.getKey();
-      if (combinedParams.containsKey(paramName)) {
-        var value = combinedParams.get(paramName);
-        var convertedValue = convertParameterValue(value, entry.getValue());
-        variables.put(paramName, convertedValue);
+  protected static void extractPathParameters(
+      RoutingContext ctx, ApiOperation operation, Map<String, Object> variables) {
+    var functionParams = operation.getFunction().getParameters();
+    if (functionParams == null || functionParams.getProperties() == null) {
+      return;
+    }
+
+    var properties = functionParams.getProperties();
+    for (var pathParameter : ctx.pathParams().entrySet()) {
+      var argument = properties.get(pathParameter.getKey());
+      if (argument != null) {
+        variables.put(
+            pathParameter.getKey(), convertParameterValue(pathParameter.getValue(), argument));
       }
     }
   }
 
-  protected static void extractPostParameters(RoutingContext ctx, Map<String, Object> variables) {
+  protected static void extractBodyParameters(RoutingContext ctx, Map<String, Object> variables) {
     JsonObject body = ctx.body().asJsonObject();
     if (body != null) {
-      variables.putAll(body.getMap());
+      for (var parameter : body.getMap().entrySet()) {
+        var name = parameter.getKey();
+        var bodyValue = parameter.getValue();
+        if (variables.containsKey(name)
+            && !String.valueOf(variables.get(name)).equals(String.valueOf(bodyValue))) {
+          throw new ValidationException(
+              "Path parameter '%s' does not match the request body".formatted(name));
+        }
+        variables.put(name, bodyValue);
+      }
     }
   }
 
@@ -220,7 +235,7 @@ public abstract class AbstractBridgeVerticle extends AbstractVerticle {
   }
 
   /** Custom exception for parameter validation errors */
-  public static class ValidationException extends Exception {
+  public static class ValidationException extends RuntimeException {
     public ValidationException(String message) {
       super(message);
     }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/McpBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/McpBridgeVerticle.java
@@ -20,6 +20,7 @@ import com.datasqrl.server.config.ServerConfig;
 import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.operation.ApiOperation;
 import com.datasqrl.server.operation.McpMethodType;
+import com.datasqrl.util.JsonUtils;
 import com.datasqrl.util.ProjectConstants;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -177,7 +178,7 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
         ctx -> {
           log.debug("Received POST request to MCP endpoint: {}", mcpRoutePrefix);
           try {
-            var payload = OBJECT_MAPPER.readTree(ctx.body().buffer().getBytes());
+            var payload = JsonUtils.MAPPER.readTree(ctx.body().buffer().getBytes());
             log.debug("Parsed payload: {}", payload);
             processIncomingMessages(ctx, payload);
           } catch (IOException e) { // TODO: improve error handling
@@ -441,8 +442,7 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
     return Future.succeededFuture(new JsonObject().put("contents", contents));
   }
 
-  private Future<JsonObject> handleCallTool(RoutingContext ctx, JsonNode params)
-      throws ValidationException {
+  private Future<JsonObject> handleCallTool(RoutingContext ctx, JsonNode params) {
     var toolName = params.get("name").asText();
     var arguments = params.get("arguments");
 
@@ -451,7 +451,7 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
       return Future.failedFuture(new McpException(-32602, "Tool not found: " + toolName));
     }
     var variables =
-        OBJECT_MAPPER.<Map<String, Object>>convertValue(arguments, new TypeReference<>() {});
+        JsonUtils.MAPPER.<Map<String, Object>>convertValue(arguments, new TypeReference<>() {});
     return bridgeRequestToGraphQL(ctx, tool, variables)
         .map(
             executionResult -> {
@@ -477,7 +477,7 @@ public class McpBridgeVerticle extends AbstractBridgeVerticle {
                       List.of(
                           new JsonObject()
                               .put("type", "text")
-                              .put("text", OBJECT_MAPPER.writeValueAsString(result))));
+                              .put("text", JsonUtils.MAPPER.writeValueAsString(result))));
                   json.put("isError", false);
                 } catch (JsonProcessingException e) {
                   throw new RuntimeException(e);

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/RestBridgeVerticle.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/RestBridgeVerticle.java
@@ -32,9 +32,12 @@ import io.vertx.ext.web.handler.AuthenticationHandler;
 import io.vertx.ext.web.handler.ChainAuthHandler;
 import io.vertx.ext.web.handler.JWTAuthHandler;
 import io.vertx.ext.web.handler.OAuth2AuthHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,6 +56,8 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
   // Pattern for RFC 6570 URI template path parameters: {param}
   private static final Pattern PATH_PARAMS_PATTERN = Pattern.compile("\\{([^}?]+)\\}");
 
+  private final Path openApiArtifact;
+
   private OpenApiService openApiService;
 
   public RestBridgeVerticle(
@@ -61,8 +66,10 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
       String modelVersion,
       RootGraphQLModel model,
       List<AuthenticationProvider> authProviders,
-      GraphQLServerVerticle graphQLServerVerticle) {
+      GraphQLServerVerticle graphQLServerVerticle,
+      Path openApiArtifact) {
     super(router, config, modelVersion, model, authProviders, graphQLServerVerticle);
+    this.openApiArtifact = openApiArtifact;
   }
 
   @Override
@@ -99,6 +106,7 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
             modelVersion,
             config.getServletConfig().getRestEndpoint(modelVersion));
 
+    var openApiArtifactJson = loadOpenApiArtifact();
     var openApiJsonEndpoint = config.getOpenApiConfig().getEndpoint(modelVersion);
     router
         .get(openApiJsonEndpoint)
@@ -107,8 +115,14 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
               try {
                 // Extract request host and port for dynamic server URL
                 var requestHost = getRequestBaseUrl(ctx);
-                var openApiJson = openApiService.generateOpenApiJson(requestHost);
-                ctx.response().putHeader("content-type", "application/json").end(openApiJson);
+                var openApiWithRequestHost =
+                    openApiArtifactJson
+                        .map(
+                            openApiJson -> openApiService.withRequestHost(openApiJson, requestHost))
+                        .orElseGet(() -> openApiService.generateOpenApiJson(requestHost));
+                ctx.response()
+                    .putHeader("content-type", "application/json")
+                    .end(openApiWithRequestHost);
               } catch (Exception e) {
                 log.error("Failed to generate OpenAPI JSON", e);
                 ctx.response()
@@ -138,6 +152,23 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
     log.info("OpenAPI endpoints setup completed:");
     log.info("  OpenAPI JSON: {}", openApiJsonEndpoint);
     log.info("  Swagger UI: {}", swaggerUiEndpoint);
+  }
+
+  private Optional<String> loadOpenApiArtifact() {
+    try {
+      var openApiJson = Files.readString(openApiArtifact);
+      openApiService.validateOpenApiJson(openApiJson);
+
+      return Optional.of(openApiJson);
+
+    } catch (Exception e) {
+      log.warn(
+          "OpenAPI artifact {} is unavailable or invalid; generating it for OpenAPI requests: {}",
+          openApiArtifact,
+          e.getMessage());
+    }
+
+    return Optional.empty();
   }
 
   private void createRestEndpoint(ApiOperation operation) {
@@ -177,8 +208,8 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
     // Add the REST handler
     route.handler(
         ctx -> {
-          var variables = extractParameters(ctx, operation);
           try {
+            var variables = extractParameters(ctx, operation);
             var fut = bridgeRequestToGraphQL(ctx, operation, variables);
             fut.onSuccess(
                     executionResult -> {
@@ -245,12 +276,12 @@ public class RestBridgeVerticle extends AbstractBridgeVerticle {
       RoutingContext ctx, ApiOperation operation) {
     var variables = new HashMap<String, Object>();
 
-    if (operation.getRestMethod() == RestMethodType.GET) {
-      // For GET requests, extract parameters from URL query parameters and path parameters
-      extractGetParameters(ctx, operation, variables);
-    } else {
-      // For POST/PUT requests, use the JSON body as variables
-      extractPostParameters(ctx, variables);
+    if (operation.getRestMethod() == RestMethodType.POST) {
+      extractPathParameters(ctx, operation, variables);
+      extractBodyParameters(ctx, variables);
+
+    } else if (operation.getRestMethod() == RestMethodType.GET) {
+      extractUriParameters(ctx, operation, variables);
     }
 
     return variables;

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/modules/ApiDeploymentModule.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/modules/ApiDeploymentModule.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.server.modules;
 
+import static com.datasqrl.server.openapi.OpenApiService.OPENAPI_JSON_ARTIFACT_NAME_SUFFIX_TEMPLATE;
+
 import com.datasqrl.server.GraphQLServerVerticle;
 import com.datasqrl.server.McpBridgeVerticle;
 import com.datasqrl.server.RestBridgeVerticle;
@@ -129,6 +131,8 @@ public class ApiDeploymentModule implements ServerModule<VertxServerModuleContex
     }
 
     if (hasRest) {
+      var openApiArtifact =
+          ("vertx" + OPENAPI_JSON_ARTIFACT_NAME_SUFFIX_TEMPLATE).formatted(modelVersion);
       var restBridgeVerticle =
           new RestBridgeVerticle(
               context.router(),
@@ -136,7 +140,8 @@ public class ApiDeploymentModule implements ServerModule<VertxServerModuleContex
               modelVersion,
               model,
               authProviders,
-              graphQLVerticle);
+              graphQLVerticle,
+              context.planDir().resolve(openApiArtifact));
       bridgeDeploymentFutures.add(
           context
               .vertx()

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/openapi/OpenApiService.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/openapi/OpenApiService.java
@@ -242,7 +242,8 @@ public class OpenApiService {
                             .schema(
                                 new Schema<>()
                                     .type("object")
-                                    .addProperty("data", resultToSchema(operation.getResult())))));
+                                    .addProperty(
+                                        "data", resultToSchema(operation.getResultDefinition())))));
     responses.addApiResponse("200", successResponse);
 
     // Error response

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/openapi/OpenApiService.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/openapi/OpenApiService.java
@@ -20,8 +20,11 @@ import com.datasqrl.server.graphql.RootGraphQLModel;
 import com.datasqrl.server.operation.ApiOperation;
 import com.datasqrl.server.operation.FunctionDefinition;
 import com.datasqrl.server.operation.RestMethodType;
+import com.datasqrl.server.operation.ResultDefinition;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -52,6 +55,8 @@ import org.apache.commons.lang3.StringUtils;
 @Slf4j
 public class OpenApiService {
 
+  public static final String OPENAPI_JSON_ARTIFACT_NAME_SUFFIX_TEMPLATE = "-%s-openapi.json";
+
   private static final Pattern QUERY_PARAMS_PATTERN = Pattern.compile("\\{\\?([^}]+)\\}");
   private static final Pattern PATH_PARAMS_PATTERN = Pattern.compile("\\{([^}?]+)\\}");
   private static final ObjectMapper objectMapper = Json.mapper();
@@ -67,7 +72,7 @@ public class OpenApiService {
 
   public String generateOpenApiJson(String requestHost) {
     try {
-      var openAPI = createOpenAPI(Optional.ofNullable(requestHost));
+      var openAPI = createOpenAPI(requestHost);
       return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
     } catch (JsonProcessingException e) {
       log.error("Failed to generate OpenAPI JSON", e);
@@ -75,7 +80,47 @@ public class OpenApiService {
     }
   }
 
-  private OpenAPI createOpenAPI(Optional<String> requestHost) {
+  public void validateOpenApiJson(String openApiJson) {
+    try {
+      var openApi = objectMapper.readTree(openApiJson);
+      if (!(openApi instanceof ObjectNode openApiObject)
+          || !openApiObject.path("openapi").isTextual()
+          || !openApiObject.path("info").isObject()
+          || !openApiObject.path("paths").isObject()) {
+        throw new IllegalArgumentException("OpenAPI artifact is not a valid OpenAPI document");
+      }
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("OpenAPI artifact is not valid JSON", e);
+    }
+  }
+
+  /**
+   * Replaces the deployment-specific server URL without regenerating the compiled specification.
+   */
+  public String withRequestHost(String openApiJson, String requestHost) {
+    if (StringUtils.isBlank(requestHost)) {
+      return openApiJson;
+    }
+    try {
+      var openApi = objectMapper.readTree(openApiJson);
+      if (!(openApi instanceof ObjectNode openApiObject)) {
+        throw new IllegalArgumentException("OpenAPI artifact must contain a JSON object");
+      }
+      ArrayNode servers = openApiObject.withArray("servers");
+      if (servers.isEmpty()) {
+        servers.addObject().put("url", requestHost).put("description", "DataSQRL API Server");
+      } else if (servers.get(0) instanceof ObjectNode server) {
+        server.put("url", requestHost);
+      } else {
+        throw new IllegalArgumentException("OpenAPI artifact server must be a JSON object");
+      }
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(openApi);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to update OpenAPI artifact server URL", e);
+    }
+  }
+
+  private OpenAPI createOpenAPI(String requestHost) {
     var openAPI = new OpenAPI();
 
     // Set API info
@@ -102,8 +147,7 @@ public class OpenApiService {
 
     openAPI.info(info);
 
-    // Add server based on request host
-    var serverUrl = requestHost.orElse("http://localhost:8888");
+    var serverUrl = StringUtils.defaultIfBlank(requestHost, "http://localhost:8888");
     var server = new Server().url(serverUrl).description("DataSQRL API Server");
     openAPI.addServersItem(server);
 
@@ -172,11 +216,9 @@ public class OpenApiService {
     }
 
     // Add parameters
-    if (operation.getRestMethod() == RestMethodType.GET) {
-      var parameters = extractParameters(uriTemplate);
-      if (!parameters.isEmpty()) {
-        openApiOperation.parameters(parameters);
-      }
+    var parameters = extractParameters(uriTemplate);
+    if (!parameters.isEmpty()) {
+      openApiOperation.parameters(parameters);
     }
 
     // Add request body
@@ -200,11 +242,7 @@ public class OpenApiService {
                             .schema(
                                 new Schema<>()
                                     .type("object")
-                                    .addProperty(
-                                        "data",
-                                        new Schema<>()
-                                            .type("object")
-                                            .description("Response data")))));
+                                    .addProperty("data", resultToSchema(operation.getResult())))));
     responses.addApiResponse("200", successResponse);
 
     // Error response
@@ -229,6 +267,28 @@ public class OpenApiService {
     openApiOperation.responses(responses);
 
     return openApiOperation;
+  }
+
+  private Schema<?> resultToSchema(ResultDefinition result) {
+    if (result == null) {
+      return new Schema<>().type("object").description("Response data");
+    }
+    var schema = new Schema<>();
+    schema.type(result.getType());
+    schema.format(result.getFormat());
+    schema.description(result.getDescription());
+    if (result.getEnumValues() != null) {
+      schema._enum(new ArrayList<>(result.getEnumValues()));
+    }
+    if (result.getItems() != null) {
+      schema.items(resultToSchema(result.getItems()));
+    }
+    if (ObjectUtils.isNotEmpty(result.getProperties())) {
+      for (var entry : result.getProperties().entrySet()) {
+        schema.addProperty(entry.getKey(), resultToSchema(entry.getValue()));
+      }
+    }
+    return schema;
   }
 
   private String getSummary(String description) {

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/RestBridgeVerticleTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/RestBridgeVerticleTest.java
@@ -16,15 +16,20 @@
 package com.datasqrl.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datasqrl.server.config.OpenApiConfig;
 import com.datasqrl.server.config.ServerConfig;
 import com.datasqrl.server.config.ServletConfig;
 import com.datasqrl.server.graphql.ModelContainer;
 import com.datasqrl.server.graphql.RootGraphQLModel;
+import com.datasqrl.server.openapi.OpenApiService;
 import com.datasqrl.server.operation.ApiOperation;
+import com.datasqrl.server.operation.RestMethodType;
+import com.datasqrl.server.operation.ResultDefinition;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import graphql.ExecutionInput;
@@ -40,6 +45,8 @@ import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +54,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -71,6 +79,7 @@ class RestBridgeVerticleTest {
   private RootGraphQLModel model;
   private RestBridgeVerticle restBridgeVerticle;
   private Vertx vertx;
+  @TempDir Path tempDir;
 
   @BeforeEach
   @SneakyThrows
@@ -102,7 +111,14 @@ class RestBridgeVerticleTest {
     when(route.handler(any())).thenReturn(route);
 
     restBridgeVerticle =
-        new RestBridgeVerticle(router, serverConfig, "v1", model, List.of(), graphQLServerVerticle);
+        new RestBridgeVerticle(
+            router,
+            serverConfig,
+            "v1",
+            model,
+            List.of(),
+            graphQLServerVerticle,
+            Path.of("unused-openapi-artifact.json"));
   }
 
   @Test
@@ -247,6 +263,200 @@ class RestBridgeVerticleTest {
     // Then
     assertThat(parameters).containsKey("event");
     assertThat(parameters.get("event")).isInstanceOf(List.class);
+  }
+
+  @Test
+  void given_postRequestWithPathParams_when_extractParameters_then_extractsPathParameters() {
+    var operation = getSensorMaxOperation();
+    var postOperation =
+        ApiOperation.builder()
+            .function(operation.getFunction())
+            .apiQuery(operation.getApiQuery())
+            .mcpMethod(operation.getMcpMethod())
+            .restMethod(RestMethodType.POST)
+            .uriTemplate("mutations/{sensorid}")
+            .format(operation.getFormat())
+            .build();
+    when(requestBody.asJsonObject()).thenReturn(null);
+    when(routingContext.body()).thenReturn(requestBody);
+    when(routingContext.pathParams()).thenReturn(Map.of("sensorid", "123"));
+
+    var parameters = RestBridgeVerticle.extractParameters(routingContext, postOperation);
+
+    assertThat(parameters).containsEntry("sensorid", 123L);
+  }
+
+  @Test
+  void
+      givenPostRequestWithMismatchedPathAndBodyParameters_whenExtractParameters_thenRejectsRequest() {
+    var operation = getSensorMaxOperation();
+    var postOperation =
+        ApiOperation.builder()
+            .function(operation.getFunction())
+            .apiQuery(operation.getApiQuery())
+            .mcpMethod(operation.getMcpMethod())
+            .restMethod(RestMethodType.POST)
+            .uriTemplate("mutations/{sensorid}")
+            .format(operation.getFormat())
+            .build();
+    when(requestBody.asJsonObject()).thenReturn(new JsonObject().put("sensorid", 456));
+    when(routingContext.body()).thenReturn(requestBody);
+    when(routingContext.pathParams()).thenReturn(Map.of("sensorid", "123"));
+
+    assertThatThrownBy(() -> RestBridgeVerticle.extractParameters(routingContext, postOperation))
+        .isInstanceOf(AbstractBridgeVerticle.ValidationException.class)
+        .hasMessage("Path parameter 'sensorid' does not match the request body");
+  }
+
+  @Test
+  void givenPostRequestWithQueryParameters_whenExtractParameters_thenIgnoresQueryParameters() {
+    var operation = getSensorMaxOperation();
+    var postOperation =
+        ApiOperation.builder()
+            .function(operation.getFunction())
+            .apiQuery(operation.getApiQuery())
+            .mcpMethod(operation.getMcpMethod())
+            .restMethod(RestMethodType.POST)
+            .uriTemplate("mutations")
+            .format(operation.getFormat())
+            .build();
+    var queryParams = MultiMap.caseInsensitiveMultiMap();
+    queryParams.add("sensorid", "123");
+    when(request.params()).thenReturn(queryParams);
+    when(requestBody.asJsonObject()).thenReturn(null);
+    when(routingContext.body()).thenReturn(requestBody);
+
+    var parameters = RestBridgeVerticle.extractParameters(routingContext, postOperation);
+
+    assertThat(parameters).doesNotContainKey("sensorid");
+  }
+
+  @Test
+  @SneakyThrows
+  void given_modelWithRestOperations_when_generateOpenApi_then_includesResponseSchemas() {
+    var operation = addSensorReadingOperation();
+    var result =
+        ResultDefinition.builder()
+            .type("array")
+            .items(
+                ResultDefinition.builder()
+                    .type("object")
+                    .properties(
+                        Map.of(
+                            "sensorid", ResultDefinition.builder().type("integer").build(),
+                            "event_time",
+                                ResultDefinition.builder()
+                                    .type("string")
+                                    .format("date-time")
+                                    .build()))
+                    .build())
+            .build();
+    var operationWithResult =
+        ApiOperation.builder()
+            .function(operation.getFunction())
+            .apiQuery(operation.getApiQuery())
+            .result(result)
+            .mcpMethod(operation.getMcpMethod())
+            .restMethod(operation.getRestMethod())
+            .uriTemplate(operation.getUriTemplate())
+            .format(operation.getFormat())
+            .build();
+    var modelWithResult =
+        RootGraphQLModel.builder()
+            .queries(model.getQueries())
+            .mutations(model.getMutations())
+            .subscriptions(model.getSubscriptions())
+            .operations(
+                model.getOperations().stream()
+                    .map(current -> current.equals(operation) ? operationWithResult : current)
+                    .toList())
+            .schema(model.getSchema())
+            .build();
+    var openApi =
+        new ObjectMapper()
+            .readTree(
+                new OpenApiService(new OpenApiConfig(), modelWithResult, "v1", "/v1/api/rest")
+                    .generateOpenApiJson());
+
+    var dataSchema =
+        openApi.at(
+            "/paths/~1v1~1api~1rest~1mutations~1SensorReading/post/responses/200/content/application~1json/schema/properties/data");
+
+    assertThat(dataSchema.path("type").asText()).isEqualTo("array");
+    assertThat(dataSchema.path("items").path("properties").path("sensorid").path("type").asText())
+        .isEqualTo("integer");
+    assertThat(
+            dataSchema.path("items").path("properties").path("event_time").path("format").asText())
+        .isEqualTo("date-time");
+  }
+
+  @Test
+  @SneakyThrows
+  void givenCompiledOpenApiArtifact_whenRequestHostProvided_thenOnlyServerUrlChanges() {
+    var compiledOpenApi =
+        """
+        {
+          "openapi": "3.0.1",
+          "servers": [{"url": "http://localhost:8888", "description": "compiled"}],
+          "paths": {"/custom": {"get": {"operationId": "customOperation"}}}
+        }
+        """;
+
+    var openApiWithRequestHost =
+        new OpenApiService(new OpenApiConfig(), model, "v1", "/v1/api/rest")
+            .withRequestHost(compiledOpenApi, "https://api.example.com");
+    var openApi = new ObjectMapper().readTree(openApiWithRequestHost);
+
+    assertThat(openApi.at("/servers/0/url").asText()).isEqualTo("https://api.example.com");
+    assertThat(openApi.at("/servers/0/description").asText()).isEqualTo("compiled");
+    assertThat(openApi.at("/paths/~1custom/get/operationId").asText()).isEqualTo("customOperation");
+  }
+
+  @Test
+  @SneakyThrows
+  void givenRequestHost_whenGenerateOpenApi_thenUsesItForTheServerUrl() {
+    var openApi =
+        new ObjectMapper()
+            .readTree(
+                new OpenApiService(new OpenApiConfig(), model, "v1", "/v1/api/rest")
+                    .generateOpenApiJson("https://api.example.com"));
+
+    assertThat(openApi.at("/servers/0/url").asText()).isEqualTo("https://api.example.com");
+  }
+
+  @Test
+  void givenMissingOpenApiArtifact_whenStartingRestBridge_thenRegeneratesIt() {
+    when(serverConfig.getOpenApiConfig()).thenReturn(new OpenApiConfig());
+    restBridgeVerticle =
+        new RestBridgeVerticle(
+            router,
+            serverConfig,
+            "v1",
+            model,
+            List.of(),
+            graphQLServerVerticle,
+            Path.of("missing-openapi-artifact.json"));
+    var promise = Promise.<Void>promise();
+
+    restBridgeVerticle.start(promise);
+
+    assertThat(promise.future().succeeded()).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  void givenInvalidOpenApiArtifact_whenStartingRestBridge_thenRegeneratesIt() {
+    var openApiArtifact = tempDir.resolve("invalid-openapi-artifact.json");
+    Files.writeString(openApiArtifact, "not JSON");
+    when(serverConfig.getOpenApiConfig()).thenReturn(new OpenApiConfig());
+    restBridgeVerticle =
+        new RestBridgeVerticle(
+            router, serverConfig, "v1", model, List.of(), graphQLServerVerticle, openApiArtifact);
+    var promise = Promise.<Void>promise();
+
+    restBridgeVerticle.start(promise);
+
+    assertThat(promise.future().succeeded()).isTrue();
   }
 
   @Test

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/RestBridgeVerticleTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/RestBridgeVerticleTest.java
@@ -355,7 +355,7 @@ class RestBridgeVerticleTest {
         ApiOperation.builder()
             .function(operation.getFunction())
             .apiQuery(operation.getApiQuery())
-            .result(result)
+            .resultDefinition(result)
             .mcpMethod(operation.getMcpMethod())
             .restMethod(operation.getRestMethod())
             .uriTemplate(operation.getUriTemplate())

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
@@ -517,7 +517,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid\ntimestamp\ncol2\n}\n\n}",
+            "queryName" : "FilteredOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FilteredOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -560,16 +569,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid\ntimestamp\ncol2\n}\n\n}",
-            "queryName" : "FilteredOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FilteredOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -587,7 +587,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderIds($limit: Int = 10, $offset: Int = 0) {\nOrderIds(limit: $limit, offset: $offset) {\nid1\nid2\ntime\n}\n\n}",
+            "queryName" : "OrderIds",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderIds{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -604,16 +613,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderIds($limit: Int = 10, $offset: Int = 0) {\nOrderIds(limit: $limit, offset: $offset) {\nid1\nid2\ntime\n}\n\n}",
-            "queryName" : "OrderIds",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderIds{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -631,7 +631,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -668,16 +677,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
@@ -517,6 +517,50 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "integer"
+                },
+                "col2" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid\ntimestamp\ncol2\n}\n\n}",
@@ -543,6 +587,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id1" : {
+                  "type" : "integer"
+                },
+                "id2" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderIds($limit: Int = 10, $offset: Int = 0) {\nOrderIds(limit: $limit, offset: $offset) {\nid1\nid2\ntime\n}\n\n}",
@@ -567,6 +629,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
@@ -804,7 +804,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
+            "queryName" : "OrderAgg1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -817,16 +826,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
-            "queryName" : "OrderAgg1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -844,7 +844,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg2($limit: Int = 10, $offset: Int = 0) {\nOrderAgg2(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\ncnt\n}\n\n}",
+            "queryName" : "OrderAgg2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -861,16 +870,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg2($limit: Int = 10, $offset: Int = 0) {\nOrderAgg2(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\ncnt\n}\n\n}",
-            "queryName" : "OrderAgg2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -888,7 +888,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg3($limit: Int = 10, $offset: Int = 0) {\nOrderAgg3(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
+            "queryName" : "OrderAgg3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg3{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -901,16 +910,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg3($limit: Int = 10, $offset: Int = 0) {\nOrderAgg3(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
-            "queryName" : "OrderAgg3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg3{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -928,7 +928,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg4($limit: Int = 10, $offset: Int = 0) {\nOrderAgg4(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\ncnt\n}\n\n}",
+            "queryName" : "OrderAgg4",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg4{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -945,16 +954,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg4($limit: Int = 10, $offset: Int = 0) {\nOrderAgg4(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\ncnt\n}\n\n}",
-            "queryName" : "OrderAgg4",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg4{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -972,7 +972,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1009,16 +1018,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1036,7 +1036,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrdersState($limit: Int = 10, $offset: Int = 0) {\nOrdersState(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrdersState",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrdersState{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1073,16 +1082,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrdersState($limit: Int = 10, $offset: Int = 0) {\nOrdersState(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrdersState",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrdersState{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
@@ -804,6 +804,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "cnt" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
@@ -828,6 +842,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "cnt" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -856,6 +888,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "cnt" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderAgg3($limit: Int = 10, $offset: Int = 0) {\nOrderAgg3(limit: $limit, offset: $offset) {\ncustomerid\ncnt\n}\n\n}",
@@ -880,6 +926,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "cnt" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -908,6 +972,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -932,6 +1034,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
@@ -886,7 +886,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -909,16 +918,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -936,7 +936,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerWithEmail($limit: Int = 10, $offset: Int = 0) {\nCustomerWithEmail(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerWithEmail",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerWithEmail{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -959,16 +968,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerWithEmail($limit: Int = 10, $offset: Int = 0) {\nCustomerWithEmail(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerWithEmail",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerWithEmail{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -987,7 +987,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "DistinctCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1012,16 +1021,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "DistinctCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1039,7 +1039,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1058,16 +1067,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1090,7 +1090,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerById{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1113,16 +1122,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerById{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -1145,7 +1145,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "DistinctCustomerById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomerById{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1170,16 +1179,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "DistinctCustomerById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomerById{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -1202,7 +1202,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ProductByCategory($category: String!, $limit: Int = 10, $offset: Int = 0) {\nProductByCategory(category: $category, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "ProductByCategory",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductByCategory{?offset,limit,category}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1221,16 +1230,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ProductByCategory($category: String!, $limit: Int = 10, $offset: Int = 0) {\nProductByCategory(category: $category, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "ProductByCategory",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductByCategory{?offset,limit,category}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
@@ -886,6 +886,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -910,6 +934,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -939,6 +987,32 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer",
+                  "description" : "The unique id of a customer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time",
+                  "description" : "When the customer was last updated"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -963,6 +1037,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -996,6 +1090,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1027,6 +1145,32 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer",
+                  "description" : "The unique id of a customer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time",
+                  "description" : "When the customer was last updated"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctCustomerById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerById(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1056,6 +1200,26 @@ END
               "required" : [
                 "category"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
@@ -1203,6 +1203,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1227,6 +1251,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1255,6 +1317,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
@@ -1279,6 +1361,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1307,6 +1409,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductFilter2($limit: Int = 10, $offset: Int = 0) {\nProductFilter2(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
@@ -1331,6 +1453,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1359,6 +1496,21 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SelectOrders2($limit: Int = 10, $offset: Int = 0) {\nSelectOrders2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
@@ -1383,6 +1535,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
@@ -1203,7 +1203,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1226,16 +1235,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1253,7 +1253,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1290,16 +1299,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1317,7 +1317,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1336,16 +1345,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1363,7 +1363,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ProductFilter1($limit: Int = 10, $offset: Int = 0) {\nProductFilter1(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "ProductFilter1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductFilter1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1382,16 +1391,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ProductFilter1($limit: Int = 10, $offset: Int = 0) {\nProductFilter1(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "ProductFilter1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductFilter1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1409,7 +1409,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ProductFilter2($limit: Int = 10, $offset: Int = 0) {\nProductFilter2(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "ProductFilter2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductFilter2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1428,16 +1437,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ProductFilter2($limit: Int = 10, $offset: Int = 0) {\nProductFilter2(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "ProductFilter2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductFilter2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1455,7 +1455,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectOrders1($limit: Int = 10, $offset: Int = 0) {\nSelectOrders1(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
+            "queryName" : "SelectOrders1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectOrders1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1469,16 +1478,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectOrders1($limit: Int = 10, $offset: Int = 0) {\nSelectOrders1(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
-            "queryName" : "SelectOrders1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectOrders1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1496,7 +1496,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectOrders2($limit: Int = 10, $offset: Int = 0) {\nSelectOrders2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
+            "queryName" : "SelectOrders2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectOrders2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1510,16 +1519,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectOrders2($limit: Int = 10, $offset: Int = 0) {\nSelectOrders2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
-            "queryName" : "SelectOrders2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectOrders2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1537,7 +1537,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectOrders3($limit: Int = 10, $offset: Int = 0) {\nSelectOrders3(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
+            "queryName" : "SelectOrders3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectOrders3{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1551,16 +1560,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectOrders3($limit: Int = 10, $offset: Int = 0) {\nSelectOrders3(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
-            "queryName" : "SelectOrders3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectOrders3{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
@@ -2663,6 +2663,23 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
@@ -2687,6 +2704,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2715,6 +2756,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -2741,6 +2806,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -2765,6 +2854,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2794,6 +2907,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time",
+                  "description" : "Start of the aggregation window"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "unique_email_count" : {
+                  "type" : "integer",
+                  "description" : "Number of unique emails for all customers per minute"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
@@ -2818,6 +2952,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2846,6 +2998,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ExternalOrders($limit: Int = 10, $offset: Int = 0) {\nExternalOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -2872,6 +3062,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "namee" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
@@ -2896,6 +3104,51 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2925,6 +3178,22 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orderid" : {
+                  "type" : "integer",
+                  "description" : "The id of the order"
+                },
+                "amount" : {
+                  "type" : "number",
+                  "description" : "The amount ordered"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\norderid\namount\n}\n\n}",
@@ -2950,6 +3219,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2978,6 +3271,54 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "customerid0" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid0\ntimestamp\nname\n}\n\n}",
@@ -3002,6 +3343,36 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "discount" : {
+                  "type" : "number"
+                },
+                "newId" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3035,6 +3406,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3066,6 +3461,23 @@ END
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3103,6 +3515,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3132,6 +3568,19 @@ END
               "required" : [
                 "orderid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "orderid" : {
+                "type" : "integer",
+                "description" : "The id of the order"
+              },
+              "amount" : {
+                "type" : "number",
+                "description" : "The amount ordered"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
@@ -2663,7 +2663,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
+            "queryName" : "AnotherCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2679,16 +2688,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
-            "queryName" : "AnotherCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2706,7 +2706,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2729,16 +2738,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2756,7 +2756,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByMultipleTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2779,16 +2788,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByMultipleTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2806,7 +2806,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByTime2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2829,16 +2838,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTime2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2856,7 +2856,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerFilteredDistinct($limit: Int = 10, $offset: Int = 0) {\nCustomerFilteredDistinct(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerFilteredDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerFilteredDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2879,16 +2888,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerFilteredDistinct($limit: Int = 10, $offset: Int = 0) {\nCustomerFilteredDistinct(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerFilteredDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerFilteredDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2907,7 +2907,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
+            "queryName" : "CustomerTimeWindow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2927,16 +2936,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
-            "queryName" : "CustomerTimeWindow",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2954,7 +2954,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
+            "queryName" : "ExplicitDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2971,16 +2980,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
-            "queryName" : "ExplicitDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2998,7 +2998,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExternalOrders($limit: Int = 10, $offset: Int = 0) {\nExternalOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "ExternalOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExternalOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3035,16 +3044,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExternalOrders($limit: Int = 10, $offset: Int = 0) {\nExternalOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "ExternalOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExternalOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3062,7 +3062,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
+            "queryName" : "InvalidDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/InvalidDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3079,16 +3088,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
-            "queryName" : "InvalidDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/InvalidDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3106,7 +3106,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MissedTemporalJoin($limit: Int = 10, $offset: Int = 0) {\nMissedTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
+            "queryName" : "MissedTemporalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MissedTemporalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3150,16 +3159,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MissedTemporalJoin($limit: Int = 10, $offset: Int = 0) {\nMissedTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
-            "queryName" : "MissedTemporalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MissedTemporalJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3178,7 +3178,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\norderid\namount\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3193,16 +3202,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\norderid\namount\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3221,7 +3221,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectCustomers($limit: Int = 10, $offset: Int = 0) {\nSelectCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "SelectCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectCustomers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3244,16 +3253,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectCustomers($limit: Int = 10, $offset: Int = 0) {\nSelectCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "SelectCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectCustomers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3271,7 +3271,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid0\ntimestamp\nname\n}\n\n}",
+            "queryName" : "TemporalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TemporalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3318,16 +3327,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid0\ntimestamp\nname\n}\n\n}",
-            "queryName" : "TemporalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TemporalJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3345,7 +3345,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\nnewId\n}\n\n}",
+            "queryName" : "UnnestOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/UnnestOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3374,16 +3383,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\nnewId\n}\n\n}",
-            "queryName" : "UnnestOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/UnnestOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3406,7 +3406,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerById{?offset,limit,minId}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3429,16 +3438,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerById{?offset,limit,minId}"
+          }
         },
         {
           "function" : {
@@ -3463,7 +3463,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerQuery($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerQuery(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
+            "queryName" : "CustomerQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerQuery{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3479,16 +3488,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerQuery($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerQuery(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
-            "queryName" : "CustomerQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerQuery{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -3515,7 +3515,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "TableFunctionCallsTblFct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3538,16 +3547,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "TableFunctionCallsTblFct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}"
+          }
         },
         {
           "function" : {
@@ -3570,7 +3570,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation Orders($orderid: Int!, $amount: Float) {\nOrders(event: { orderid: $orderid, amount: $amount }) {\norderid\namount\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/Orders",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "orderid" : {
@@ -3582,16 +3591,7 @@ END
                 "description" : "The amount ordered"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation Orders($orderid: Int!, $amount: Float) {\nOrders(event: { orderid: $orderid, amount: $amount }) {\norderid\namount\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/Orders"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
@@ -443,7 +443,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -466,16 +475,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -493,7 +493,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -530,16 +539,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -566,7 +566,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FrequentCustomers($threshold: Long!, $afterTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nFrequentCustomers(threshold: $threshold, afterTime: $afterTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "FrequentCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FrequentCustomers{?offset,limit,afterTime,threshold}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -589,16 +598,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FrequentCustomers($threshold: Long!, $afterTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nFrequentCustomers(threshold: $threshold, afterTime: $afterTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "FrequentCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FrequentCustomers{?offset,limit,afterTime,threshold}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
@@ -443,6 +443,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -467,6 +491,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -502,6 +564,30 @@ END
                 "threshold",
                 "afterTime"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
@@ -497,7 +497,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -517,16 +526,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -544,7 +544,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "MachineTempByHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -561,16 +570,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "MachineTempByHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
@@ -497,6 +497,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
@@ -521,6 +542,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
@@ -196,7 +196,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Output($limit: Int = 10, $offset: Int = 0) {\nOutput(limit: $limit, offset: $offset) {\nkey_col\nint_col\n}\n\n}",
+            "queryName" : "Output",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Output{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -209,16 +218,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Output($limit: Int = 10, $offset: Int = 0) {\nOutput(limit: $limit, offset: $offset) {\nkey_col\nint_col\n}\n\n}",
-            "queryName" : "Output",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Output{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
@@ -196,6 +196,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "key_col" : {
+                  "type" : "string"
+                },
+                "int_col" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Output($limit: Int = 10, $offset: Int = 0) {\nOutput(limit: $limit, offset: $offset) {\nkey_col\nint_col\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
@@ -353,6 +353,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuid" : {
+                  "type" : "string"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "epoch_timestamp" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
@@ -377,6 +401,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
@@ -353,7 +353,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -376,16 +385,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -403,7 +403,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SensorTempByHour($limit: Int = 10, $offset: Int = 0) {\nSensorTempByHour(limit: $limit, offset: $offset) {\nsensorid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "SensorTempByHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorTempByHour{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -420,16 +429,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SensorTempByHour($limit: Int = 10, $offset: Int = 0) {\nSensorTempByHour(limit: $limit, offset: $offset) {\nsensorid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "SensorTempByHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorTempByHour{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
@@ -606,6 +606,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuid" : {
+                  "type" : "string"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "epoch_timestamp" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
@@ -632,6 +656,33 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuid" : {
+                  "type" : "string"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "epoch_timestamp" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "testField" : {
+                  "type" : "number"
+                },
+                "recordedTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReadingInput($limit: Int = 10, $offset: Int = 0) {\nSensorReadingInput(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
@@ -656,6 +707,33 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuid" : {
+                  "type" : "string"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "epoch_timestamp" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "testField" : {
+                  "type" : "number"
+                },
+                "recordedTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -696,6 +774,30 @@ END
                 "epoch_timestamp",
                 "temperature"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "uuid" : {
+                "type" : "string"
+              },
+              "sensorid" : {
+                "type" : "integer"
+              },
+              "epoch_timestamp" : {
+                "type" : "integer"
+              },
+              "temperature" : {
+                "type" : "number"
+              },
+              "testField" : {
+                "type" : "number"
+              },
+              "recordedTime" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
@@ -606,7 +606,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -629,16 +638,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntimestamp\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -656,7 +656,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SensorReadingInput($limit: Int = 10, $offset: Int = 0) {\nSensorReadingInput(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
+            "queryName" : "SensorReadingInput",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReadingInput{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -682,16 +691,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SensorReadingInput($limit: Int = 10, $offset: Int = 0) {\nSensorReadingInput(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
-            "queryName" : "SensorReadingInput",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReadingInput{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -709,7 +709,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SensorReadingMutation($limit: Int = 10, $offset: Int = 0) {\nSensorReadingMutation(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
+            "queryName" : "SensorReadingMutation",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReadingMutation{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -735,16 +744,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SensorReadingMutation($limit: Int = 10, $offset: Int = 0) {\nSensorReadingMutation(limit: $limit, offset: $offset) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
-            "queryName" : "SensorReadingMutation",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReadingMutation{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -776,7 +776,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation SensorReadingMutation($uuid: String!, $sensorid: Long!, $epoch_timestamp: Long!, $temperature: Float!, $testField: Float) {\nSensorReadingMutation(event: { uuid: $uuid, sensorid: $sensorid, epoch_timestamp: $epoch_timestamp, temperature: $temperature, testField: $testField }) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
+            "queryName" : "SensorReadingMutation",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SensorReadingMutation",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "uuid" : {
@@ -799,16 +808,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation SensorReadingMutation($uuid: String!, $sensorid: Long!, $epoch_timestamp: Long!, $temperature: Float!, $testField: Float) {\nSensorReadingMutation(event: { uuid: $uuid, sensorid: $sensorid, epoch_timestamp: $epoch_timestamp, temperature: $temperature, testField: $testField }) {\nuuid\nsensorid\nepoch_timestamp\ntemperature\ntestField\nrecordedTime\n}\n\n}",
-            "queryName" : "SensorReadingMutation",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SensorReadingMutation"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
@@ -390,6 +390,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -416,6 +454,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "num_special_orders" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SpecialOrderSummary($limit: Int = 10, $offset: Int = 0) {\nSpecialOrderSummary(limit: $limit, offset: $offset) {\ncustomerid\nnum_special_orders\n}\n\n}",
@@ -440,6 +492,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "num_special_orders" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
@@ -390,7 +390,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -427,16 +436,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -454,7 +454,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SpecialOrderSummary($limit: Int = 10, $offset: Int = 0) {\nSpecialOrderSummary(limit: $limit, offset: $offset) {\ncustomerid\nnum_special_orders\n}\n\n}",
+            "queryName" : "SpecialOrderSummary",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SpecialOrderSummary{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -467,16 +476,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SpecialOrderSummary($limit: Int = 10, $offset: Int = 0) {\nSpecialOrderSummary(limit: $limit, offset: $offset) {\ncustomerid\nnum_special_orders\n}\n\n}",
-            "queryName" : "SpecialOrderSummary",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SpecialOrderSummary{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -494,7 +494,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SpecialOrderSummaryDatabase($limit: Int = 10, $offset: Int = 0) {\nSpecialOrderSummaryDatabase(limit: $limit, offset: $offset) {\ncustomerid\nnum_special_orders\n}\n\n}",
+            "queryName" : "SpecialOrderSummaryDatabase",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SpecialOrderSummaryDatabase{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -507,16 +516,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SpecialOrderSummaryDatabase($limit: Int = 10, $offset: Int = 0) {\nSpecialOrderSummaryDatabase(limit: $limit, offset: $offset) {\ncustomerid\nnum_special_orders\n}\n\n}",
-            "queryName" : "SpecialOrderSummaryDatabase",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SpecialOrderSummaryDatabase{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
@@ -275,7 +275,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderEntryJoin($limit: Int = 10, $offset: Int = 0) {\nOrderEntryJoin(limit: $limit, offset: $offset) {\nid1\nid2\nmulti\n}\n\n}",
+            "queryName" : "OrderEntryJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderEntryJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -291,16 +300,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderEntryJoin($limit: Int = 10, $offset: Int = 0) {\nOrderEntryJoin(limit: $limit, offset: $offset) {\nid1\nid2\nmulti\n}\n\n}",
-            "queryName" : "OrderEntryJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderEntryJoin{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
@@ -275,6 +275,23 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id1" : {
+                  "type" : "integer"
+                },
+                "id2" : {
+                  "type" : "integer"
+                },
+                "multi" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderEntryJoin($limit: Int = 10, $offset: Int = 0) {\nOrderEntryJoin(limit: $limit, offset: $offset) {\nid1\nid2\nmulti\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
@@ -167,7 +167,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomer_id\ncustomer {\nname\nprofile {\nemail\n}\n}\n}\n\n}",
+            "queryName" : "NestedCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/NestedCustomers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -193,16 +202,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomer_id\ncustomer {\nname\nprofile {\nemail\n}\n}\n}\n\n}",
-            "queryName" : "NestedCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/NestedCustomers{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
@@ -167,6 +167,33 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "profile" : {
+                      "type" : "object",
+                      "properties" : {
+                        "email" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomer_id\ncustomer {\nname\nprofile {\nemail\n}\n}\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
@@ -482,7 +482,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -505,16 +514,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -532,7 +532,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomerid\nendOfMin\ntotal\n}\n\n}",
+            "queryName" : "CustomerUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerUpdates{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -549,16 +558,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomerid\nendOfMin\ntotal\n}\n\n}",
-            "queryName" : "CustomerUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerUpdates{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -576,7 +576,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerUpdates(limit: $limit, offset: $offset) {\ncustomerid\nendOfMin\ntotal\n}\n\n}",
+            "queryName" : "DistinctCustomerUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomerUpdates{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -593,16 +602,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerUpdates(limit: $limit, offset: $offset) {\ncustomerid\nendOfMin\ntotal\n}\n\n}",
-            "queryName" : "DistinctCustomerUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomerUpdates{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
@@ -482,6 +482,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -508,6 +532,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "endOfMin" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomerid\nendOfMin\ntotal\n}\n\n}",
@@ -532,6 +574,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "endOfMin" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
@@ -1427,6 +1427,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1451,6 +1475,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1479,6 +1527,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1503,6 +1575,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1531,6 +1627,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1555,6 +1675,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1583,6 +1727,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByUpdated($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdated(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1609,6 +1777,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByUpdatedAsc($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdatedAsc(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1633,6 +1825,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
@@ -1427,7 +1427,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1450,16 +1459,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1477,7 +1477,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByMultiple($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultiple(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByMultiple",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByMultiple{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1500,16 +1509,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByMultiple($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultiple(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByMultiple",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByMultiple{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1527,7 +1527,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByMultipleTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1550,16 +1559,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByMultipleTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1577,7 +1577,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTime{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1600,16 +1609,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1627,7 +1627,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByTime2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1650,16 +1659,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTime2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1677,7 +1677,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTimeAsc($limit: Int = 10, $offset: Int = 0) {\nCustomerByTimeAsc(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByTimeAsc",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTimeAsc{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1700,16 +1709,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTimeAsc($limit: Int = 10, $offset: Int = 0) {\nCustomerByTimeAsc(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTimeAsc",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTimeAsc{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1727,7 +1727,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByUpdated($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdated(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByUpdated",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByUpdated{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1750,16 +1759,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByUpdated($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdated(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByUpdated",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByUpdated{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1777,7 +1777,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByUpdatedAsc($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdatedAsc(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByUpdatedAsc",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByUpdatedAsc{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1800,16 +1809,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByUpdatedAsc($limit: Int = 10, $offset: Int = 0) {\nCustomerByUpdatedAsc(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByUpdatedAsc",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByUpdatedAsc{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1827,7 +1827,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
+            "queryName" : "ExplicitDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1844,16 +1853,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
-            "queryName" : "ExplicitDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
@@ -401,7 +401,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query JoinTable($limit: Int = 10, $offset: Int = 0) {\nJoinTable(limit: $limit, offset: $offset) {\nuserid\nevent_time\nunique_id\nunique_id0\n}\n\n}",
+            "queryName" : "JoinTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/JoinTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -421,16 +430,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query JoinTable($limit: Int = 10, $offset: Int = 0) {\nJoinTable(limit: $limit, offset: $offset) {\nuserid\nevent_time\nunique_id\nunique_id0\n}\n\n}",
-            "queryName" : "JoinTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/JoinTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -445,7 +445,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation SimpleInput($userid: Int) {\nSimpleInput(event: { userid: $userid }) {\nuserid\nevent_time\n}\n\n}",
+            "queryName" : "SimpleInput",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SimpleInput",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "userid" : {
@@ -456,16 +465,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation SimpleInput($userid: Int) {\nSimpleInput(event: { userid: $userid }) {\nuserid\nevent_time\n}\n\n}",
-            "queryName" : "SimpleInput",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SimpleInput"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
@@ -401,6 +401,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "userid" : {
+                  "type" : "integer"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "unique_id" : {
+                  "type" : "string"
+                },
+                "unique_id0" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query JoinTable($limit: Int = 10, $offset: Int = 0) {\nJoinTable(limit: $limit, offset: $offset) {\nuserid\nevent_time\nunique_id\nunique_id0\n}\n\n}",
@@ -422,6 +443,18 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "userid" : {
+                "type" : "integer"
+              },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
@@ -908,7 +908,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -931,16 +940,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -958,7 +958,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerSubset($limit: Int = 10, $offset: Int = 0) {\nCustomerSubset(limit: $limit, offset: $offset) {\ncustomerid\nname\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerSubset",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerSubset{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -975,16 +984,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerSubset($limit: Int = 10, $offset: Int = 0) {\nCustomerSubset(limit: $limit, offset: $offset) {\ncustomerid\nname\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerSubset",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerSubset{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1002,7 +1002,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "DistinctCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1025,16 +1034,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "DistinctCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1052,7 +1052,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
+            "queryName" : "JoinStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/JoinStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1065,16 +1074,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
-            "queryName" : "JoinStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/JoinStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1092,7 +1092,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1129,16 +1138,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1156,7 +1156,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation CustomerExport($customerid: Long, $name: String) {\nCustomerExport(event: { customerid: $customerid, name: $name }) {\ncustomerid\nname\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerExport",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/CustomerExport",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "customerid" : {
@@ -1170,16 +1179,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation CustomerExport($customerid: Long, $name: String) {\nCustomerExport(event: { customerid: $customerid, name: $name }) {\ncustomerid\nname\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerExport",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/CustomerExport"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
@@ -908,6 +908,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -932,6 +956,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -960,6 +1002,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -984,6 +1050,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1012,6 +1092,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -1036,6 +1154,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "customerid" : {
+                "type" : "integer"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "timestamp" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
@@ -891,7 +891,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "Customer",
@@ -899,7 +898,32 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -917,7 +941,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerSubset($limit: Int = 10, $offset: Int = 0) {\nCustomerSubset(limit: $limit, offset: $offset) {\ncustomerid\nname\ntimestamp\n}\n\n}",
             "queryName" : "CustomerSubset",
@@ -925,7 +948,26 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerSubset{?offset,limit}"
+          "uriTemplate" : "queries/CustomerSubset{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -943,7 +985,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "DistinctCustomer",
@@ -951,7 +992,32 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}"
+          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -969,7 +1035,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
             "queryName" : "JoinStream",
@@ -977,7 +1042,22 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/JoinStream{?offset,limit}"
+          "uriTemplate" : "queries/JoinStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -995,7 +1075,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
             "queryName" : "Orders",
@@ -1003,7 +1082,46 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
@@ -876,6 +876,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -900,6 +924,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -928,6 +970,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -954,6 +1020,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
@@ -978,6 +1058,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
@@ -876,7 +876,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -899,16 +908,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -926,7 +926,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerSubset($limit: Int = 10, $offset: Int = 0) {\nCustomerSubset(limit: $limit, offset: $offset) {\ncustomerid\nname\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerSubset",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerSubset{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -943,16 +952,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerSubset($limit: Int = 10, $offset: Int = 0) {\nCustomerSubset(limit: $limit, offset: $offset) {\ncustomerid\nname\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerSubset",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerSubset{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -970,7 +970,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "DistinctCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -993,16 +1002,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "DistinctCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1020,7 +1020,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
+            "queryName" : "JoinStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/JoinStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1033,16 +1042,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query JoinStream($limit: Int = 10, $offset: Int = 0) {\nJoinStream(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
-            "queryName" : "JoinStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/JoinStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1060,7 +1060,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1097,16 +1106,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
@@ -996,7 +996,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1015,16 +1024,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1042,7 +1042,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomerWoutTs($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerWoutTs(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
+            "queryName" : "DistinctCustomerWoutTs",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomerWoutTs{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1061,16 +1070,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomerWoutTs($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomerWoutTs(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
-            "queryName" : "DistinctCustomerWoutTs",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomerWoutTs{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1088,7 +1088,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctOrderFieldsWoutTs($limit: Int = 10, $offset: Int = 0) {\nDistinctOrderFieldsWoutTs(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
+            "queryName" : "DistinctOrderFieldsWoutTs",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctOrderFieldsWoutTs{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1105,16 +1114,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctOrderFieldsWoutTs($limit: Int = 10, $offset: Int = 0) {\nDistinctOrderFieldsWoutTs(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
-            "queryName" : "DistinctOrderFieldsWoutTs",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctOrderFieldsWoutTs{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1132,7 +1132,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctOrderWithTs($limit: Int = 10, $offset: Int = 0) {\nDistinctOrderWithTs(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "DistinctOrderWithTs",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctOrderWithTs{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1169,16 +1178,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctOrderWithTs($limit: Int = 10, $offset: Int = 0) {\nDistinctOrderWithTs(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "DistinctOrderWithTs",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctOrderWithTs{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1196,7 +1196,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderFields($limit: Int = 10, $offset: Int = 0) {\nOrderFields(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
+            "queryName" : "OrderFields",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderFields{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1213,16 +1222,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderFields($limit: Int = 10, $offset: Int = 0) {\nOrderFields(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
-            "queryName" : "OrderFields",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderFields{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1240,7 +1240,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1277,16 +1286,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
@@ -996,6 +996,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
@@ -1020,6 +1040,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1048,6 +1088,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctOrderFieldsWoutTs($limit: Int = 10, $offset: Int = 0) {\nDistinctOrderFieldsWoutTs(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
@@ -1072,6 +1130,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1100,6 +1196,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderFields($limit: Int = 10, $offset: Int = 0) {\nOrderFields(limit: $limit, offset: $offset) {\nid\ntime\ncustomerid\n}\n\n}",
@@ -1124,6 +1238,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
@@ -467,6 +467,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -493,6 +517,25 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "unique_email_count" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerHighCount($limit: Int = 10, $offset: Int = 0) {\nCustomerHighCount(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
@@ -517,6 +560,25 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "unique_email_count" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
@@ -467,7 +467,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -490,16 +499,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -517,7 +517,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerHighCount($limit: Int = 10, $offset: Int = 0) {\nCustomerHighCount(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
+            "queryName" : "CustomerHighCount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerHighCount{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -535,16 +544,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerHighCount($limit: Int = 10, $offset: Int = 0) {\nCustomerHighCount(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
-            "queryName" : "CustomerHighCount",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerHighCount{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -562,7 +562,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
+            "queryName" : "CustomerTimeWindow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -580,16 +589,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
-            "queryName" : "CustomerTimeWindow",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
@@ -612,6 +612,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -636,6 +660,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -669,6 +707,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -698,6 +760,20 @@ END
               "required" : [
                 "name"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
@@ -612,7 +612,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -635,16 +644,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -662,7 +662,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerVectorEmbed($limit: Int = 10, $offset: Int = 0) {\nCustomerVectorEmbed(limit: $limit, offset: $offset) {\ncustomerid\nname\n}\n\n}",
+            "queryName" : "CustomerVectorEmbed",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerVectorEmbed{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -675,16 +684,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerVectorEmbed($limit: Int = 10, $offset: Int = 0) {\nCustomerVectorEmbed(limit: $limit, offset: $offset) {\ncustomerid\nname\n}\n\n}",
-            "queryName" : "CustomerVectorEmbed",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerVectorEmbed{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -707,7 +707,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomersByName",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersByName{?offset,limit,inputName}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -730,16 +739,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomersByName",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersByName{?offset,limit,inputName}"
+          }
         },
         {
           "function" : {
@@ -762,7 +762,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomersByVector($name: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByVector(name: $name, limit: $limit, offset: $offset) {\ncustomerid\nname\n}\n\n}",
+            "queryName" : "CustomersByVector",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersByVector{?offset,name,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -775,16 +784,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomersByVector($name: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByVector(name: $name, limit: $limit, offset: $offset) {\ncustomerid\nname\n}\n\n}",
-            "queryName" : "CustomersByVector",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersByVector{?offset,name,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
@@ -465,6 +465,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -494,6 +518,30 @@ END
               "required" : [
                 "fromTime"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
@@ -465,7 +465,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -488,16 +497,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -520,7 +520,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomersByTime($fromTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByTime(fromTime: $fromTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomersByTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersByTime{?offset,fromTime,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -543,16 +552,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomersByTime($fromTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByTime(fromTime: $fromTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomersByTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersByTime{?offset,fromTime,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
@@ -521,7 +521,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -544,16 +553,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -579,7 +579,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByEmail($email: String!, $id: Long, $limit: Int = 10, $offset: Int = 0) {\nCustomerByEmail(email: $email, id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByEmail",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByEmail{?offset,limit,id,email}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -602,16 +611,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByEmail($email: String!, $id: Long, $limit: Int = 10, $offset: Int = 0) {\nCustomerByEmail(email: $email, id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByEmail",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByEmail{?offset,limit,id,email}"
+          }
         },
         {
           "function" : {
@@ -637,7 +637,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByIds($ids: [Long]!, $limit: Int = 100, $offset: Int = 0) {\nCustomerByIds(ids: $ids, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByIds",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByIds{?offset,limit,ids}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -660,16 +669,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByIds($ids: [Long]!, $limit: Int = 100, $offset: Int = 0) {\nCustomerByIds(ids: $ids, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByIds",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByIds{?offset,limit,ids}"
+          }
         },
         {
           "function" : {
@@ -696,7 +696,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomersByTime($customerid: Long!, $fromTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByTime(customerid: $customerid, fromTime: $fromTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomersByTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersByTime{?offset,customerid,fromTime,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -719,16 +728,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomersByTime($customerid: Long!, $fromTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByTime(customerid: $customerid, fromTime: $fromTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomersByTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersByTime{?offset,customerid,fromTime,limit}"
+          }
         },
         {
           "function" : {
@@ -749,7 +749,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectCustomer($id: Long, $limit: Int = 10, $offset: Int = 0) {\nSelectCustomer(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "SelectCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectCustomer{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -772,16 +781,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectCustomer($id: Long, $limit: Int = 10, $offset: Int = 0) {\nSelectCustomer(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "SelectCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectCustomer{?offset,limit,id}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
@@ -521,6 +521,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -555,6 +579,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByEmail($email: String!, $id: Long, $limit: Int = 10, $offset: Int = 0) {\nCustomerByEmail(email: $email, id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -587,6 +635,30 @@ END
               "required" : [
                 "ids"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -624,6 +696,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersByTime($customerid: Long!, $fromTime: DateTime!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByTime(customerid: $customerid, fromTime: $fromTime, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -651,6 +747,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
@@ -329,7 +329,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nsearchResult\nformat\n}\n\n}",
+            "queryName" : "FunctionCalls",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FunctionCalls{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -342,16 +351,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nsearchResult\nformat\n}\n\n}",
-            "queryName" : "FunctionCalls",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FunctionCalls{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -369,7 +369,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -388,16 +397,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
@@ -329,6 +329,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "searchResult" : {
+                  "type" : "number"
+                },
+                "format" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nsearchResult\nformat\n}\n\n}",
@@ -353,6 +367,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
@@ -597,6 +597,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -623,6 +647,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -647,6 +695,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
@@ -597,7 +597,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "AnotherCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -620,16 +629,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "AnotherCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -647,7 +647,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -670,16 +679,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -697,7 +697,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FinalCustomer($limit: Int = 10, $offset: Int = 0) {\nFinalCustomer(limit: $limit, offset: $offset) {\ncustomerid\nlastUpdated\n}\n\n}",
+            "queryName" : "FinalCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FinalCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -710,16 +719,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FinalCustomer($limit: Int = 10, $offset: Int = 0) {\nFinalCustomer(limit: $limit, offset: $offset) {\ncustomerid\nlastUpdated\n}\n\n}",
-            "queryName" : "FinalCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FinalCustomer{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
@@ -572,7 +572,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -609,16 +618,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -636,7 +636,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectOrders1($limit: Int = 10, $offset: Int = 0) {\nSelectOrders1(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "SelectOrders1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectOrders1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -673,16 +682,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectOrders1($limit: Int = 10, $offset: Int = 0) {\nSelectOrders1(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "SelectOrders1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectOrders1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -700,7 +700,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectOrders2($limit: Int = 10, $offset: Int = 0) {\nSelectOrders2(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "SelectOrders2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectOrders2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -737,16 +746,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectOrders2($limit: Int = 10, $offset: Int = 0) {\nSelectOrders2(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "SelectOrders2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectOrders2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -769,7 +769,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrdersById1($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById1(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrdersById1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrdersById1{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -806,16 +815,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrdersById1($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById1(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrdersById1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrdersById1{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -838,7 +838,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrdersById2($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById2(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrdersById2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrdersById2{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -875,16 +884,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrdersById2($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById2(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrdersById2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrdersById2{?offset,limit,id}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
@@ -572,6 +572,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -598,6 +636,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SelectOrders1($limit: Int = 10, $offset: Int = 0) {\nSelectOrders1(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -622,6 +698,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -655,6 +769,44 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrdersById1($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById1(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -684,6 +836,44 @@ END
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
@@ -340,6 +340,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "categoryid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "updateTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
@@ -364,6 +385,27 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "categoryid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "updateTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
@@ -340,7 +340,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
+            "queryName" : "Category",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Category{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -360,16 +369,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
-            "queryName" : "Category",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Category{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -387,7 +387,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CategoryDistinct($limit: Int = 10, $offset: Int = 0) {\nCategoryDistinct(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
+            "queryName" : "CategoryDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CategoryDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -407,16 +416,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CategoryDistinct($limit: Int = 10, $offset: Int = 0) {\nCategoryDistinct(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
-            "queryName" : "CategoryDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CategoryDistinct{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
@@ -417,7 +417,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerAggregate1($limit: Int = 10, $offset: Int = 0) {\nCustomerAggregate1(limit: $limit, offset: $offset) {\ncustomerid\nupdates\n}\n\n}",
+            "queryName" : "CustomerAggregate1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerAggregate1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -430,16 +439,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerAggregate1($limit: Int = 10, $offset: Int = 0) {\nCustomerAggregate1(limit: $limit, offset: $offset) {\ncustomerid\nupdates\n}\n\n}",
-            "queryName" : "CustomerAggregate1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerAggregate1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -457,7 +457,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerAggregate2($limit: Int = 10, $offset: Int = 0) {\nCustomerAggregate2(limit: $limit, offset: $offset) {\ncustomerid\nupdates\n}\n\n}",
+            "queryName" : "CustomerAggregate2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerAggregate2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -470,16 +479,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerAggregate2($limit: Int = 10, $offset: Int = 0) {\nCustomerAggregate2(limit: $limit, offset: $offset) {\ncustomerid\nupdates\n}\n\n}",
-            "queryName" : "CustomerAggregate2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerAggregate2{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
@@ -417,6 +417,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "updates" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerAggregate1($limit: Int = 10, $offset: Int = 0) {\nCustomerAggregate1(limit: $limit, offset: $offset) {\ncustomerid\nupdates\n}\n\n}",
@@ -441,6 +455,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "updates" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
@@ -555,7 +555,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -575,16 +584,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -602,7 +602,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "MachineTempByHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -619,16 +628,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "MachineTempByHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -651,7 +651,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineTempHourlyById($machineid: Int!, $limit: Int = 10, $offset: Int = 0) {\nMachineTempHourlyById(machineid: $machineid, limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "MachineTempHourlyById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineTempHourlyById{?machineid,offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -668,16 +677,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineTempHourlyById($machineid: Int!, $limit: Int = 10, $offset: Int = 0) {\nMachineTempHourlyById(machineid: $machineid, limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "MachineTempHourlyById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineTempHourlyById{?machineid,offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
@@ -555,6 +555,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
@@ -579,6 +600,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -610,6 +649,24 @@ END
               "required" : [
                 "machineid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
@@ -787,7 +787,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
+            "queryName" : "Category",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Category{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -807,16 +816,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
-            "queryName" : "Category",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Category{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -834,7 +834,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -857,16 +866,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -884,7 +884,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerOther($limit: Int = 10, $offset: Int = 0) {\nCustomerOther(limit: $limit, offset: $offset) {\ncustomer_id\nfull_name\nlast_updated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerOther",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerOther{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -904,16 +913,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerOther($limit: Int = 10, $offset: Int = 0) {\nCustomerOther(limit: $limit, offset: $offset) {\ncustomer_id\nfull_name\nlast_updated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerOther",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerOther{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -936,7 +936,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProduct(productid: $productid, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?productid,offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -955,16 +964,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProduct(productid: $productid, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?productid,offset,limit}"
+          }
         },
         {
           "function" : {
@@ -979,7 +979,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation MyEvents($payload: String) {\nMyEvents(event: { payload: $payload }) {\nid\npayload\ntimestamp\n}\n\n}",
+            "queryName" : "MyEvents",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/MyEvents",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "id" : {
@@ -993,16 +1002,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation MyEvents($payload: String) {\nMyEvents(event: { payload: $payload }) {\nid\npayload\ntimestamp\n}\n\n}",
-            "queryName" : "MyEvents",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/MyEvents"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
@@ -787,6 +787,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "categoryid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "updateTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Category($limit: Int = 10, $offset: Int = 0) {\nCategory(limit: $limit, offset: $offset) {\ncategoryid\nname\ndescription\nupdateTime\n}\n\n}",
@@ -813,6 +834,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -837,6 +882,27 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "full_name" : {
+                  "type" : "string"
+                },
+                "last_updated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -870,6 +936,26 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Product($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProduct(productid: $productid, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
@@ -891,6 +977,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "string"
+              },
+              "payload" : {
+                "type" : "string"
+              },
+              "timestamp" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
@@ -239,7 +239,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerInternal($limit: Int = 10, $offset: Int = 0) {\nCustomerInternal(limit: $limit, offset: $offset) {\ncustomer_id\nfull_name\ntimestamp\n}\n\n}",
             "queryName" : "CustomerInternal",
@@ -247,7 +246,26 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerInternal{?offset,limit}"
+          "uriTemplate" : "queries/CustomerInternal{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "full_name" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -267,7 +285,6 @@ END
               ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation CustomerInternal($customer_id: Long!, $full_name: String) {\nCustomerInternal(event: { customer_id: $customer_id, full_name: $full_name }) {\ncustomer_id\nfull_name\ntimestamp\n}\n\n}",
             "queryName" : "CustomerInternal",
@@ -275,7 +292,23 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "POST",
-          "uriTemplate" : "mutations/CustomerInternal"
+          "uriTemplate" : "mutations/CustomerInternal",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "object",
+            "properties" : {
+              "customer_id" : {
+                "type" : "integer"
+              },
+              "full_name" : {
+                "type" : "string"
+              },
+              "timestamp" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
+            }
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
@@ -196,6 +196,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
@@ -196,7 +196,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -233,16 +242,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -793,7 +793,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyOrdersIndexBtree($limit: Int = 10, $offset: Int = 0) {\nMyOrdersIndexBtree(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "MyOrdersIndexBtree",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyOrdersIndexBtree{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -830,16 +839,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyOrdersIndexBtree($limit: Int = 10, $offset: Int = 0) {\nMyOrdersIndexBtree(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "MyOrdersIndexBtree",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyOrdersIndexBtree{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -857,7 +857,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyOrdersIndexHash($limit: Int = 10, $offset: Int = 0) {\nMyOrdersIndexHash(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "MyOrdersIndexHash",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyOrdersIndexHash{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -894,16 +903,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyOrdersIndexHash($limit: Int = 10, $offset: Int = 0) {\nMyOrdersIndexHash(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "MyOrdersIndexHash",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyOrdersIndexHash{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -921,7 +921,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyOrdersNoHint($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoHint(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "MyOrdersNoHint",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyOrdersNoHint{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -958,16 +967,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyOrdersNoHint($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoHint(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "MyOrdersNoHint",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyOrdersNoHint{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -985,7 +985,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyOrdersNoIndex($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoIndex(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "MyOrdersNoIndex",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyOrdersNoIndex{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1022,16 +1031,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyOrdersNoIndex($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoIndex(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "MyOrdersNoIndex",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyOrdersNoIndex{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1049,7 +1049,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyOrdersTwoIndex($limit: Int = 10, $offset: Int = 0) {\nMyOrdersTwoIndex(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "MyOrdersTwoIndex",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyOrdersTwoIndex{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1086,16 +1095,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyOrdersTwoIndex($limit: Int = 10, $offset: Int = 0) {\nMyOrdersTwoIndex(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "MyOrdersTwoIndex",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyOrdersTwoIndex{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -793,6 +793,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyOrdersIndexBtree($limit: Int = 10, $offset: Int = 0) {\nMyOrdersIndexBtree(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -817,6 +855,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -845,6 +921,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyOrdersNoHint($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoHint(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -871,6 +985,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyOrdersNoIndex($limit: Int = 10, $offset: Int = 0) {\nMyOrdersNoIndex(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -895,6 +1047,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
@@ -779,7 +779,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?orders_limit,offset,limit,orders_offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -840,16 +849,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?orders_limit,offset,limit,orders_offset}"
+          }
         },
         {
           "function" : {
@@ -876,7 +876,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrders(time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,customerid,limit,time}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -913,16 +922,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrders(time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,customerid,limit,time}"
+          }
         },
         {
           "function" : {
@@ -952,7 +952,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($name: String, $description: String, $category: String, $_ingest_time: DateTime, $limit: Int = 10, $offset: Int = 0) {\nProduct(name: $name, description: $description, category: $category, _ingest_time: $_ingest_time, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,name,limit,description,category,_ingest_time}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -971,16 +980,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($name: String, $description: String, $category: String, $_ingest_time: DateTime, $limit: Int = 10, $offset: Int = 0) {\nProduct(name: $name, description: $description, category: $category, _ingest_time: $_ingest_time, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,name,limit,description,category,_ingest_time}"
+          }
         },
         {
           "function" : {
@@ -1003,7 +1003,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrdersById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrdersById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrdersById{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1040,16 +1049,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrdersById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersById(id: $id, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrdersById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrdersById{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -1076,7 +1076,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrdersByTime($time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersByTime(time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrdersByTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrdersByTime{?offset,customerid,limit,time}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1113,16 +1122,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrdersByTime($time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrdersByTime(time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrdersByTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrdersByTime{?offset,customerid,limit,time}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
@@ -779,6 +779,68 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "orders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "entries" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "quantity" : {
+                              "type" : "integer"
+                            },
+                            "unit_price" : {
+                              "type" : "number"
+                            },
+                            "discount" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n}\n\n}",
@@ -812,6 +874,44 @@ END
                 "time",
                 "customerid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -852,6 +952,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Product($name: String, $description: String, $category: String, $_ingest_time: DateTime, $limit: Int = 10, $offset: Int = 0) {\nProduct(name: $name, description: $description, category: $category, _ingest_time: $_ingest_time, limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
@@ -881,6 +1001,44 @@ END
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -916,6 +1074,44 @@ END
                 "time",
                 "customerid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -253,6 +253,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -253,7 +253,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -276,16 +285,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -553,7 +553,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -576,16 +585,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -603,7 +603,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerCount($limit: Int = 10, $offset: Int = 0) {\nCustomerCount(limit: $limit, offset: $offset) {\ncustomerid\nnumEntries\n}\n\n}",
+            "queryName" : "CustomerCount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerCount{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -616,16 +625,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerCount($limit: Int = 10, $offset: Int = 0) {\nCustomerCount(limit: $limit, offset: $offset) {\ncustomerid\nnumEntries\n}\n\n}",
-            "queryName" : "CustomerCount",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerCount{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -643,7 +643,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerForApi($limit: Int = 10, $offset: Int = 0) {\nCustomerForApi(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerForApi",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerForApi{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -666,16 +675,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerForApi($limit: Int = 10, $offset: Int = 0) {\nCustomerForApi(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerForApi",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerForApi{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -695,7 +695,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation CustomerCount($customerid: Long!, $numEntries: Long) {\nCustomerCount(event: { customerid: $customerid, numEntries: $numEntries }) {\ncustomerid\nnumEntries\n}\n\n}",
+            "queryName" : "CustomerCount",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/CustomerCount",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "customerid" : {
@@ -705,16 +714,7 @@ END
                 "type" : "integer"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation CustomerCount($customerid: Long!, $numEntries: Long) {\nCustomerCount(event: { customerid: $customerid, numEntries: $numEntries }) {\ncustomerid\nnumEntries\n}\n\n}",
-            "queryName" : "CustomerCount",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/CustomerCount"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -553,6 +553,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -577,6 +601,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "numEntries" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -605,6 +643,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerForApi($limit: Int = 10, $offset: Int = 0) {\nCustomerForApi(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -631,6 +693,17 @@ END
               "required" : [
                 "customerid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "customerid" : {
+                "type" : "integer"
+              },
+              "numEntries" : {
+                "type" : "integer"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
@@ -521,6 +521,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
@@ -545,6 +565,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -573,6 +607,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ntimestamp\n}\n\n}",
@@ -597,6 +649,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
@@ -521,7 +521,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -540,16 +549,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -567,7 +567,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer1($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer1(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
+            "queryName" : "OrderCustomer1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -580,16 +589,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer1($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer1(limit: $limit, offset: $offset) {\nid\nname\n}\n\n}",
-            "queryName" : "OrderCustomer1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -607,7 +607,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ntimestamp\n}\n\n}",
+            "queryName" : "OrderCustomer2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -624,16 +633,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ntimestamp\n}\n\n}",
-            "queryName" : "OrderCustomer2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -651,7 +651,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -688,16 +697,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
@@ -978,6 +978,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1002,6 +1026,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1030,6 +1078,15 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ObjComplex($limit: Int = 10, $offset: Int = 0) {\nObjComplex(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
@@ -1054,6 +1111,15 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "agg" : { }
+              }
             }
           },
           "format" : "JSON",
@@ -1082,6 +1148,15 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonArrayTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
@@ -1106,6 +1181,15 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
             }
           },
           "format" : "JSON",
@@ -1134,6 +1218,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
@@ -1158,6 +1253,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1186,6 +1292,15 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "agg" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonObjectAggTable($limit: Int = 10, $offset: Int = 0) {\njsonObjectAggTable(limit: $limit, offset: $offset) {\nagg\n}\n\n}",
@@ -1210,6 +1325,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1238,6 +1364,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
@@ -1262,6 +1399,15 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
@@ -978,7 +978,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1001,16 +1010,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1028,7 +1028,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerStream($limit: Int = 10, $offset: Int = 0) {\nCustomerStream(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1051,16 +1060,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerStream($limit: Int = 10, $offset: Int = 0) {\nCustomerStream(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1078,16 +1078,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "obj" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ObjComplex($limit: Int = 10, $offset: Int = 0) {\nObjComplex(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
             "queryName" : "ObjComplex",
@@ -1095,7 +1085,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/ObjComplex{?offset,limit}"
+          "uriTemplate" : "queries/ObjComplex{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -1113,16 +1113,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "agg" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonArrayAggTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayAggTable(limit: $limit, offset: $offset) {\nagg\n}\n\n}",
             "queryName" : "jsonArrayAggTable",
@@ -1130,7 +1120,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonArrayAggTable{?offset,limit}"
+          "uriTemplate" : "queries/jsonArrayAggTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "agg" : { }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -1148,16 +1148,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "obj" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonArrayTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
             "queryName" : "jsonArrayTable",
@@ -1165,7 +1155,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonArrayTable{?offset,limit}"
+          "uriTemplate" : "queries/jsonArrayTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -1183,16 +1183,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "obj" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonConcatTable($limit: Int = 10, $offset: Int = 0) {\njsonConcatTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
             "queryName" : "jsonConcatTable",
@@ -1200,7 +1190,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonConcatTable{?offset,limit}"
+          "uriTemplate" : "queries/jsonConcatTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -1218,7 +1218,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
+            "queryName" : "jsonExistsTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonExistsTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1228,16 +1237,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
-            "queryName" : "jsonExistsTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonExistsTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1255,7 +1255,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonExtractTable($limit: Int = 10, $offset: Int = 0) {\njsonExtractTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
+            "queryName" : "jsonExtractTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonExtractTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1265,16 +1274,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonExtractTable($limit: Int = 10, $offset: Int = 0) {\njsonExtractTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
-            "queryName" : "jsonExtractTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonExtractTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1292,16 +1292,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "agg" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonObjectAggTable($limit: Int = 10, $offset: Int = 0) {\njsonObjectAggTable(limit: $limit, offset: $offset) {\nagg\n}\n\n}",
             "queryName" : "jsonObjectAggTable",
@@ -1309,7 +1299,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonObjectAggTable{?offset,limit}"
+          "uriTemplate" : "queries/jsonObjectAggTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "agg" : { }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -1327,7 +1327,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonQueryTable($limit: Int = 10, $offset: Int = 0) {\njsonQueryTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
+            "queryName" : "jsonQueryTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonQueryTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1337,16 +1346,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonQueryTable($limit: Int = 10, $offset: Int = 0) {\njsonQueryTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
-            "queryName" : "jsonQueryTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonQueryTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1364,7 +1364,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
+            "queryName" : "jsonToStringTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonToStringTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1374,16 +1383,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
-            "queryName" : "jsonToStringTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonToStringTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1401,16 +1401,6 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "obj" : { }
-              }
-            }
-          },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query toJsonTable($limit: Int = 10, $offset: Int = 0) {\ntoJsonTable(limit: $limit, offset: $offset) {\nobj\n}\n\n}",
             "queryName" : "toJsonTable",
@@ -1418,7 +1408,17 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/toJsonTable{?offset,limit}"
+          "uriTemplate" : "queries/toJsonTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "obj" : { }
+              }
+            }
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
@@ -1456,7 +1456,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1479,16 +1488,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1506,7 +1506,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerStream($limit: Int = 10, $offset: Int = 0) {\nCustomerStream(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1529,16 +1538,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerStream($limit: Int = 10, $offset: Int = 0) {\nCustomerStream(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1556,7 +1556,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ObjComplex($limit: Int = 10, $offset: Int = 0) {\nObjComplex(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "ObjComplex",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ObjComplex{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1567,16 +1576,7 @@ END
                 "obj" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ObjComplex($limit: Int = 10, $offset: Int = 0) {\nObjComplex(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "ObjComplex",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ObjComplex{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1594,7 +1594,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonArrayAggTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayAggTable(limit: $limit, offset: $offset) {\nname\nagg\n}\n\n}",
+            "queryName" : "jsonArrayAggTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonArrayAggTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1605,16 +1614,7 @@ END
                 "agg" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonArrayAggTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayAggTable(limit: $limit, offset: $offset) {\nname\nagg\n}\n\n}",
-            "queryName" : "jsonArrayAggTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonArrayAggTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1632,7 +1632,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonArrayTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonArrayTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonArrayTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1643,16 +1652,7 @@ END
                 "obj" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonArrayTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonArrayTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonArrayTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1670,7 +1670,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonConcatTable($limit: Int = 10, $offset: Int = 0) {\njsonConcatTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonConcatTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonConcatTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1681,16 +1690,7 @@ END
                 "obj" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonConcatTable($limit: Int = 10, $offset: Int = 0) {\njsonConcatTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonConcatTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonConcatTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1708,7 +1708,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonExistsTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonExistsTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1721,16 +1730,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonExistsTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonExistsTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1748,7 +1748,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonExtractTable($limit: Int = 10, $offset: Int = 0) {\njsonExtractTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonExtractTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonExtractTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1761,16 +1770,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonExtractTable($limit: Int = 10, $offset: Int = 0) {\njsonExtractTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonExtractTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonExtractTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1788,7 +1788,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonObjectAggTable($limit: Int = 10, $offset: Int = 0) {\njsonObjectAggTable(limit: $limit, offset: $offset) {\nname\nagg\n}\n\n}",
+            "queryName" : "jsonObjectAggTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonObjectAggTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1799,16 +1808,7 @@ END
                 "agg" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonObjectAggTable($limit: Int = 10, $offset: Int = 0) {\njsonObjectAggTable(limit: $limit, offset: $offset) {\nname\nagg\n}\n\n}",
-            "queryName" : "jsonObjectAggTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonObjectAggTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1826,7 +1826,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonQueryTable($limit: Int = 10, $offset: Int = 0) {\njsonQueryTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonQueryTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonQueryTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1839,16 +1848,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonQueryTable($limit: Int = 10, $offset: Int = 0) {\njsonQueryTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonQueryTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonQueryTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1866,7 +1866,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "jsonToStringTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/jsonToStringTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1879,16 +1888,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "jsonToStringTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/jsonToStringTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1906,7 +1906,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query toJsonTable($limit: Int = 10, $offset: Int = 0) {\ntoJsonTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
+            "queryName" : "toJsonTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/toJsonTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1917,16 +1926,7 @@ END
                 "obj" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query toJsonTable($limit: Int = 10, $offset: Int = 0) {\ntoJsonTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
-            "queryName" : "toJsonTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/toJsonTable{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
@@ -1456,6 +1456,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1480,6 +1504,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1508,6 +1556,18 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ObjComplex($limit: Int = 10, $offset: Int = 0) {\nObjComplex(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
@@ -1532,6 +1592,18 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "agg" : { }
+              }
             }
           },
           "format" : "JSON",
@@ -1560,6 +1632,18 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonArrayTable($limit: Int = 10, $offset: Int = 0) {\njsonArrayTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
@@ -1584,6 +1668,18 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : { }
+              }
             }
           },
           "format" : "JSON",
@@ -1612,6 +1708,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonExistsTable($limit: Int = 10, $offset: Int = 0) {\njsonExistsTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
@@ -1636,6 +1746,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1664,6 +1788,18 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "agg" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonObjectAggTable($limit: Int = 10, $offset: Int = 0) {\njsonObjectAggTable(limit: $limit, offset: $offset) {\nname\nagg\n}\n\n}",
@@ -1688,6 +1824,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1716,6 +1866,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query jsonToStringTable($limit: Int = 10, $offset: Int = 0) {\njsonToStringTable(limit: $limit, offset: $offset) {\ncustomerid\nobj\n}\n\n}",
@@ -1740,6 +1904,18 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "obj" : { }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/lateralJoinTableFunction.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/lateralJoinTableFunction.txt
@@ -331,7 +331,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "Customer",
@@ -339,7 +338,32 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
         },
         {
           "function" : {
@@ -357,7 +381,6 @@ END
               "required" : [ ]
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerEmailCopies($limit: Int = 10, $offset: Int = 0) {\nCustomerEmailCopies(limit: $limit, offset: $offset) {\ncustomerid\nemail\n}\n\n}",
             "queryName" : "CustomerEmailCopies",
@@ -365,7 +388,22 @@ END
           },
           "mcpMethod" : "TOOL",
           "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerEmailCopies{?offset,limit}"
+          "uriTemplate" : "queries/CustomerEmailCopies{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
@@ -596,6 +596,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
@@ -622,6 +643,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
@@ -646,6 +685,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "updatedTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -685,6 +742,24 @@ END
               "required" : [
                 "event"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "updatedTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
@@ -596,7 +596,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -616,16 +625,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -643,7 +643,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "MachineTempByHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -660,16 +669,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "MachineTempByHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -687,7 +687,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nsensorid\nmachineid\nupdatedTime\n}\n\n}",
+            "queryName" : "Sensors",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Sensors{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -704,16 +713,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nsensorid\nmachineid\nupdatedTime\n}\n\n}",
-            "queryName" : "Sensors",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Sensors{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -744,7 +744,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation Sensors($event: [SensorsInput!]!) {\nSensors(event: $event) {\nsensorid\nmachineid\nupdatedTime\n}\n\n}",
+            "queryName" : "Sensors",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "NONE",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/Sensors",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -761,16 +770,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation Sensors($event: [SensorsInput!]!) {\nSensors(event: $event) {\nsensorid\nmachineid\nupdatedTime\n}\n\n}",
-            "queryName" : "Sensors",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "NONE",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/Sensors"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
@@ -508,7 +508,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerData($limit: Int = 10, $offset: Int = 0) {\nCustomerData(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\n}\n\n}",
+            "queryName" : "CustomerData",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerData{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -532,16 +541,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerData($limit: Int = 10, $offset: Int = 0) {\nCustomerData(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\n}\n\n}",
-            "queryName" : "CustomerData",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerData{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -559,7 +559,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\nupdatedTime\n}\n\n}",
+            "queryName" : "NestedCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/NestedCustomers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -587,16 +596,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\nupdatedTime\n}\n\n}",
-            "queryName" : "NestedCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/NestedCustomers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -614,7 +614,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -651,16 +660,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -692,7 +692,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation NestedCustomers($customerid: Int!, $payload: NestedCustomers_payloadInput) {\nNestedCustomers(event: { customerid: $customerid, payload: $payload }) {\ncustomerid\npayload {\na\nb\nc\n}\nupdatedTime\n}\n\n}",
+            "queryName" : "NestedCustomers",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "NONE",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/NestedCustomers",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "customerid" : {
@@ -717,16 +726,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation NestedCustomers($customerid: Int!, $payload: NestedCustomers_payloadInput) {\nNestedCustomers(event: { customerid: $customerid, payload: $payload }) {\ncustomerid\npayload {\na\nb\nc\n}\nupdatedTime\n}\n\n}",
-            "queryName" : "NestedCustomers",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "NONE",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/NestedCustomers"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
@@ -508,6 +508,31 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "payload" : {
+                  "type" : "object",
+                  "properties" : {
+                    "a" : {
+                      "type" : "integer"
+                    },
+                    "b" : {
+                      "type" : "integer"
+                    },
+                    "c" : {
+                      "type" : "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerData($limit: Int = 10, $offset: Int = 0) {\nCustomerData(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\n}\n\n}",
@@ -534,6 +559,35 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "payload" : {
+                  "type" : "object",
+                  "properties" : {
+                    "a" : {
+                      "type" : "integer"
+                    },
+                    "b" : {
+                      "type" : "integer"
+                    },
+                    "c" : {
+                      "type" : "integer"
+                    }
+                  }
+                },
+                "updatedTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query NestedCustomers($limit: Int = 10, $offset: Int = 0) {\nNestedCustomers(limit: $limit, offset: $offset) {\ncustomerid\npayload {\na\nb\nc\n}\nupdatedTime\n}\n\n}",
@@ -558,6 +612,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -598,6 +690,32 @@ END
               "required" : [
                 "customerid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "customerid" : {
+                "type" : "integer"
+              },
+              "payload" : {
+                "type" : "object",
+                "properties" : {
+                  "a" : {
+                    "type" : "integer"
+                  },
+                  "b" : {
+                    "type" : "integer"
+                  },
+                  "c" : {
+                    "type" : "integer"
+                  }
+                }
+              },
+              "updatedTime" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
@@ -313,7 +313,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\nprice\nsaving\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?totals_limit,offset,totals_offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -367,16 +376,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\nprice\nsaving\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?totals_limit,offset,totals_offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
@@ -313,6 +313,61 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "totals" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "price" : {
+                        "type" : "number"
+                      },
+                      "saving" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\nprice\nsaving\n}\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
@@ -1310,6 +1310,72 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "largeOrders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "orderid" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "orderTime" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                },
+                "orders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "orderid" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "orderTime" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
@@ -1334,6 +1400,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1362,6 +1452,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orderid" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "orderTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query LargeOrders($limit: Int = 10, $offset: Int = 0) {\nLargeOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
@@ -1386,6 +1497,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1414,6 +1563,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orderid" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "orderTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SimpleOrders($limit: Int = 10, $offset: Int = 0) {\nSimpleOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
@@ -1438,6 +1608,33 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "discount" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1487,6 +1684,72 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "largeOrders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "orderid" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "orderTime" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                },
+                "orders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "orderid" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "orderTime" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerById($customerid: Long!, $limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomerById(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
@@ -1514,6 +1777,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "orderid" : {
+                "type" : "integer"
+              },
+              "customerid" : {
+                "type" : "integer"
+              },
+              "amount" : {
+                "type" : "number"
+              },
+              "orderTime" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
@@ -1310,7 +1310,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?largeOrders_limit,orders_limit,offset,largeOrders_offset,limit,largeOrders_minAmount,orders_offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1375,16 +1384,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?largeOrders_limit,orders_limit,offset,largeOrders_offset,limit,largeOrders_minAmount,orders_offset}"
+          }
         },
         {
           "function" : {
@@ -1402,7 +1402,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerImport($limit: Int = 10, $offset: Int = 0) {\nCustomerImport(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerImport",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerImport{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1425,16 +1434,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerImport($limit: Int = 10, $offset: Int = 0) {\nCustomerImport(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerImport",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerImport{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1452,7 +1452,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query LargeOrders($limit: Int = 10, $offset: Int = 0) {\nLargeOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
+            "queryName" : "LargeOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/LargeOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1472,16 +1481,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query LargeOrders($limit: Int = 10, $offset: Int = 0) {\nLargeOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
-            "queryName" : "LargeOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/LargeOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1499,7 +1499,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1536,16 +1545,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1563,7 +1563,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SimpleOrders($limit: Int = 10, $offset: Int = 0) {\nSimpleOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
+            "queryName" : "SimpleOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SimpleOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1583,16 +1592,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SimpleOrders($limit: Int = 10, $offset: Int = 0) {\nSimpleOrders(limit: $limit, offset: $offset) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
-            "queryName" : "SimpleOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SimpleOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1610,7 +1610,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\n}\n\n}",
+            "queryName" : "UnnestOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/UnnestOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1636,16 +1645,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\n}\n\n}",
-            "queryName" : "UnnestOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/UnnestOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1684,7 +1684,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerById($customerid: Long!, $limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomerById(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
+            "queryName" : "CustomerById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerById{?largeOrders_limit,orders_limit,offset,largeOrders_offset,customerid,limit,largeOrders_minAmount,orders_offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1749,16 +1758,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerById($customerid: Long!, $limit: Int = 10, $offset: Int = 0$largeOrders_minAmount: Float!, $largeOrders_limit: Int = 10, $largeOrders_offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0) {\nCustomerById(customerid: $customerid, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\nlargeOrders(minAmount: $largeOrders_minAmount, limit: $largeOrders_limit, offset: $largeOrders_offset) {\norderid\ncustomerid\namount\norderTime\n}\norders(limit: $orders_limit, offset: $orders_offset) {\norderid\ncustomerid\namount\norderTime\n}\n}\n\n}",
-            "queryName" : "CustomerById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerById{?largeOrders_limit,orders_limit,offset,largeOrders_offset,customerid,limit,largeOrders_minAmount,orders_offset}"
+          }
         },
         {
           "function" : {
@@ -1779,7 +1779,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation SimpleOrders($orderid: Int, $customerid: Long, $amount: Float) {\nSimpleOrders(event: { orderid: $orderid, customerid: $customerid, amount: $amount }) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
+            "queryName" : "SimpleOrders",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SimpleOrders",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "orderid" : {
@@ -1796,16 +1805,7 @@ END
                 "format" : "date-time"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation SimpleOrders($orderid: Int, $customerid: Long, $amount: Float) {\nSimpleOrders(event: { orderid: $orderid, customerid: $customerid, amount: $amount }) {\norderid\ncustomerid\namount\norderTime\n}\n\n}",
-            "queryName" : "SimpleOrders",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SimpleOrders"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -514,7 +514,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderMetrics($limit: Int = 10, $offset: Int = 0) {\nOrderMetrics(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrderMetrics",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderMetrics{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -551,16 +560,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderMetrics($limit: Int = 10, $offset: Int = 0) {\nOrderMetrics(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrderMetrics",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderMetrics{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -578,7 +578,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderUpdates($limit: Int = 10, $offset: Int = 0) {\nOrderUpdates(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "OrderUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderUpdates{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -615,16 +624,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderUpdates($limit: Int = 10, $offset: Int = 0) {\nOrderUpdates(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "OrderUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderUpdates{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -642,7 +642,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -679,16 +688,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -514,6 +514,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderMetrics($limit: Int = 10, $offset: Int = 0) {\nOrderMetrics(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -540,6 +578,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderUpdates($limit: Int = 10, $offset: Int = 0) {\nOrderUpdates(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -564,6 +640,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
@@ -410,7 +410,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "FilteredOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FilteredOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -447,16 +456,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "FilteredOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FilteredOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -474,7 +474,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -511,16 +520,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -543,7 +543,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query PassThroughFunction($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nPassThroughFunction(customerid: $customerid, limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "PassThroughFunction",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/PassThroughFunction{?offset,customerid,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -553,16 +562,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query PassThroughFunction($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nPassThroughFunction(customerid: $customerid, limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "PassThroughFunction",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/PassThroughFunction{?offset,customerid,limit}"
+          }
         },
         {
           "function" : {
@@ -580,7 +580,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query PassThroughTable($limit: Int = 10, $offset: Int = 0) {\nPassThroughTable(limit: $limit, offset: $offset) {\nid\nupdateTime\n}\n\n}",
+            "queryName" : "PassThroughTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/PassThroughTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -594,16 +603,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query PassThroughTable($limit: Int = 10, $offset: Int = 0) {\nPassThroughTable(limit: $limit, offset: $offset) {\nid\nupdateTime\n}\n\n}",
-            "queryName" : "PassThroughTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/PassThroughTable{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
@@ -410,6 +410,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -434,6 +472,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -467,6 +543,17 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query PassThroughFunction($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nPassThroughFunction(customerid: $customerid, limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -491,6 +578,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "updateTime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
@@ -204,6 +204,18 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "attrs" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DuckDbTable($limit: Int = 10, $offset: Int = 0) {\nDuckDbTable(limit: $limit, offset: $offset) {\nuser_id\nattrs\n}\n\n}",
@@ -228,6 +240,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "num" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
@@ -204,7 +204,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DuckDbTable($limit: Int = 10, $offset: Int = 0) {\nDuckDbTable(limit: $limit, offset: $offset) {\nuser_id\nattrs\n}\n\n}",
+            "queryName" : "DuckDbTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DuckDbTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -215,16 +224,7 @@ END
                 "attrs" : { }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DuckDbTable($limit: Int = 10, $offset: Int = 0) {\nDuckDbTable(limit: $limit, offset: $offset) {\nuser_id\nattrs\n}\n\n}",
-            "queryName" : "DuckDbTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DuckDbTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -242,7 +242,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nnum\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -252,16 +261,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nnum\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
@@ -589,6 +589,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
@@ -615,6 +635,56 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid0" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerOrdersJoin($limit: Int = 10, $offset: Int = 0) {\nCustomerOrdersJoin(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\nid\ncustomerid0\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -639,6 +709,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
@@ -589,7 +589,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -608,16 +617,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -635,7 +635,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerOrdersJoin($limit: Int = 10, $offset: Int = 0) {\nCustomerOrdersJoin(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\nid\ncustomerid0\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "CustomerOrdersJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerOrdersJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -684,16 +693,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerOrdersJoin($limit: Int = 10, $offset: Int = 0) {\nCustomerOrdersJoin(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\nid\ncustomerid0\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "CustomerOrdersJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerOrdersJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -711,7 +711,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -748,16 +757,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
@@ -482,6 +482,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -515,6 +553,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -554,6 +630,44 @@ END
                 "time",
                 "customerid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
@@ -482,7 +482,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -519,16 +528,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -555,7 +555,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders1($id: Long, $time: DateTime, $customerid: Long, $limit: Int = 10, $offset: Int = 0) {\nOrders1(id: $id, time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders1{?offset,customerid,limit,id,time}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -592,16 +601,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders1($id: Long, $time: DateTime, $customerid: Long, $limit: Int = 10, $offset: Int = 0) {\nOrders1(id: $id, time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders1{?offset,customerid,limit,id,time}"
+          }
         },
         {
           "function" : {
@@ -632,7 +632,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders2($id: Long!, $time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrders2(id: $id, time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders2{?offset,customerid,limit,id,time}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -669,16 +678,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders2($id: Long!, $time: DateTime!, $customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nOrders2(id: $id, time: $time, customerid: $customerid, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders2{?offset,customerid,limit,id,time}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
@@ -551,6 +551,79 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "orders" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "entries" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "quantity" : {
+                              "type" : "integer"
+                            },
+                            "unit_price" : {
+                              "type" : "number"
+                            },
+                            "discount" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "orders2" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
@@ -575,6 +648,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -608,6 +719,17 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query rootFunction($i: Int!, $limit: Int = 10, $offset: Int = 0) {\nrootFunction(i: $i, limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -637,6 +759,44 @@ END
               "required" : [
                 "i"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
@@ -551,7 +551,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?orders_limit,orders2_offset,offset,limit,orders2_limit,orders_offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -623,16 +632,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?orders_limit,orders2_offset,offset,limit,orders2_limit,orders_offset}"
+          }
         },
         {
           "function" : {
@@ -650,7 +650,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -687,16 +696,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -719,7 +719,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query rootFunction($i: Int!, $limit: Int = 10, $offset: Int = 0) {\nrootFunction(i: $i, limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "rootFunction",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/rootFunction{?offset,limit,i}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -729,16 +738,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query rootFunction($i: Int!, $limit: Int = 10, $offset: Int = 0) {\nrootFunction(i: $i, limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "rootFunction",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/rootFunction{?offset,limit,i}"
+          }
         },
         {
           "function" : {
@@ -761,7 +761,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query rootFunctionWithBaseTable($i: Int!, $limit: Int = 10, $offset: Int = 0) {\nrootFunctionWithBaseTable(i: $i, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "rootFunctionWithBaseTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/rootFunctionWithBaseTable{?offset,limit,i}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -798,16 +807,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query rootFunctionWithBaseTable($i: Int!, $limit: Int = 10, $offset: Int = 0) {\nrootFunctionWithBaseTable(i: $i, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "rootFunctionWithBaseTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/rootFunctionWithBaseTable{?offset,limit,i}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
@@ -445,6 +445,80 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "orders" : {
+                  "type" : "array",
+                  "description" : "These are the orders for a customer",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "entries" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "quantity" : {
+                              "type" : "integer"
+                            },
+                            "unit_price" : {
+                              "type" : "number"
+                            },
+                            "discount" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "orders2" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
@@ -469,6 +543,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
@@ -445,7 +445,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?orders_limit,orders2_offset,offset,limit,orders2_limit,orders_offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -518,16 +527,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0$orders_limit: Int = 10, $orders_offset: Int = 0$orders2_limit: Int = 10, $orders2_offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\norders(limit: $orders_limit, offset: $orders_offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\norders2(limit: $orders2_limit, offset: $orders2_offset) {\nid\n}\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?orders_limit,orders2_offset,offset,limit,orders2_limit,orders_offset}"
+          }
         },
         {
           "function" : {
@@ -545,7 +545,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -582,16 +591,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
@@ -387,6 +387,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Order($limit: Int = 10, $offset: Int = 0) {\nOrder(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -411,6 +449,47 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "select" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
@@ -387,7 +387,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Order($limit: Int = 10, $offset: Int = 0) {\nOrder(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Order",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Order{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -424,16 +433,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Order($limit: Int = 10, $offset: Int = 0) {\nOrder(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Order",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Order{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -451,7 +451,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Where($limit: Int = 10, $offset: Int = 0) {\nWhere(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\nselect\n}\n\n}",
+            "queryName" : "Where",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Where{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -491,16 +500,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Where($limit: Int = 10, $offset: Int = 0) {\nWhere(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\nselect\n}\n\n}",
-            "queryName" : "Where",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Where{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
@@ -297,6 +297,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -321,6 +359,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
@@ -297,7 +297,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -334,16 +343,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -361,7 +361,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ProductId($limit: Int = 10, $offset: Int = 0) {\nProductId(limit: $limit, offset: $offset) {\nproductid\n}\n\n}",
+            "queryName" : "ProductId",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductId{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -371,16 +380,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ProductId($limit: Int = 10, $offset: Int = 0) {\nProductId(limit: $limit, offset: $offset) {\nproductid\n}\n\n}",
-            "queryName" : "ProductId",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductId{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
@@ -252,7 +252,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyTimestamp\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -266,16 +275,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyTimestamp\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -293,7 +293,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nval\nmyTimestamp\n}\n\n}",
+            "queryName" : "MyTable2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -307,16 +316,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nval\nmyTimestamp\n}\n\n}",
-            "queryName" : "MyTable2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable2{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
@@ -252,6 +252,21 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                },
+                "myTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyTimestamp\n}\n\n}",
@@ -276,6 +291,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                },
+                "myTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
@@ -1792,7 +1792,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "Numbers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Numbers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1802,16 +1811,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "Numbers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Numbers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1829,7 +1829,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Numbers2($limit: Int = 10, $offset: Int = 0) {\nNumbers2(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "Numbers2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Numbers2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1839,16 +1848,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Numbers2($limit: Int = 10, $offset: Int = 0) {\nNumbers2(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "Numbers2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Numbers2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1866,7 +1866,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query NumbersLarge($limit: Int = 10, $offset: Int = 0) {\nNumbersLarge(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "NumbersLarge",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/NumbersLarge{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1876,16 +1885,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query NumbersLarge($limit: Int = 10, $offset: Int = 0) {\nNumbersLarge(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "NumbersLarge",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/NumbersLarge{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1903,7 +1903,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderNumbers($limit: Int = 10, $offset: Int = 0) {\nOrderNumbers(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
+            "queryName" : "OrderNumbers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderNumbers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1917,16 +1926,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderNumbers($limit: Int = 10, $offset: Int = 0) {\nOrderNumbers(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
-            "queryName" : "OrderNumbers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderNumbers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1944,7 +1944,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderNumbers2($limit: Int = 10, $offset: Int = 0) {\nOrderNumbers2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
+            "queryName" : "OrderNumbers2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderNumbers2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1958,16 +1967,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderNumbers2($limit: Int = 10, $offset: Int = 0) {\nOrderNumbers2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
-            "queryName" : "OrderNumbers2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderNumbers2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1985,7 +1985,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderPairs($limit: Int = 10, $offset: Int = 0) {\nOrderPairs(limit: $limit, offset: $offset) {\nid\ntime\notherid\n}\n\n}",
+            "queryName" : "OrderPairs",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderPairs{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2002,16 +2011,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderPairs($limit: Int = 10, $offset: Int = 0) {\nOrderPairs(limit: $limit, offset: $offset) {\nid\ntime\notherid\n}\n\n}",
-            "queryName" : "OrderPairs",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderPairs{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2029,7 +2029,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderPairs2($limit: Int = 10, $offset: Int = 0) {\nOrderPairs2(limit: $limit, offset: $offset) {\nid\ntime\npk\n}\n\n}",
+            "queryName" : "OrderPairs2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderPairs2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2046,16 +2055,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderPairs2($limit: Int = 10, $offset: Int = 0) {\nOrderPairs2(limit: $limit, offset: $offset) {\nid\ntime\npk\n}\n\n}",
-            "queryName" : "OrderPairs2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderPairs2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2073,7 +2073,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2110,16 +2119,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
@@ -1792,6 +1792,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -1816,6 +1827,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1844,6 +1866,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query NumbersLarge($limit: Int = 10, $offset: Int = 0) {\nNumbersLarge(limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -1868,6 +1901,21 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1896,6 +1944,21 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderNumbers2($limit: Int = 10, $offset: Int = 0) {\nOrderNumbers2(limit: $limit, offset: $offset) {\nid\ntime\n}\n\n}",
@@ -1920,6 +1983,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "otherid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1948,6 +2029,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "pk" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderPairs2($limit: Int = 10, $offset: Int = 0) {\nOrderPairs2(limit: $limit, offset: $offset) {\nid\ntime\npk\n}\n\n}",
@@ -1972,6 +2071,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
@@ -406,6 +406,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer" : {
+                  "type" : "integer"
+                },
+                "order_count" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomer\norder_count\n}\n\n}",
@@ -432,6 +446,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "order_count" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderAgg2($limit: Int = 10, $offset: Int = 0) {\nOrderAgg2(limit: $limit, offset: $offset) {\norder_count\n}\n\n}",
@@ -456,6 +481,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
@@ -406,7 +406,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomer\norder_count\n}\n\n}",
+            "queryName" : "OrderAgg1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -419,16 +428,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg1($limit: Int = 10, $offset: Int = 0) {\nOrderAgg1(limit: $limit, offset: $offset) {\ncustomer\norder_count\n}\n\n}",
-            "queryName" : "OrderAgg1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -446,7 +446,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderAgg2($limit: Int = 10, $offset: Int = 0) {\nOrderAgg2(limit: $limit, offset: $offset) {\norder_count\n}\n\n}",
+            "queryName" : "OrderAgg2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderAgg2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -456,16 +465,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderAgg2($limit: Int = 10, $offset: Int = 0) {\nOrderAgg2(limit: $limit, offset: $offset) {\norder_count\n}\n\n}",
-            "queryName" : "OrderAgg2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderAgg2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -483,7 +483,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -520,16 +529,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
@@ -947,7 +947,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -970,16 +979,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -997,7 +997,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExcludedOrders($limit: Int = 10, $offset: Int = 0) {\nExcludedOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
+            "queryName" : "ExcludedOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExcludedOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1014,16 +1023,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExcludedOrders($limit: Int = 10, $offset: Int = 0) {\nExcludedOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
-            "queryName" : "ExcludedOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExcludedOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1041,7 +1041,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
+            "queryName" : "FilteredOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FilteredOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1058,16 +1067,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
-            "queryName" : "FilteredOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FilteredOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1085,7 +1085,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query FilteredOrdersByProduct($limit: Int = 10, $offset: Int = 0) {\nFilteredOrdersByProduct(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
+            "queryName" : "FilteredOrdersByProduct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FilteredOrdersByProduct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1102,16 +1111,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query FilteredOrdersByProduct($limit: Int = 10, $offset: Int = 0) {\nFilteredOrdersByProduct(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
-            "queryName" : "FilteredOrdersByProduct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FilteredOrdersByProduct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1129,7 +1129,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1166,16 +1175,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1193,7 +1193,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1212,16 +1221,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nproductid\nname\ndescription\ncategory\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
@@ -947,6 +947,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -971,6 +995,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -999,6 +1041,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query FilteredOrders($limit: Int = 10, $offset: Int = 0) {\nFilteredOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\n}\n\n}",
@@ -1023,6 +1083,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1051,6 +1129,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -1075,6 +1191,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
@@ -814,7 +814,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -837,16 +846,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -864,7 +864,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerWithOrders($limit: Int = 10, $offset: Int = 0) {\nCustomerWithOrders(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerWithOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerWithOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -887,16 +896,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerWithOrders($limit: Int = 10, $offset: Int = 0) {\nCustomerWithOrders(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerWithOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerWithOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -914,7 +914,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -951,16 +960,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -987,7 +987,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query AdminOrderCustomers($customerId: Long!, $hasOrders: Boolean!, $limit: Int = 10, $offset: Int = 0) {\nAdminOrderCustomers(customerId: $customerId, hasOrders: $hasOrders, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "AdminOrderCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AdminOrderCustomers{?offset,customerId,limit,hasOrders}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1010,16 +1019,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query AdminOrderCustomers($customerId: Long!, $hasOrders: Boolean!, $limit: Int = 10, $offset: Int = 0) {\nAdminOrderCustomers(customerId: $customerId, hasOrders: $hasOrders, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "AdminOrderCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AdminOrderCustomers{?offset,customerId,limit,hasOrders}"
+          }
         },
         {
           "function" : {
@@ -1042,7 +1042,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerOrderCount($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerOrderCount(customerid: $customerid, limit: $limit, offset: $offset) {\nname\nnum_orders\n}\n\n}",
+            "queryName" : "CustomerOrderCount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerOrderCount{?offset,customerid,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1055,16 +1064,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerOrderCount($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerOrderCount(customerid: $customerid, limit: $limit, offset: $offset) {\nname\nnum_orders\n}\n\n}",
-            "queryName" : "CustomerOrderCount",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerOrderCount{?offset,customerid,limit}"
+          }
         },
         {
           "function" : {
@@ -1087,7 +1087,16 @@ END
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SimilarOrders($name: String!, $limit: Int = 10, $offset: Int = 0) {\nSimilarOrders(name: $name, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\nsimilarity\n}\n\n}",
+            "queryName" : "SimilarOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SimilarOrders{?offset,name,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1127,16 +1136,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SimilarOrders($name: String!, $limit: Int = 10, $offset: Int = 0) {\nSimilarOrders(name: $name, limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\nsimilarity\n}\n\n}",
-            "queryName" : "SimilarOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SimilarOrders{?offset,name,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
@@ -814,6 +814,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -840,6 +864,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerWithOrders($limit: Int = 10, $offset: Int = 0) {\nCustomerWithOrders(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -864,6 +912,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -901,6 +987,30 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AdminOrderCustomers($customerId: Long!, $hasOrders: Boolean!, $limit: Int = 10, $offset: Int = 0) {\nAdminOrderCustomers(customerId: $customerId, hasOrders: $hasOrders, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -932,6 +1042,20 @@ END
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "num_orders" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerOrderCount($customerid: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerOrderCount(customerid: $customerid, limit: $limit, offset: $offset) {\nname\nnum_orders\n}\n\n}",
@@ -961,6 +1085,47 @@ END
               "required" : [
                 "name"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "similarity" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
@@ -758,6 +758,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -782,6 +806,23 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -810,6 +851,23 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
@@ -836,6 +894,23 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomer3($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer3(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
@@ -860,6 +935,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
@@ -758,7 +758,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -781,16 +790,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -808,7 +808,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer1($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer1(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomer1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -824,16 +833,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer1($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer1(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomer1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -851,7 +851,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomer2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -867,16 +876,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer2($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer2(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomer2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -894,7 +894,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer3($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer3(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomer3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer3{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -910,16 +919,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer3($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer3(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomer3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer3{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -937,7 +937,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -974,16 +983,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
@@ -767,6 +767,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineIntervalJoin($limit: Int = 10, $offset: Int = 0) {\nMachineIntervalJoin(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
@@ -791,6 +812,27 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -819,6 +861,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machineid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
@@ -843,6 +906,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineid" : {
+                  "type" : "integer"
+                },
+                "time_hour" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
@@ -767,7 +767,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineIntervalJoin($limit: Int = 10, $offset: Int = 0) {\nMachineIntervalJoin(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineIntervalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineIntervalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -787,16 +796,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineIntervalJoin($limit: Int = 10, $offset: Int = 0) {\nMachineIntervalJoin(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineIntervalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineIntervalJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -814,7 +814,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineIntervalJoinLimit($limit: Int = 10, $offset: Int = 0) {\nMachineIntervalJoinLimit(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineIntervalJoinLimit",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineIntervalJoinLimit{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -834,16 +843,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineIntervalJoinLimit($limit: Int = 10, $offset: Int = 0) {\nMachineIntervalJoinLimit(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineIntervalJoinLimit",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineIntervalJoinLimit{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -861,7 +861,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
+            "queryName" : "MachineReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineReading{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -881,16 +890,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineReading($limit: Int = 10, $offset: Int = 0) {\nMachineReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\nmachineid\n}\n\n}",
-            "queryName" : "MachineReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -908,7 +908,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
+            "queryName" : "MachineTempByHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -925,16 +934,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MachineTempByHour($limit: Int = 10, $offset: Int = 0) {\nMachineTempByHour(limit: $limit, offset: $offset) {\nmachineid\ntime_hour\navg_temperature\n}\n\n}",
-            "queryName" : "MachineTempByHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineTempByHour{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
@@ -1258,7 +1258,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1281,16 +1290,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1308,7 +1308,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1328,16 +1337,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1355,7 +1355,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerConstant",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerConstant{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1375,16 +1384,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerConstant",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerConstant{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1402,7 +1402,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerLeft($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeft(limit: $limit, offset: $offset) {\nlastUpdated\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerLeft",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerLeft{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1421,16 +1430,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerLeft($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeft(limit: $limit, offset: $offset) {\nlastUpdated\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerLeft",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerLeft{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1448,7 +1448,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerLeftExcluded",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerLeftExcluded{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1465,16 +1474,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerLeftExcluded",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerLeftExcluded{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1492,7 +1492,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerRight($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRight(limit: $limit, offset: $offset) {\nouuid\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerRight",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerRight{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1511,16 +1520,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerRight($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRight(limit: $limit, offset: $offset) {\nouuid\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerRight",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerRight{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1538,7 +1538,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerRightExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRightExcluded(limit: $limit, offset: $offset) {\nlastUpdated\ncustomerid\nname\n}\n\n}",
+            "queryName" : "OrderCustomerRightExcluded",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerRightExcluded{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1554,16 +1563,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerRightExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRightExcluded(limit: $limit, offset: $offset) {\nlastUpdated\ncustomerid\nname\n}\n\n}",
-            "queryName" : "OrderCustomerRightExcluded",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerRightExcluded{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1581,7 +1581,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1618,16 +1627,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
@@ -1258,6 +1258,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1282,6 +1306,27 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1310,6 +1355,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
@@ -1334,6 +1400,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1362,6 +1448,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
@@ -1386,6 +1490,26 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "ouuid" : {
+                  "type" : "integer"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1414,6 +1538,23 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerRightExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRightExcluded(limit: $limit, offset: $offset) {\nlastUpdated\ncustomerid\nname\n}\n\n}",
@@ -1438,6 +1579,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
@@ -1137,6 +1137,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -1161,6 +1185,23 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1189,6 +1230,27 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
@@ -1213,6 +1275,29 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "cid" : {
+                  "type" : "integer"
+                },
+                "ctime" : {
+                  "type" : "integer"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1241,6 +1326,24 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
@@ -1265,6 +1368,24 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1293,6 +1414,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "ouuid" : {
+                  "type" : "integer"
+                },
+                "otime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCustomerRight($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRight(limit: $limit, offset: $offset) {\nouuid\notime\nid\nname\ncustomerid\n}\n\n}",
@@ -1317,6 +1462,23 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1345,6 +1507,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -1369,6 +1569,28 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "total" : {
+                  "type" : "integer"
+                },
+                "total_id" : {
+                  "type" : "integer"
+                },
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
@@ -1137,7 +1137,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1160,16 +1169,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1187,7 +1187,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomer($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1203,16 +1212,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomer($limit: Int = 10, $offset: Int = 0) {\nOrderCustomer(limit: $limit, offset: $offset) {\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1230,7 +1230,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerConstant",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerConstant{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1250,16 +1259,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerConstant($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerConstant(limit: $limit, offset: $offset) {\ntime\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerConstant",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerConstant{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1277,7 +1277,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerLeft($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeft(limit: $limit, offset: $offset) {\ncid\nctime\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerLeft",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerLeft{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1299,16 +1308,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerLeft($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeft(limit: $limit, offset: $offset) {\ncid\nctime\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerLeft",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerLeft{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1326,7 +1326,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerLeftExcluded",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerLeftExcluded{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1343,16 +1352,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerLeftExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcluded(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerLeftExcluded",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerLeftExcluded{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1370,7 +1370,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerLeftExcludedTimeBound($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcludedTimeBound(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerLeftExcludedTimeBound",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerLeftExcludedTimeBound{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1387,16 +1396,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerLeftExcludedTimeBound($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerLeftExcludedTimeBound(limit: $limit, offset: $offset) {\ntime\nid\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerLeftExcludedTimeBound",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerLeftExcludedTimeBound{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1414,7 +1414,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerRight($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRight(limit: $limit, offset: $offset) {\nouuid\notime\nid\nname\ncustomerid\n}\n\n}",
+            "queryName" : "OrderCustomerRight",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerRight{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1437,16 +1446,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerRight($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRight(limit: $limit, offset: $offset) {\nouuid\notime\nid\nname\ncustomerid\n}\n\n}",
-            "queryName" : "OrderCustomerRight",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerRight{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1464,7 +1464,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query OrderCustomerRightExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRightExcluded(limit: $limit, offset: $offset) {\nlastUpdated\ncustomerid\nname\n}\n\n}",
+            "queryName" : "OrderCustomerRightExcluded",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCustomerRightExcluded{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1480,16 +1489,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query OrderCustomerRightExcluded($limit: Int = 10, $offset: Int = 0) {\nOrderCustomerRightExcluded(limit: $limit, offset: $offset) {\nlastUpdated\ncustomerid\nname\n}\n\n}",
-            "queryName" : "OrderCustomerRightExcluded",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCustomerRightExcluded{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1507,7 +1507,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1544,16 +1553,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1571,7 +1571,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query VerifyStream($limit: Int = 10, $offset: Int = 0) {\nVerifyStream(limit: $limit, offset: $offset) {\ntotal\ntotal_id\nwindow_start\nwindow_end\n}\n\n}",
+            "queryName" : "VerifyStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/VerifyStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1592,16 +1601,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query VerifyStream($limit: Int = 10, $offset: Int = 0) {\nVerifyStream(limit: $limit, offset: $offset) {\ntotal\ntotal_id\nwindow_start\nwindow_end\n}\n\n}",
-            "queryName" : "VerifyStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/VerifyStream{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
@@ -956,6 +956,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -980,6 +1004,25 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1008,6 +1051,29 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerHop($limit: Int = 10, $offset: Int = 0) {\nCustomerHop(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nwindow_time\ntotal\n}\n\n}",
@@ -1032,6 +1098,32 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1060,6 +1152,25 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerTumble($limit: Int = 10, $offset: Int = 0) {\nCustomerTumble(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\ntotal\n}\n\n}",
@@ -1084,6 +1195,43 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "window_start0" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end0" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "total0" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
@@ -956,7 +956,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -979,16 +988,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1006,7 +1006,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerCumulate($limit: Int = 10, $offset: Int = 0) {\nCustomerCumulate(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\ntotal\n}\n\n}",
+            "queryName" : "CustomerCumulate",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerCumulate{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1024,16 +1033,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerCumulate($limit: Int = 10, $offset: Int = 0) {\nCustomerCumulate(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\ntotal\n}\n\n}",
-            "queryName" : "CustomerCumulate",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerCumulate{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1051,7 +1051,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerHop($limit: Int = 10, $offset: Int = 0) {\nCustomerHop(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nwindow_time\ntotal\n}\n\n}",
+            "queryName" : "CustomerHop",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerHop{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1073,16 +1082,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerHop($limit: Int = 10, $offset: Int = 0) {\nCustomerHop(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nwindow_time\ntotal\n}\n\n}",
-            "queryName" : "CustomerHop",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerHop{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1100,7 +1100,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerSession($limit: Int = 10, $offset: Int = 0) {\nCustomerSession(limit: $limit, offset: $offset) {\ncustomerid\nwindow_start\nwindow_end\nwindow_time\ntotal\n}\n\n}",
+            "queryName" : "CustomerSession",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerSession{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1125,16 +1134,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerSession($limit: Int = 10, $offset: Int = 0) {\nCustomerSession(limit: $limit, offset: $offset) {\ncustomerid\nwindow_start\nwindow_end\nwindow_time\ntotal\n}\n\n}",
-            "queryName" : "CustomerSession",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerSession{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1152,7 +1152,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerTumble($limit: Int = 10, $offset: Int = 0) {\nCustomerTumble(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\ntotal\n}\n\n}",
+            "queryName" : "CustomerTumble",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerTumble{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1170,16 +1179,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerTumble($limit: Int = 10, $offset: Int = 0) {\nCustomerTumble(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\ntotal\n}\n\n}",
-            "queryName" : "CustomerTumble",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerTumble{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1197,7 +1197,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query StreamJoin($limit: Int = 10, $offset: Int = 0) {\nStreamJoin(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nwindow_time\ntotal\ncustomerid\nwindow_start0\nwindow_end0\ntotal0\n}\n\n}",
+            "queryName" : "StreamJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/StreamJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1233,16 +1242,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query StreamJoin($limit: Int = 10, $offset: Int = 0) {\nStreamJoin(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nwindow_time\ntotal\ncustomerid\nwindow_start0\nwindow_end0\ntotal0\n}\n\n}",
-            "queryName" : "StreamJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/StreamJoin{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
@@ -725,6 +725,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -749,6 +773,30 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -777,6 +825,44 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
@@ -801,6 +887,60 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "customerid0" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
@@ -725,7 +725,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -748,16 +757,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -775,7 +775,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "DistinctCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -798,16 +807,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query DistinctCustomer($limit: Int = 10, $offset: Int = 0) {\nDistinctCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "DistinctCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -825,7 +825,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -862,16 +871,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -889,7 +889,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid0\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "TemporalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TemporalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -942,16 +951,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomerid0\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "TemporalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TemporalJoin{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
@@ -495,6 +495,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "num" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerAgg1($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg1(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
@@ -519,6 +533,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "num" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -547,6 +575,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "num" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerAgg3($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg3(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
@@ -571,6 +613,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
@@ -495,7 +495,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerAgg1($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg1(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
+            "queryName" : "CustomerAgg1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerAgg1{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -508,16 +517,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerAgg1($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg1(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
-            "queryName" : "CustomerAgg1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerAgg1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -535,7 +535,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerAgg2($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg2(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
+            "queryName" : "CustomerAgg2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerAgg2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -548,16 +557,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerAgg2($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg2(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
-            "queryName" : "CustomerAgg2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerAgg2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -575,7 +575,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerAgg3($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg3(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
+            "queryName" : "CustomerAgg3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerAgg3{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -588,16 +597,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerAgg3($limit: Int = 10, $offset: Int = 0) {\nCustomerAgg3(limit: $limit, offset: $offset) {\ncustomerid\nnum\n}\n\n}",
-            "queryName" : "CustomerAgg3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerAgg3{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -615,7 +615,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -652,16 +661,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
@@ -397,6 +397,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id_a" : {
+                  "type" : "string"
+                },
+                "val" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
@@ -423,6 +437,20 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id_a" : {
+                  "type" : "string"
+                },
+                "val" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query source_a($limit: Int = 10, $offset: Int = 0) {\nsource_a(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
@@ -447,6 +475,20 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id_b" : {
+                  "type" : "string"
+                },
+                "val" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
@@ -397,7 +397,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
+            "queryName" : "CombinedStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CombinedStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -410,16 +419,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
-            "queryName" : "CombinedStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CombinedStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -437,7 +437,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query source_a($limit: Int = 10, $offset: Int = 0) {\nsource_a(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
+            "queryName" : "source_a",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/source_a{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -450,16 +459,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query source_a($limit: Int = 10, $offset: Int = 0) {\nsource_a(limit: $limit, offset: $offset) {\nid_a\nval\n}\n\n}",
-            "queryName" : "source_a",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/source_a{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -477,7 +477,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query source_b($limit: Int = 10, $offset: Int = 0) {\nsource_b(limit: $limit, offset: $offset) {\nid_b\nval\n}\n\n}",
+            "queryName" : "source_b",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/source_b{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -490,16 +499,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query source_b($limit: Int = 10, $offset: Int = 0) {\nsource_b(limit: $limit, offset: $offset) {\nid_b\nval\n}\n\n}",
-            "queryName" : "source_b",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/source_b{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
@@ -489,6 +489,21 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "rowtime" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\ncustomerid\nrowtime\n}\n\n}",
@@ -515,6 +530,30 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -539,6 +578,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
@@ -489,7 +489,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\ncustomerid\nrowtime\n}\n\n}",
+            "queryName" : "CombinedStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CombinedStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -503,16 +512,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\ncustomerid\nrowtime\n}\n\n}",
-            "queryName" : "CombinedStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CombinedStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -530,7 +530,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -553,16 +562,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -580,7 +580,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -617,16 +626,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
@@ -588,7 +588,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CombinedState($limit: Int = 10, $offset: Int = 0) {\nCombinedState(limit: $limit, offset: $offset) {\ncustomerid\n}\n\n}",
+            "queryName" : "CombinedState",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CombinedState{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -598,16 +607,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CombinedState($limit: Int = 10, $offset: Int = 0) {\nCombinedState(limit: $limit, offset: $offset) {\ncustomerid\n}\n\n}",
-            "queryName" : "CombinedState",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CombinedState{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -625,7 +625,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\ncustomerid\n}\n\n}",
+            "queryName" : "CombinedStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CombinedStream{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -635,16 +644,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CombinedStream($limit: Int = 10, $offset: Int = 0) {\nCombinedStream(limit: $limit, offset: $offset) {\ncustomerid\n}\n\n}",
-            "queryName" : "CombinedStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CombinedStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -662,7 +662,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -681,16 +690,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -708,7 +708,16 @@ END
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -745,16 +754,7 @@ END
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
@@ -588,6 +588,17 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CombinedState($limit: Int = 10, $offset: Int = 0) {\nCombinedState(limit: $limit, offset: $offset) {\ncustomerid\n}\n\n}",
@@ -612,6 +623,17 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -640,6 +662,26 @@ END
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\n}\n\n}",
@@ -664,6 +706,44 @@ END
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-snowflake.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-snowflake.txt
@@ -188,7 +188,16 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "Numbers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Numbers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -198,16 +207,7 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "Numbers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Numbers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -225,7 +225,16 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Numbers2($limit: Int = 10, $offset: Int = 0) {\nNumbers2(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "Numbers2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Numbers2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -235,16 +244,7 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Numbers2($limit: Int = 10, $offset: Int = 0) {\nNumbers2(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "Numbers2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Numbers2{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-snowflake.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-snowflake.txt
@@ -188,6 +188,17 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Numbers($limit: Int = 10, $offset: Int = 0) {\nNumbers(limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -212,6 +223,17 @@ CREATE OR REPLACE ICEBERG TABLE Numbers2 EXTERNAL_VOLUME = 'MyNewVolume' CATALOG
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
@@ -1854,50 +1854,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Error response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "object",
-                  "properties" : {
-                    "errors" : {
                       "type" : "array",
                       "items" : {
-                        "type" : "object"
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
                       }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/rest/queries/CustomerByTime2" : {
-      "get" : {
-        "summary" : "GetCustomerByTime2",
-        "operationId" : "GetCustomerByTime2",
-        "responses" : {
-          "200" : {
-            "description" : "Successful operation",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "object",
-                  "properties" : {
-                    "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
                     }
                   }
                 }
@@ -1946,8 +1924,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -1996,8 +1994,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2232,6 +2250,30 @@ FROM "ExternalOrders"
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -2244,25 +2286,6 @@ FROM "ExternalOrders"
         },
         {
           "function" : {
-            "name" : "GetCustomerByTime2",
-            "parameters" : {
-              "type" : "object",
-              "properties" : { },
-              "required" : [ ]
-            }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime2() {\nCustomerByTime2 {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTime2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime2"
-        },
-        {
-          "function" : {
             "name" : "GetCustomerByMultipleTime",
             "parameters" : {
               "type" : "object",
@@ -2272,6 +2295,30 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -2295,6 +2342,30 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
@@ -1805,7 +1805,7 @@ FROM "ExternalOrders"
       "name" : "Apache License 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "unknown"
+    "version" : "0.11.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8888",
@@ -2250,7 +2250,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "TableFunctionCallsTblFct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2273,16 +2282,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TableFunctionCallsTblFct($arg1: Int!, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "TableFunctionCallsTblFct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}"
+          }
         },
         {
           "function" : {
@@ -2297,7 +2297,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByMultipleTime($limit: Int = 10) {\nCustomerByMultipleTime(limit: $limit) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByMultipleTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByMultipleTime{?limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2320,16 +2329,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByMultipleTime($limit: Int = 10) {\nCustomerByMultipleTime(limit: $limit) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByMultipleTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByMultipleTime{?limit}"
+          }
         },
         {
           "function" : {
@@ -2344,7 +2344,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectCustomers($offset: Int = 0) {\nSelectCustomers(offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "SelectCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectCustomers{?offset}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2367,16 +2376,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectCustomers($offset: Int = 0) {\nSelectCustomers(offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "SelectCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectCustomers{?offset}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
@@ -1842,7 +1842,69 @@ FROM "ExternalOrders"
                   "properties" : {
                     "data" : {
                       "type" : "object",
-                      "description" : "Response data"
+                      "properties" : {
+                        "results" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "customerid" : {
+                                "type" : "integer"
+                              },
+                              "email" : {
+                                "type" : "string"
+                              },
+                              "name" : {
+                                "type" : "string"
+                              },
+                              "lastUpdated" : {
+                                "type" : "integer"
+                              },
+                              "timestamp" : {
+                                "type" : "string",
+                                "format" : "date-time"
+                              }
+                            }
+                          }
+                        },
+                        "pagination" : {
+                          "type" : "object",
+                          "properties" : {
+                            "pageSize" : {
+                              "type" : "integer"
+                            },
+                            "currentPage" : {
+                              "type" : "integer"
+                            },
+                            "totalRecords" : {
+                              "type" : "integer"
+                            },
+                            "totalPages" : {
+                              "type" : "integer"
+                            },
+                            "hasNextPage" : {
+                              "type" : "boolean"
+                            },
+                            "hasPreviousPage" : {
+                              "type" : "boolean"
+                            },
+                            "nextOffset" : {
+                              "type" : "integer"
+                            },
+                            "prevOffset" : {
+                              "type" : "integer"
+                            },
+                            "firstEventTime" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "lastEventTime" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -1923,6 +1985,72 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "results" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              },
+              "pagination" : {
+                "type" : "object",
+                "properties" : {
+                  "pageSize" : {
+                    "type" : "integer"
+                  },
+                  "currentPage" : {
+                    "type" : "integer"
+                  },
+                  "totalRecords" : {
+                    "type" : "integer"
+                  },
+                  "totalPages" : {
+                    "type" : "integer"
+                  },
+                  "hasNextPage" : {
+                    "type" : "boolean"
+                  },
+                  "hasPreviousPage" : {
+                    "type" : "boolean"
+                  },
+                  "nextOffset" : {
+                    "type" : "integer"
+                  },
+                  "prevOffset" : {
+                    "type" : "integer"
+                  },
+                  "firstEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  },
+                  "lastEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
@@ -1806,7 +1806,7 @@ FROM "ExternalOrders"
       "name" : "Apache License 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "unknown"
+    "version" : "0.11.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8888",
@@ -1987,7 +1987,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\nresults {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
+            "queryName" : "CustomerByTime2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "results" : {
@@ -2052,16 +2061,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\nresults {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
-            "queryName" : "CustomerByTime2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
@@ -1807,7 +1807,7 @@ FROM "ExternalOrders"
       "name" : "Apache License 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "unknown"
+    "version" : "0.11.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8888",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
@@ -1805,7 +1805,7 @@ FROM "ExternalOrders"
       "name" : "Apache License 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "unknown"
+    "version" : "0.11.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8888",
@@ -2052,7 +2052,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TableFunctionCallsTblFct($arg2: Int!, $arg1: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg2: $arg2, arg1: $arg1, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "TableFunctionCallsTblFct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2075,16 +2084,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TableFunctionCallsTblFct($arg2: Int!, $arg1: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg2: $arg2, arg1: $arg1, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "TableFunctionCallsTblFct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
@@ -1854,8 +1854,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2030,6 +2050,30 @@ FROM "ExternalOrders"
                 "arg2",
                 "arg1"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
@@ -1840,8 +1840,21 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -1897,8 +1910,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -1954,8 +1987,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2011,8 +2064,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2068,8 +2141,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2125,8 +2218,23 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "window_start" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "window_end" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "unique_email_count" : {
+                            "type" : "integer"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2182,8 +2290,22 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2239,8 +2361,42 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "id" : {
+                            "type" : "integer"
+                          },
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "time" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "entries" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "properties" : {
+                                "productid" : {
+                                  "type" : "integer"
+                                },
+                                "quantity" : {
+                                  "type" : "integer"
+                                },
+                                "unit_price" : {
+                                  "type" : "number"
+                                },
+                                "discount" : {
+                                  "type" : "number"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2296,8 +2452,22 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "namee" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2353,8 +2523,49 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "id" : {
+                            "type" : "integer"
+                          },
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "time" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "entries" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "properties" : {
+                                "productid" : {
+                                  "type" : "integer"
+                                },
+                                "quantity" : {
+                                  "type" : "integer"
+                                },
+                                "unit_price" : {
+                                  "type" : "number"
+                                },
+                                "discount" : {
+                                  "type" : "number"
+                                }
+                              }
+                            }
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2410,8 +2621,18 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "orderid" : {
+                            "type" : "integer"
+                          },
+                          "amount" : {
+                            "type" : "number"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2468,8 +2689,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2525,8 +2766,49 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "id" : {
+                            "type" : "integer"
+                          },
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "time" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "entries" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "properties" : {
+                                "productid" : {
+                                  "type" : "integer"
+                                },
+                                "quantity" : {
+                                  "type" : "integer"
+                                },
+                                "unit_price" : {
+                                  "type" : "number"
+                                },
+                                "discount" : {
+                                  "type" : "number"
+                                }
+                              }
+                            }
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2582,8 +2864,34 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "id" : {
+                            "type" : "integer"
+                          },
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "time" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          },
+                          "productid" : {
+                            "type" : "integer"
+                          },
+                          "quantity" : {
+                            "type" : "integer"
+                          },
+                          "discount" : {
+                            "type" : "number"
+                          },
+                          "newId" : {
+                            "type" : "integer"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2646,8 +2954,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2710,8 +3038,21 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2781,8 +3122,28 @@ FROM "ExternalOrders"
                   "type" : "object",
                   "properties" : {
                     "data" : {
-                      "type" : "object",
-                      "description" : "Response data"
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "customerid" : {
+                            "type" : "integer"
+                          },
+                          "email" : {
+                            "type" : "string"
+                          },
+                          "name" : {
+                            "type" : "string"
+                          },
+                          "lastUpdated" : {
+                            "type" : "integer"
+                          },
+                          "timestamp" : {
+                            "type" : "string",
+                            "format" : "date-time"
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2842,7 +3203,14 @@ FROM "ExternalOrders"
                   "properties" : {
                     "data" : {
                       "type" : "object",
-                      "description" : "Response data"
+                      "properties" : {
+                        "orderid" : {
+                          "type" : "integer"
+                        },
+                        "amount" : {
+                          "type" : "number"
+                        }
+                      }
                     }
                   }
                 }
@@ -3464,6 +3832,23 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
@@ -3488,6 +3873,30 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3516,6 +3925,30 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3540,6 +3973,30 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3568,6 +4025,30 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerFilteredDistinct($limit: Int = 10, $offset: Int = 0) {\nCustomerFilteredDistinct(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3592,6 +4073,25 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "window_start" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "unique_email_count" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3620,6 +4120,24 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
@@ -3644,6 +4162,44 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3672,6 +4228,24 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "namee" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
@@ -3698,6 +4272,51 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MissedTemporalJoin($limit: Int = 10, $offset: Int = 0) {\nMissedTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
@@ -3722,6 +4341,20 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orderid" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3751,6 +4384,30 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SelectCustomers($limit: Int = 10, $offset: Int = 0) {\nSelectCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3777,6 +4434,51 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
@@ -3801,6 +4503,36 @@ FROM "ExternalOrders"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "discount" : {
+                  "type" : "number"
+                },
+                "newId" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3834,6 +4566,30 @@ FROM "ExternalOrders"
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3863,6 +4619,23 @@ FROM "ExternalOrders"
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -3899,6 +4672,30 @@ FROM "ExternalOrders"
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TableFunctionCallsTblFct($arg1: Int, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -3925,6 +4722,17 @@ FROM "ExternalOrders"
               "required" : [
                 "orderid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "orderid" : {
+                "type" : "integer"
+              },
+              "amount" : {
+                "type" : "number"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
@@ -1805,7 +1805,7 @@ FROM "ExternalOrders"
       "name" : "Apache License 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "unknown"
+    "version" : "0.11.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8888",
@@ -3832,7 +3832,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
+            "queryName" : "AnotherCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3848,16 +3857,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query AnotherCustomer($limit: Int = 10, $offset: Int = 0) {\nAnotherCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
-            "queryName" : "AnotherCustomer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AnotherCustomer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3875,7 +3875,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3898,16 +3907,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customer",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customer{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3925,7 +3925,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByMultipleTime",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3948,16 +3957,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByMultipleTime($limit: Int = 10, $offset: Int = 0) {\nCustomerByMultipleTime(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByMultipleTime",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByMultipleTime{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -3975,7 +3975,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerByTime2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -3998,16 +4007,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerByTime2($limit: Int = 10, $offset: Int = 0) {\nCustomerByTime2(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerByTime2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerByTime2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4025,7 +4025,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerFilteredDistinct($limit: Int = 10, $offset: Int = 0) {\nCustomerFilteredDistinct(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerFilteredDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerFilteredDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4048,16 +4057,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerFilteredDistinct($limit: Int = 10, $offset: Int = 0) {\nCustomerFilteredDistinct(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerFilteredDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerFilteredDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4075,7 +4075,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
+            "queryName" : "CustomerTimeWindow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4093,16 +4102,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerTimeWindow($limit: Int = 10, $offset: Int = 0) {\nCustomerTimeWindow(limit: $limit, offset: $offset) {\nwindow_start\nwindow_end\nunique_email_count\n}\n\n}",
-            "queryName" : "CustomerTimeWindow",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerTimeWindow{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4120,7 +4120,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
+            "queryName" : "ExplicitDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4137,16 +4146,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExplicitDistinct($limit: Int = 10, $offset: Int = 0) {\nExplicitDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nname\n}\n\n}",
-            "queryName" : "ExplicitDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExplicitDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4164,7 +4164,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query ExternalOrders($limit: Int = 10, $offset: Int = 0) {\nExternalOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "ExternalOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ExternalOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4201,16 +4210,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query ExternalOrders($limit: Int = 10, $offset: Int = 0) {\nExternalOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "ExternalOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ExternalOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4228,7 +4228,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
+            "queryName" : "InvalidDistinct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/InvalidDistinct{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4245,16 +4254,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query InvalidDistinct($limit: Int = 10, $offset: Int = 0) {\nInvalidDistinct(limit: $limit, offset: $offset) {\ncustomerid\ntimestamp\nnamee\n}\n\n}",
-            "queryName" : "InvalidDistinct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/InvalidDistinct{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4272,7 +4272,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query MissedTemporalJoin($limit: Int = 10, $offset: Int = 0) {\nMissedTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
+            "queryName" : "MissedTemporalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MissedTemporalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4316,16 +4325,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query MissedTemporalJoin($limit: Int = 10, $offset: Int = 0) {\nMissedTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
-            "queryName" : "MissedTemporalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MissedTemporalJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4343,7 +4343,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\norderid\namount\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4356,16 +4365,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\norderid\namount\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4384,7 +4384,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query SelectCustomers($limit: Int = 10, $offset: Int = 0) {\nSelectCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "SelectCustomers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SelectCustomers{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4407,16 +4416,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query SelectCustomers($limit: Int = 10, $offset: Int = 0) {\nSelectCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "SelectCustomers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SelectCustomers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4434,7 +4434,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
+            "queryName" : "TemporalJoin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TemporalJoin{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4478,16 +4487,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TemporalJoin($limit: Int = 10, $offset: Int = 0) {\nTemporalJoin(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\ntimestamp\nname\n}\n\n}",
-            "queryName" : "TemporalJoin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TemporalJoin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4505,7 +4505,16 @@ FROM "ExternalOrders"
               "required" : [ ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\nnewId\n}\n\n}",
+            "queryName" : "UnnestOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/UnnestOrders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4534,16 +4543,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query UnnestOrders($limit: Int = 10, $offset: Int = 0) {\nUnnestOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\ndiscount\nnewId\n}\n\n}",
-            "queryName" : "UnnestOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/UnnestOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -4566,7 +4566,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomerById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerById{?offset,limit,minId}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4589,16 +4598,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerById($minId: Int!, $limit: Int = 10, $offset: Int = 0) {\nCustomerById(minId: $minId, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomerById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerById{?offset,limit,minId}"
+          }
         },
         {
           "function" : {
@@ -4621,7 +4621,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query CustomerQuery($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerQuery(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
+            "queryName" : "CustomerQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerQuery{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4637,16 +4646,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query CustomerQuery($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerQuery(id: $id, limit: $limit, offset: $offset) {\ncustomerid\nemail\nlastUpdated\n}\n\n}",
-            "queryName" : "CustomerQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerQuery{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -4672,7 +4672,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "query TableFunctionCallsTblFct($arg1: Int, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "TableFunctionCallsTblFct",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -4695,16 +4704,7 @@ FROM "ExternalOrders"
                 }
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "query TableFunctionCallsTblFct($arg1: Int, $arg2: Int!, $limit: Int = 10, $offset: Int = 0) {\nTableFunctionCallsTblFct(arg1: $arg1, arg2: $arg2, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "TableFunctionCallsTblFct",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TableFunctionCallsTblFct{?arg2,offset,arg1,limit}"
+          }
         },
         {
           "function" : {
@@ -4724,7 +4724,16 @@ FROM "ExternalOrders"
               ]
             }
           },
-          "result" : {
+          "apiQuery" : {
+            "query" : "mutation Orders($orderid: Int!, $amount: Float) {\nOrders(event: { orderid: $orderid, amount: $amount }) {\norderid\namount\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/Orders",
+          "format" : "JSON",
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "orderid" : {
@@ -4734,16 +4743,7 @@ FROM "ExternalOrders"
                 "type" : "number"
               }
             }
-          },
-          "format" : "JSON",
-          "apiQuery" : {
-            "query" : "mutation Orders($orderid: Int!, $amount: Float) {\nOrders(event: { orderid: $orderid, amount: $amount }) {\norderid\namount\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/Orders"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
@@ -177,6 +177,7 @@ CREATE TABLE IF NOT EXISTS "Res" ("uuidField" TEXT NOT NULL, "timestampMillisFie
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -196,7 +197,6 @@ CREATE TABLE IF NOT EXISTS "Res" ("uuidField" TEXT NOT NULL, "timestampMillisFie
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Res($limit: Int = 10, $offset: Int = 0) {\nRes(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\n}\n\n}",
             "queryName" : "Res",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
@@ -177,8 +177,16 @@ CREATE TABLE IF NOT EXISTS "Res" ("uuidField" TEXT NOT NULL, "timestampMillisFie
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Res($limit: Int = 10, $offset: Int = 0) {\nRes(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\n}\n\n}",
+            "queryName" : "Res",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Res{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -196,15 +204,7 @@ CREATE TABLE IF NOT EXISTS "Res" ("uuidField" TEXT NOT NULL, "timestampMillisFie
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Res($limit: Int = 10, $offset: Int = 0) {\nRes(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\n}\n\n}",
-            "queryName" : "Res",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Res{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
@@ -177,6 +177,25 @@ CREATE TABLE IF NOT EXISTS "Res" ("uuidField" TEXT NOT NULL, "timestampMillisFie
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuidField" : {
+                  "type" : "string"
+                },
+                "timestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "nullableTimestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Res($limit: Int = 10, $offset: Int = 0) {\nRes(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
@@ -373,8 +373,16 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
+            "queryName" : "Schema",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Schema{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -549,15 +557,7 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
                 "nullableMapField" : { }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
-            "queryName" : "Schema",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Schema{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
@@ -373,6 +373,7 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -549,7 +550,6 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
             "queryName" : "Schema",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
@@ -373,6 +373,182 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuidField" : {
+                  "type" : "string"
+                },
+                "timestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "nullableTimestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "timestampMicrosField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "nullableTimestampMicrosField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "dateField" : {
+                  "type" : "string",
+                  "format" : "date"
+                },
+                "nullableDateField" : {
+                  "type" : "string",
+                  "format" : "date"
+                },
+                "timeMillisField" : {
+                  "type" : "string"
+                },
+                "nullableTimeMillisField" : {
+                  "type" : "string"
+                },
+                "timeMicrosField" : {
+                  "type" : "string"
+                },
+                "nullableTimeMicrosField" : {
+                  "type" : "string"
+                },
+                "complexArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "itemFieldOne" : {
+                        "type" : "integer"
+                      },
+                      "itemFieldTwo" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "nullableComplexArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "nullableItemFieldOne" : {
+                        "type" : "number"
+                      },
+                      "nullableItemFieldTwo" : {
+                        "type" : "boolean"
+                      }
+                    }
+                  }
+                },
+                "multiNestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nestedLevelOne" : {
+                      "type" : "object",
+                      "properties" : {
+                        "levelOneField" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "stringField" : {
+                  "type" : "string"
+                },
+                "nullableStringField" : {
+                  "type" : "string"
+                },
+                "intField" : {
+                  "type" : "integer"
+                },
+                "nullableIntField" : {
+                  "type" : "integer"
+                },
+                "longField" : {
+                  "type" : "integer"
+                },
+                "nullableLongField" : {
+                  "type" : "integer"
+                },
+                "floatField" : {
+                  "type" : "number"
+                },
+                "nullableFloatField" : {
+                  "type" : "number"
+                },
+                "doubleField" : {
+                  "type" : "number"
+                },
+                "nullableDoubleField" : {
+                  "type" : "number"
+                },
+                "booleanField" : {
+                  "type" : "boolean"
+                },
+                "nullableBooleanField" : {
+                  "type" : "boolean"
+                },
+                "enumField" : {
+                  "type" : "string"
+                },
+                "nullableEnumField" : {
+                  "type" : "string"
+                },
+                "arrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "nullableArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "integer"
+                  }
+                },
+                "nestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nestedStringField" : {
+                      "type" : "string"
+                    },
+                    "nestedIntField" : {
+                      "type" : "integer"
+                    },
+                    "nestedArrayField" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "number"
+                      }
+                    },
+                    "nestedMapField" : { }
+                  }
+                },
+                "nullableNestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nullableNestedStringField" : {
+                      "type" : "string"
+                    },
+                    "nullableNestedLongField" : {
+                      "type" : "integer"
+                    }
+                  }
+                },
+                "decimalField" : {
+                  "type" : "number"
+                },
+                "mapField" : { },
+                "nullableMapField" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
@@ -373,8 +373,16 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
+            "queryName" : "Schema",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Schema{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -549,15 +557,7 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
                 "nullableMapField" : { }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
-            "queryName" : "Schema",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Schema{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
@@ -373,6 +373,7 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -549,7 +550,6 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",
             "queryName" : "Schema",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
@@ -373,6 +373,182 @@ CREATE TABLE IF NOT EXISTS "Schema" ("uuidField" TEXT NOT NULL, "timestampMillis
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuidField" : {
+                  "type" : "string"
+                },
+                "timestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "nullableTimestampMillisField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "timestampMicrosField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "nullableTimestampMicrosField" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "dateField" : {
+                  "type" : "string",
+                  "format" : "date"
+                },
+                "nullableDateField" : {
+                  "type" : "string",
+                  "format" : "date"
+                },
+                "timeMillisField" : {
+                  "type" : "string"
+                },
+                "nullableTimeMillisField" : {
+                  "type" : "string"
+                },
+                "timeMicrosField" : {
+                  "type" : "string"
+                },
+                "nullableTimeMicrosField" : {
+                  "type" : "string"
+                },
+                "complexArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "itemFieldOne" : {
+                        "type" : "integer"
+                      },
+                      "itemFieldTwo" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "nullableComplexArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "nullableItemFieldOne" : {
+                        "type" : "number"
+                      },
+                      "nullableItemFieldTwo" : {
+                        "type" : "boolean"
+                      }
+                    }
+                  }
+                },
+                "multiNestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nestedLevelOne" : {
+                      "type" : "object",
+                      "properties" : {
+                        "levelOneField" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "stringField" : {
+                  "type" : "string"
+                },
+                "nullableStringField" : {
+                  "type" : "string"
+                },
+                "intField" : {
+                  "type" : "integer"
+                },
+                "nullableIntField" : {
+                  "type" : "integer"
+                },
+                "longField" : {
+                  "type" : "integer"
+                },
+                "nullableLongField" : {
+                  "type" : "integer"
+                },
+                "floatField" : {
+                  "type" : "number"
+                },
+                "nullableFloatField" : {
+                  "type" : "number"
+                },
+                "doubleField" : {
+                  "type" : "number"
+                },
+                "nullableDoubleField" : {
+                  "type" : "number"
+                },
+                "booleanField" : {
+                  "type" : "boolean"
+                },
+                "nullableBooleanField" : {
+                  "type" : "boolean"
+                },
+                "enumField" : {
+                  "type" : "string"
+                },
+                "nullableEnumField" : {
+                  "type" : "string"
+                },
+                "arrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "nullableArrayField" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "integer"
+                  }
+                },
+                "nestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nestedStringField" : {
+                      "type" : "string"
+                    },
+                    "nestedIntField" : {
+                      "type" : "integer"
+                    },
+                    "nestedArrayField" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "number"
+                      }
+                    },
+                    "nestedMapField" : { }
+                  }
+                },
+                "nullableNestedRecord" : {
+                  "type" : "object",
+                  "properties" : {
+                    "nullableNestedStringField" : {
+                      "type" : "string"
+                    },
+                    "nullableNestedLongField" : {
+                      "type" : "integer"
+                    }
+                  }
+                },
+                "decimalField" : {
+                  "type" : "number"
+                },
+                "mapField" : { },
+                "nullableMapField" : { }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Schema($limit: Int = 10, $offset: Int = 0) {\nSchema(limit: $limit, offset: $offset) {\nuuidField\ntimestampMillisField\nnullableTimestampMillisField\ntimestampMicrosField\nnullableTimestampMicrosField\ndateField\nnullableDateField\ntimeMillisField\nnullableTimeMillisField\ntimeMicrosField\nnullableTimeMicrosField\ncomplexArrayField {\nitemFieldOne\nitemFieldTwo\n}\nnullableComplexArrayField {\nnullableItemFieldOne\nnullableItemFieldTwo\n}\nmultiNestedRecord {\nnestedLevelOne {\nlevelOneField\n}\n}\nstringField\nnullableStringField\nintField\nnullableIntField\nlongField\nnullableLongField\nfloatField\nnullableFloatField\ndoubleField\nnullableDoubleField\nbooleanField\nnullableBooleanField\nenumField\nnullableEnumField\narrayField\nnullableArrayField\nnestedRecord {\nnestedStringField\nnestedIntField\nnestedArrayField\nnestedMapField\n}\nnullableNestedRecord {\nnullableNestedStringField\nnullableNestedLongField\n}\ndecimalField\nmapField\nnullableMapField\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
@@ -479,8 +479,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
+            "queryName" : "ApplicationUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ApplicationUpdates{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -500,15 +508,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
-            "queryName" : "ApplicationUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ApplicationUpdates{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -526,8 +526,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Applications($limit: Int = 10, $offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
+            "queryName" : "Applications",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Applications{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -557,15 +565,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Applications($limit: Int = 10, $offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
-            "queryName" : "Applications",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Applications{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -583,8 +583,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomer_id\nnum_updates\n}\n\n}",
+            "queryName" : "CustomerUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerUpdates{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -597,15 +605,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomer_id\nnum_updates\n}\n\n}",
-            "queryName" : "CustomerUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerUpdates{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -623,8 +623,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
+            "queryName" : "Customers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customers{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -656,15 +664,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
-            "queryName" : "Customers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customers{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
@@ -479,6 +479,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -500,7 +501,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
             "queryName" : "ApplicationUpdates",
@@ -526,6 +526,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -557,7 +558,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Applications($limit: Int = 10, $offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
             "queryName" : "Applications",
@@ -583,6 +583,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -597,7 +598,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomer_id\nnum_updates\n}\n\n}",
             "queryName" : "CustomerUpdates",
@@ -623,6 +623,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -656,7 +657,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
             "queryName" : "Customers",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
@@ -479,6 +479,27 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "loan_application_id" : {
+                  "type" : "integer"
+                },
+                "status" : {
+                  "type" : "string"
+                },
+                "message" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
@@ -503,6 +524,37 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "duration" : {
+                  "type" : "integer"
+                },
+                "application_date" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -531,6 +583,20 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "num_updates" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerUpdates($limit: Int = 10, $offset: Int = 0) {\nCustomerUpdates(limit: $limit, offset: $offset) {\ncustomer_id\nnum_updates\n}\n\n}",
@@ -555,6 +621,39 @@ CREATE TABLE IF NOT EXISTS "Customers" ("id" BIGINT NOT NULL, "first_name" TEXT 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "first_name" : {
+                  "type" : "string"
+                },
+                "last_name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "phone" : {
+                  "type" : "string"
+                },
+                "address" : {
+                  "type" : "string"
+                },
+                "date_of_birth" : {
+                  "type" : "string"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -1275,6 +1275,38 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "status" : {
+                  "type" : "string"
+                },
+                "message" : {
+                  "type" : "string"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "duration" : {
+                  "type" : "integer"
+                },
+                "max_amount" : {
+                  "type" : "number"
+                },
+                "min_amount" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationStatusSpecialMcp @api(rest: NONE, mcp: TOOL) {\n    ApplicationStatus(limit: 10, offset: 0) {\n        status\n        message\n        customer_id\n        loan_type_id\n        amount\n        duration\n        max_amount\n        min_amount\n    }\n}\n",
@@ -1299,6 +1331,35 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "role" : {
+                  "type" : "string"
+                },
+                "content" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "context" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    }
+                  }
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1327,6 +1388,32 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "max_amount" : {
+                  "type" : "number"
+                },
+                "min_amount" : {
+                  "type" : "number"
+                },
+                "amount" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationAlert($limit: Int = 10, $offset: Int = 0) {\nApplicationAlert(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\nmax_amount\nmin_amount\namount\n}\n\n}",
@@ -1351,6 +1438,45 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "status" : {
+                  "type" : "string"
+                },
+                "message" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "duration" : {
+                  "type" : "integer"
+                },
+                "max_amount" : {
+                  "type" : "number"
+                },
+                "min_amount" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1391,6 +1517,94 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "loan_application_id" : {
+                  "type" : "integer"
+                },
+                "status" : {
+                  "type" : "string"
+                },
+                "message" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "application" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customer_id" : {
+                        "type" : "integer"
+                      },
+                      "loan_type_id" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "duration" : {
+                        "type" : "integer"
+                      },
+                      "application_date" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "updated_at" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "loanType" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "integer"
+                            },
+                            "name" : {
+                              "type" : "string"
+                            },
+                            "description" : {
+                              "type" : "string"
+                            },
+                            "interest_rate" : {
+                              "type" : "number"
+                            },
+                            "max_amount" : {
+                              "type" : "number"
+                            },
+                            "min_amount" : {
+                              "type" : "number"
+                            },
+                            "max_duration" : {
+                              "type" : "integer"
+                            },
+                            "min_duration" : {
+                              "type" : "integer"
+                            },
+                            "updated_at" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0$application_limit: Int = 10, $application_offset: Int = 0$application_loanType_limit: Int = 10, $application_loanType_offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\napplication(limit: $application_limit, offset: $application_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $application_loanType_limit, offset: $application_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n}\n}\n\n}",
@@ -1429,6 +1643,94 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "duration" : {
+                  "type" : "integer"
+                },
+                "application_date" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "loanType" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "description" : {
+                        "type" : "string"
+                      },
+                      "interest_rate" : {
+                        "type" : "number"
+                      },
+                      "max_amount" : {
+                        "type" : "number"
+                      },
+                      "min_amount" : {
+                        "type" : "number"
+                      },
+                      "max_duration" : {
+                        "type" : "integer"
+                      },
+                      "min_duration" : {
+                        "type" : "integer"
+                      },
+                      "updated_at" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                },
+                "updates" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "loan_application_id" : {
+                        "type" : "integer"
+                      },
+                      "status" : {
+                        "type" : "string"
+                      },
+                      "message" : {
+                        "type" : "string"
+                      },
+                      "event_time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Applications($limit: Int = 10, $offset: Int = 0$loanType_limit: Int = 10, $loanType_offset: Int = 0$updates_limit: Int = 10, $updates_offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $loanType_limit, offset: $loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $updates_limit, offset: $updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\n\n}",
@@ -1455,6 +1757,37 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customer_id" : {
+                  "type" : "integer"
+                },
+                "loan_type_id" : {
+                  "type" : "integer"
+                },
+                "amount" : {
+                  "type" : "number"
+                },
+                "duration" : {
+                  "type" : "integer"
+                },
+                "application_date" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationsStream($limit: Int = 10, $offset: Int = 0) {\nApplicationsStream(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
@@ -1479,6 +1812,33 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "role" : {
+                  "type" : "string"
+                },
+                "content" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "uuid" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1531,6 +1891,144 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "first_name" : {
+                  "type" : "string"
+                },
+                "last_name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "phone" : {
+                  "type" : "string"
+                },
+                "address" : {
+                  "type" : "string"
+                },
+                "date_of_birth" : {
+                  "type" : "string"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "applications" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customer_id" : {
+                        "type" : "integer"
+                      },
+                      "loan_type_id" : {
+                        "type" : "integer"
+                      },
+                      "amount" : {
+                        "type" : "number"
+                      },
+                      "duration" : {
+                        "type" : "integer"
+                      },
+                      "application_date" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "updated_at" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "loanType" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "integer"
+                            },
+                            "name" : {
+                              "type" : "string"
+                            },
+                            "description" : {
+                              "type" : "string"
+                            },
+                            "interest_rate" : {
+                              "type" : "number"
+                            },
+                            "max_amount" : {
+                              "type" : "number"
+                            },
+                            "min_amount" : {
+                              "type" : "number"
+                            },
+                            "max_duration" : {
+                              "type" : "integer"
+                            },
+                            "min_duration" : {
+                              "type" : "integer"
+                            },
+                            "updated_at" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            }
+                          }
+                        }
+                      },
+                      "updates" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "loan_application_id" : {
+                              "type" : "integer"
+                            },
+                            "status" : {
+                              "type" : "string"
+                            },
+                            "message" : {
+                              "type" : "string"
+                            },
+                            "event_time" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "overview" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "loan_type_id" : {
+                        "type" : "integer"
+                      },
+                      "total_amount" : {
+                        "type" : "number"
+                      },
+                      "total_loans" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($limit: Int = 10, $offset: Int = 0$applications_limit: Int = 10, $applications_offset: Int = 0$applications_loanType_limit: Int = 10, $applications_loanType_offset: Int = 0$applications_updates_limit: Int = 10, $applications_updates_offset: Int = 0$overview_limit: Int = 10, $overview_offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\napplications(limit: $applications_limit, offset: $applications_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $applications_loanType_limit, offset: $applications_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $applications_updates_limit, offset: $applications_updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\noverview(limit: $overview_limit, offset: $overview_offset) {\nloan_type_id\ntotal_amount\ntotal_loans\n}\n}\n\n}",
@@ -1555,6 +2053,39 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "first_name" : {
+                  "type" : "string"
+                },
+                "last_name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "phone" : {
+                  "type" : "string"
+                },
+                "address" : {
+                  "type" : "string"
+                },
+                "date_of_birth" : {
+                  "type" : "string"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1583,6 +2114,42 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "interest_rate" : {
+                  "type" : "number"
+                },
+                "max_amount" : {
+                  "type" : "number"
+                },
+                "min_amount" : {
+                  "type" : "number"
+                },
+                "max_duration" : {
+                  "type" : "integer"
+                },
+                "min_duration" : {
+                  "type" : "integer"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query LoanTypes($limit: Int = 10, $offset: Int = 0) {\nLoanTypes(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
@@ -1607,6 +2174,42 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "interest_rate" : {
+                  "type" : "number"
+                },
+                "max_amount" : {
+                  "type" : "number"
+                },
+                "min_amount" : {
+                  "type" : "number"
+                },
+                "max_duration" : {
+                  "type" : "integer"
+                },
+                "min_duration" : {
+                  "type" : "integer"
+                },
+                "updated_at" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1651,6 +2254,32 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               ]
             }
           },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "role" : {
+                "type" : "string"
+              },
+              "content" : {
+                "type" : "string"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "context" : {
+                "type" : "object",
+                "properties" : {
+                  "customerid" : {
+                    "type" : "integer"
+                  }
+                }
+              },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation AddChatMessage($role: String!, $content: String!, $name: String, $context: AddChatMessage_contextInput!) {\nAddChatMessage(event: { role: $role, content: $content, name: $name, context: $context }) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
@@ -1692,6 +2321,27 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [
                 "event"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "loan_application_id" : {
+                  "type" : "integer"
+                },
+                "status" : {
+                  "type" : "string"
+                },
+                "message" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -1275,8 +1275,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationStatusSpecialMcp @api(rest: NONE, mcp: TOOL) {\n    ApplicationStatus(limit: 10, offset: 0) {\n        status\n        message\n        customer_id\n        loan_type_id\n        amount\n        duration\n        max_amount\n        min_amount\n    }\n}\n",
+            "queryName" : "ApplicationStatusSpecialMcp",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "NONE",
+          "uriTemplate" : "queries/ApplicationStatusSpecialMcp",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1307,15 +1315,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationStatusSpecialMcp @api(rest: NONE, mcp: TOOL) {\n    ApplicationStatus(limit: 10, offset: 0) {\n        status\n        message\n        customer_id\n        loan_type_id\n        amount\n        duration\n        max_amount\n        min_amount\n    }\n}\n",
-            "queryName" : "ApplicationStatusSpecialMcp",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "NONE",
-          "uriTemplate" : "queries/ApplicationStatusSpecialMcp"
+          }
         },
         {
           "function" : {
@@ -1333,8 +1333,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AddChatMessage($limit: Int = 10, $offset: Int = 0) {\nAddChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
+            "queryName" : "AddChatMessage",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AddChatMessage{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1362,15 +1370,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AddChatMessage($limit: Int = 10, $offset: Int = 0) {\nAddChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
-            "queryName" : "AddChatMessage",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AddChatMessage{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1388,8 +1388,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationAlert($limit: Int = 10, $offset: Int = 0) {\nApplicationAlert(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\nmax_amount\nmin_amount\namount\n}\n\n}",
+            "queryName" : "ApplicationAlert",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ApplicationAlert{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1414,15 +1422,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationAlert($limit: Int = 10, $offset: Int = 0) {\nApplicationAlert(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\nmax_amount\nmin_amount\namount\n}\n\n}",
-            "queryName" : "ApplicationAlert",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ApplicationAlert{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1440,8 +1440,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationStatus($limit: Int = 10, $offset: Int = 0) {\nApplicationStatus(limit: $limit, offset: $offset) {\nstatus\nmessage\nevent_time\nid\ncustomer_id\nloan_type_id\namount\nduration\nmax_amount\nmin_amount\n}\n\n}",
+            "queryName" : "ApplicationStatus",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ApplicationStatus{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1479,15 +1487,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationStatus($limit: Int = 10, $offset: Int = 0) {\nApplicationStatus(limit: $limit, offset: $offset) {\nstatus\nmessage\nevent_time\nid\ncustomer_id\nloan_type_id\namount\nduration\nmax_amount\nmin_amount\n}\n\n}",
-            "queryName" : "ApplicationStatus",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ApplicationStatus{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1517,8 +1517,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0$application_limit: Int = 10, $application_offset: Int = 0$application_loanType_limit: Int = 10, $application_loanType_offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\napplication(limit: $application_limit, offset: $application_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $application_loanType_limit, offset: $application_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n}\n}\n\n}",
+            "queryName" : "ApplicationUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ApplicationUpdates{?application_limit,application_offset,offset,application_loanType_limit,limit,application_loanType_offset}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1605,15 +1613,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0$application_limit: Int = 10, $application_offset: Int = 0$application_loanType_limit: Int = 10, $application_loanType_offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\napplication(limit: $application_limit, offset: $application_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $application_loanType_limit, offset: $application_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n}\n}\n\n}",
-            "queryName" : "ApplicationUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ApplicationUpdates{?application_limit,application_offset,offset,application_loanType_limit,limit,application_loanType_offset}"
+          }
         },
         {
           "function" : {
@@ -1643,8 +1643,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Applications($limit: Int = 10, $offset: Int = 0$loanType_limit: Int = 10, $loanType_offset: Int = 0$updates_limit: Int = 10, $updates_offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $loanType_limit, offset: $loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $updates_limit, offset: $updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\n\n}",
+            "queryName" : "Applications",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Applications{?offset,limit,loanType_limit,updates_offset,loanType_offset,updates_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1731,15 +1739,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Applications($limit: Int = 10, $offset: Int = 0$loanType_limit: Int = 10, $loanType_offset: Int = 0$updates_limit: Int = 10, $updates_offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $loanType_limit, offset: $loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $updates_limit, offset: $updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\n\n}",
-            "queryName" : "Applications",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Applications{?offset,limit,loanType_limit,updates_offset,loanType_offset,updates_limit}"
+          }
         },
         {
           "function" : {
@@ -1757,8 +1757,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ApplicationsStream($limit: Int = 10, $offset: Int = 0) {\nApplicationsStream(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
+            "queryName" : "ApplicationsStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ApplicationsStream{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1788,15 +1796,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ApplicationsStream($limit: Int = 10, $offset: Int = 0) {\nApplicationsStream(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
-            "queryName" : "ApplicationsStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ApplicationsStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1814,8 +1814,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CustomerChatMessage($limit: Int = 10, $offset: Int = 0) {\nCustomerChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncustomerid\ntimestamp\nuuid\n}\n\n}",
+            "queryName" : "CustomerChatMessage",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerChatMessage{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1841,15 +1849,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CustomerChatMessage($limit: Int = 10, $offset: Int = 0) {\nCustomerChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncustomerid\ntimestamp\nuuid\n}\n\n}",
-            "queryName" : "CustomerChatMessage",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomerChatMessage{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1891,8 +1891,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Customers($limit: Int = 10, $offset: Int = 0$applications_limit: Int = 10, $applications_offset: Int = 0$applications_loanType_limit: Int = 10, $applications_loanType_offset: Int = 0$applications_updates_limit: Int = 10, $applications_updates_offset: Int = 0$overview_limit: Int = 10, $overview_offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\napplications(limit: $applications_limit, offset: $applications_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $applications_loanType_limit, offset: $applications_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $applications_updates_limit, offset: $applications_updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\noverview(limit: $overview_limit, offset: $overview_offset) {\nloan_type_id\ntotal_amount\ntotal_loans\n}\n}\n\n}",
+            "queryName" : "Customers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customers{?applications_loanType_limit,applications_updates_offset,overview_limit,overview_offset,offset,applications_updates_limit,limit,applications_limit,applications_loanType_offset,applications_offset}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2029,15 +2037,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Customers($limit: Int = 10, $offset: Int = 0$applications_limit: Int = 10, $applications_offset: Int = 0$applications_loanType_limit: Int = 10, $applications_loanType_offset: Int = 0$applications_updates_limit: Int = 10, $applications_updates_offset: Int = 0$overview_limit: Int = 10, $overview_offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\napplications(limit: $applications_limit, offset: $applications_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $applications_loanType_limit, offset: $applications_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $applications_updates_limit, offset: $applications_updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\noverview(limit: $overview_limit, offset: $overview_offset) {\nloan_type_id\ntotal_amount\ntotal_loans\n}\n}\n\n}",
-            "queryName" : "Customers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customers{?applications_loanType_limit,applications_updates_offset,overview_limit,overview_offset,offset,applications_updates_limit,limit,applications_limit,applications_loanType_offset,applications_offset}"
+          }
         },
         {
           "function" : {
@@ -2055,8 +2055,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CustomersStream($limit: Int = 10, $offset: Int = 0) {\nCustomersStream(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
+            "queryName" : "CustomersStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersStream{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2088,15 +2096,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CustomersStream($limit: Int = 10, $offset: Int = 0) {\nCustomersStream(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
-            "queryName" : "CustomersStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2114,8 +2114,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query LoanTypes($limit: Int = 10, $offset: Int = 0) {\nLoanTypes(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
+            "queryName" : "LoanTypes",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/LoanTypes{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2150,15 +2158,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query LoanTypes($limit: Int = 10, $offset: Int = 0) {\nLoanTypes(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
-            "queryName" : "LoanTypes",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/LoanTypes{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2176,8 +2176,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query LoanTypesStream($limit: Int = 10, $offset: Int = 0) {\nLoanTypesStream(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
+            "queryName" : "LoanTypesStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/LoanTypesStream{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2212,15 +2220,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query LoanTypesStream($limit: Int = 10, $offset: Int = 0) {\nLoanTypesStream(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
-            "queryName" : "LoanTypesStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/LoanTypesStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -2254,8 +2254,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation AddChatMessage($role: String!, $content: String!, $name: String, $context: AddChatMessage_contextInput!) {\nAddChatMessage(event: { role: $role, content: $content, name: $name, context: $context }) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
+            "queryName" : "AddChatMessage",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "NONE",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/AddChatMessage",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "role" : {
@@ -2280,15 +2288,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation AddChatMessage($role: String!, $content: String!, $name: String, $context: AddChatMessage_contextInput!) {\nAddChatMessage(event: { role: $role, content: $content, name: $name, context: $context }) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
-            "queryName" : "AddChatMessage",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "NONE",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/AddChatMessage"
+          }
         },
         {
           "function" : {
@@ -2323,8 +2323,16 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation ApplicationUpdates($event: [ApplicationUpdatesInput!]!) {\nApplicationUpdates(event: $event) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
+            "queryName" : "ApplicationUpdates",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "NONE",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/ApplicationUpdates",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -2344,15 +2352,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation ApplicationUpdates($event: [ApplicationUpdatesInput!]!) {\nApplicationUpdates(event: $event) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
-            "queryName" : "ApplicationUpdates",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "NONE",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/ApplicationUpdates"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -1275,6 +1275,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1307,7 +1308,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationStatusSpecialMcp @api(rest: NONE, mcp: TOOL) {\n    ApplicationStatus(limit: 10, offset: 0) {\n        status\n        message\n        customer_id\n        loan_type_id\n        amount\n        duration\n        max_amount\n        min_amount\n    }\n}\n",
             "queryName" : "ApplicationStatusSpecialMcp",
@@ -1333,6 +1333,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1362,7 +1363,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AddChatMessage($limit: Int = 10, $offset: Int = 0) {\nAddChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
             "queryName" : "AddChatMessage",
@@ -1388,6 +1388,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1414,7 +1415,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationAlert($limit: Int = 10, $offset: Int = 0) {\nApplicationAlert(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\nmax_amount\nmin_amount\namount\n}\n\n}",
             "queryName" : "ApplicationAlert",
@@ -1440,6 +1440,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1479,7 +1480,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationStatus($limit: Int = 10, $offset: Int = 0) {\nApplicationStatus(limit: $limit, offset: $offset) {\nstatus\nmessage\nevent_time\nid\ncustomer_id\nloan_type_id\namount\nduration\nmax_amount\nmin_amount\n}\n\n}",
             "queryName" : "ApplicationStatus",
@@ -1517,6 +1517,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1605,7 +1606,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationUpdates($limit: Int = 10, $offset: Int = 0$application_limit: Int = 10, $application_offset: Int = 0$application_loanType_limit: Int = 10, $application_loanType_offset: Int = 0) {\nApplicationUpdates(limit: $limit, offset: $offset) {\nloan_application_id\nstatus\nmessage\nevent_time\napplication(limit: $application_limit, offset: $application_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $application_loanType_limit, offset: $application_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n}\n}\n\n}",
             "queryName" : "ApplicationUpdates",
@@ -1643,6 +1643,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1731,7 +1732,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Applications($limit: Int = 10, $offset: Int = 0$loanType_limit: Int = 10, $loanType_offset: Int = 0$updates_limit: Int = 10, $updates_offset: Int = 0) {\nApplications(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $loanType_limit, offset: $loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $updates_limit, offset: $updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\n\n}",
             "queryName" : "Applications",
@@ -1757,6 +1757,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1788,7 +1789,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ApplicationsStream($limit: Int = 10, $offset: Int = 0) {\nApplicationsStream(limit: $limit, offset: $offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\n}\n\n}",
             "queryName" : "ApplicationsStream",
@@ -1814,6 +1814,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1841,7 +1842,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomerChatMessage($limit: Int = 10, $offset: Int = 0) {\nCustomerChatMessage(limit: $limit, offset: $offset) {\nrole\ncontent\nname\ncustomerid\ntimestamp\nuuid\n}\n\n}",
             "queryName" : "CustomerChatMessage",
@@ -1891,6 +1891,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -2029,7 +2030,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($limit: Int = 10, $offset: Int = 0$applications_limit: Int = 10, $applications_offset: Int = 0$applications_loanType_limit: Int = 10, $applications_loanType_offset: Int = 0$applications_updates_limit: Int = 10, $applications_updates_offset: Int = 0$overview_limit: Int = 10, $overview_offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\napplications(limit: $applications_limit, offset: $applications_offset) {\nid\ncustomer_id\nloan_type_id\namount\nduration\napplication_date\nupdated_at\nloanType(limit: $applications_loanType_limit, offset: $applications_loanType_offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\nupdates(limit: $applications_updates_limit, offset: $applications_updates_offset) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n}\noverview(limit: $overview_limit, offset: $overview_offset) {\nloan_type_id\ntotal_amount\ntotal_loans\n}\n}\n\n}",
             "queryName" : "Customers",
@@ -2055,6 +2055,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -2088,7 +2089,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersStream($limit: Int = 10, $offset: Int = 0) {\nCustomersStream(limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nphone\naddress\ndate_of_birth\nupdated_at\n}\n\n}",
             "queryName" : "CustomersStream",
@@ -2114,6 +2114,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -2150,7 +2151,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query LoanTypes($limit: Int = 10, $offset: Int = 0) {\nLoanTypes(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
             "queryName" : "LoanTypes",
@@ -2176,6 +2176,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -2212,7 +2213,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query LoanTypesStream($limit: Int = 10, $offset: Int = 0) {\nLoanTypesStream(limit: $limit, offset: $offset) {\nid\nname\ndescription\ninterest_rate\nmax_amount\nmin_amount\nmax_duration\nmin_duration\nupdated_at\n}\n\n}",
             "queryName" : "LoanTypesStream",
@@ -2254,6 +2254,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -2280,7 +2281,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation AddChatMessage($role: String!, $content: String!, $name: String, $context: AddChatMessage_contextInput!) {\nAddChatMessage(event: { role: $role, content: $content, name: $name, context: $context }) {\nrole\ncontent\nname\ncontext {\ncustomerid\n}\nevent_time\n}\n\n}",
             "queryName" : "AddChatMessage",
@@ -2323,6 +2323,7 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -2344,7 +2345,6 @@ CREATE INDEX IF NOT EXISTS "Applications_hash_c1" ON "Applications" USING hash (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation ApplicationUpdates($event: [ApplicationUpdatesInput!]!) {\nApplicationUpdates(event: $event) {\nloan_application_id\nstatus\nmessage\nevent_time\n}\n\n}",
             "queryName" : "ApplicationUpdates",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
@@ -432,8 +432,16 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\nresults {\ntimestamp\nuserid\nurl\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
+            "queryName" : "Click",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Click{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "results" : {
@@ -492,15 +500,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\nresults {\ntimestamp\nuserid\nurl\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
-            "queryName" : "Click",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Click{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -525,8 +525,16 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nresults {\nurl\nrec\nfrequency\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
+            "queryName" : "Recommendation",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Recommendation{?offset,limit,url}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "results" : {
@@ -586,15 +594,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nresults {\nurl\nrec\nfrequency\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
-            "queryName" : "Recommendation",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Recommendation{?offset,limit,url}"
+          }
         },
         {
           "function" : {
@@ -613,8 +613,16 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nresults {\nurl\ntotal\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
+            "queryName" : "Trending",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Trending{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "results" : {
@@ -671,15 +679,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nresults {\nurl\ntotal\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
-            "queryName" : "Trending",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Trending{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -697,8 +697,16 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nresults {\nbeforeURL\nafterURL\ntimestamp\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
+            "queryName" : "VisitAfter",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/VisitAfter{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "results" : {
@@ -757,15 +765,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nresults {\nbeforeURL\nafterURL\ntimestamp\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
-            "queryName" : "VisitAfter",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/VisitAfter{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
@@ -432,6 +432,66 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "results" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "userid" : {
+                      "type" : "string"
+                    },
+                    "url" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              },
+              "pagination" : {
+                "type" : "object",
+                "properties" : {
+                  "pageSize" : {
+                    "type" : "integer"
+                  },
+                  "currentPage" : {
+                    "type" : "integer"
+                  },
+                  "totalRecords" : {
+                    "type" : "integer"
+                  },
+                  "totalPages" : {
+                    "type" : "integer"
+                  },
+                  "hasNextPage" : {
+                    "type" : "boolean"
+                  },
+                  "hasPreviousPage" : {
+                    "type" : "boolean"
+                  },
+                  "nextOffset" : {
+                    "type" : "integer"
+                  },
+                  "prevOffset" : {
+                    "type" : "integer"
+                  },
+                  "firstEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  },
+                  "lastEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\nresults {\ntimestamp\nuserid\nurl\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
@@ -465,6 +525,67 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               ]
             }
           },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "results" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "url" : {
+                      "type" : "string"
+                    },
+                    "rec" : {
+                      "type" : "string",
+                      "description" : "the recommended page URL"
+                    },
+                    "frequency" : {
+                      "type" : "integer",
+                      "description" : "the number of visitors that co-visited that page"
+                    }
+                  }
+                }
+              },
+              "pagination" : {
+                "type" : "object",
+                "properties" : {
+                  "pageSize" : {
+                    "type" : "integer"
+                  },
+                  "currentPage" : {
+                    "type" : "integer"
+                  },
+                  "totalRecords" : {
+                    "type" : "integer"
+                  },
+                  "totalPages" : {
+                    "type" : "integer"
+                  },
+                  "hasNextPage" : {
+                    "type" : "boolean"
+                  },
+                  "hasPreviousPage" : {
+                    "type" : "boolean"
+                  },
+                  "nextOffset" : {
+                    "type" : "integer"
+                  },
+                  "prevOffset" : {
+                    "type" : "integer"
+                  },
+                  "firstEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  },
+                  "lastEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nresults {\nurl\nrec\nfrequency\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
@@ -492,6 +613,64 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "results" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "url" : {
+                      "type" : "string",
+                      "description" : "URL of the top visited page"
+                    },
+                    "total" : {
+                      "type" : "integer",
+                      "description" : "Total number of visitors"
+                    }
+                  }
+                }
+              },
+              "pagination" : {
+                "type" : "object",
+                "properties" : {
+                  "pageSize" : {
+                    "type" : "integer"
+                  },
+                  "currentPage" : {
+                    "type" : "integer"
+                  },
+                  "totalRecords" : {
+                    "type" : "integer"
+                  },
+                  "totalPages" : {
+                    "type" : "integer"
+                  },
+                  "hasNextPage" : {
+                    "type" : "boolean"
+                  },
+                  "hasPreviousPage" : {
+                    "type" : "boolean"
+                  },
+                  "nextOffset" : {
+                    "type" : "integer"
+                  },
+                  "prevOffset" : {
+                    "type" : "integer"
+                  },
+                  "firstEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  },
+                  "lastEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nresults {\nurl\ntotal\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
@@ -516,6 +695,66 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "results" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "beforeURL" : {
+                      "type" : "string"
+                    },
+                    "afterURL" : {
+                      "type" : "string"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              },
+              "pagination" : {
+                "type" : "object",
+                "properties" : {
+                  "pageSize" : {
+                    "type" : "integer"
+                  },
+                  "currentPage" : {
+                    "type" : "integer"
+                  },
+                  "totalRecords" : {
+                    "type" : "integer"
+                  },
+                  "totalPages" : {
+                    "type" : "integer"
+                  },
+                  "hasNextPage" : {
+                    "type" : "boolean"
+                  },
+                  "hasPreviousPage" : {
+                    "type" : "boolean"
+                  },
+                  "nextOffset" : {
+                    "type" : "integer"
+                  },
+                  "prevOffset" : {
+                    "type" : "integer"
+                  },
+                  "firstEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  },
+                  "lastEventTime" : {
+                    "type" : "string",
+                    "format" : "date-time"
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
@@ -432,6 +432,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -492,7 +493,6 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\nresults {\ntimestamp\nuserid\nurl\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
             "queryName" : "Click",
@@ -525,6 +525,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -586,7 +587,6 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nresults {\nurl\nrec\nfrequency\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
             "queryName" : "Recommendation",
@@ -613,6 +613,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -671,7 +672,6 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nresults {\nurl\ntotal\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
             "queryName" : "Trending",
@@ -697,6 +697,7 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -757,7 +758,6 @@ CREATE INDEX IF NOT EXISTS "VisitAfter_btree_c2" ON "VisitAfter" USING btree ("t
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nresults {\nbeforeURL\nafterURL\ntimestamp\n}\npagination {\npageSize\ncurrentPage\ntotalRecords\ntotalPages\nhasNextPage\nhasPreviousPage\nnextOffset\nprevOffset\nfirstEventTime\nlastEventTime\n}\n}\n\n}",
             "queryName" : "VisitAfter",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
@@ -388,6 +388,24 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "userid" : {
+                  "type" : "string"
+                },
+                "url" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\ntimestamp\nuserid\nurl\n}\n\n}",
@@ -421,6 +439,25 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "rec" : {
+                  "type" : "string",
+                  "description" : "the recommended page URL"
+                },
+                "frequency" : {
+                  "type" : "integer",
+                  "description" : "the number of visitors that co-visited that page"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nurl\nrec\nfrequency\n}\n\n}",
@@ -448,6 +485,22 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string",
+                  "description" : "URL of the top visited page"
+                },
+                "total" : {
+                  "type" : "integer",
+                  "description" : "Total number of visitors"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nurl\ntotal\n}\n\n}",
@@ -472,6 +525,24 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "beforeURL" : {
+                  "type" : "string"
+                },
+                "afterURL" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
@@ -388,8 +388,16 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\ntimestamp\nuserid\nurl\n}\n\n}",
+            "queryName" : "Click",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Click{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -406,15 +414,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\ntimestamp\nuserid\nurl\n}\n\n}",
-            "queryName" : "Click",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Click{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -439,8 +439,16 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nurl\nrec\nfrequency\n}\n\n}",
+            "queryName" : "Recommendation",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Recommendation{?offset,limit,url}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -458,15 +466,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nurl\nrec\nfrequency\n}\n\n}",
-            "queryName" : "Recommendation",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Recommendation{?offset,limit,url}"
+          }
         },
         {
           "function" : {
@@ -485,8 +485,16 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nurl\ntotal\n}\n\n}",
+            "queryName" : "Trending",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Trending{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -501,15 +509,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nurl\ntotal\n}\n\n}",
-            "queryName" : "Trending",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Trending{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -527,8 +527,16 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nbeforeURL\nafterURL\ntimestamp\n}\n\n}",
+            "queryName" : "VisitAfter",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/VisitAfter{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -545,15 +553,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nbeforeURL\nafterURL\ntimestamp\n}\n\n}",
-            "queryName" : "VisitAfter",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/VisitAfter{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
@@ -388,6 +388,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -406,7 +407,6 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Click($limit: Int = 10, $offset: Int = 0) {\nClick(limit: $limit, offset: $offset) {\ntimestamp\nuserid\nurl\n}\n\n}",
             "queryName" : "Click",
@@ -439,6 +439,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -458,7 +459,6 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Recommendation($url: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendation(url: $url, limit: $limit, offset: $offset) {\nurl\nrec\nfrequency\n}\n\n}",
             "queryName" : "Recommendation",
@@ -485,6 +485,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -501,7 +502,6 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Trending($limit: Int = 10, $offset: Int = 0) {\nTrending(limit: $limit, offset: $offset) {\nurl\ntotal\n}\n\n}",
             "queryName" : "Trending",
@@ -527,6 +527,7 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -545,7 +546,6 @@ CREATE TABLE IF NOT EXISTS "VisitAfter" ("beforeURL" TEXT NOT NULL, "afterURL" T
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query VisitAfter($limit: Int = 10, $offset: Int = 0) {\nVisitAfter(limit: $limit, offset: $offset) {\nbeforeURL\nafterURL\ntimestamp\n}\n\n}",
             "queryName" : "VisitAfter",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
@@ -285,6 +285,7 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -307,7 +308,6 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query LatestTokens($limit: Int = 10, $offset: Int = 0) {\nLatestTokens(limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\nwindow_end\nwindow_time\n}\n\n}",
             "queryName" : "LatestTokens",
@@ -336,6 +336,7 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -351,7 +352,6 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation InputTable($userid: Int!, $tokens: Long!) {\nInputTable(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nevent_time\n}\n\n}",
             "queryName" : "InputTable",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
@@ -285,6 +285,28 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "userid" : {
+                  "type" : "integer"
+                },
+                "total_tokens" : {
+                  "type" : "integer"
+                },
+                "window_end" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query LatestTokens($limit: Int = 10, $offset: Int = 0) {\nLatestTokens(limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\nwindow_end\nwindow_time\n}\n\n}",
@@ -312,6 +334,21 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
                 "userid",
                 "tokens"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "userid" : {
+                "type" : "integer"
+              },
+              "tokens" : {
+                "type" : "integer"
+              },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
@@ -285,8 +285,16 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query LatestTokens($limit: Int = 10, $offset: Int = 0) {\nLatestTokens(limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\nwindow_end\nwindow_time\n}\n\n}",
+            "queryName" : "LatestTokens",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/LatestTokens{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -307,15 +315,7 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query LatestTokens($limit: Int = 10, $offset: Int = 0) {\nLatestTokens(limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\nwindow_end\nwindow_time\n}\n\n}",
-            "queryName" : "LatestTokens",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/LatestTokens{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -336,8 +336,16 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation InputTable($userid: Int!, $tokens: Long!) {\nInputTable(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nevent_time\n}\n\n}",
+            "queryName" : "InputTable",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/InputTable",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "userid" : {
@@ -351,15 +359,7 @@ CREATE TABLE IF NOT EXISTS "SinkTable" ("userid" INTEGER NOT NULL, "total_tokens
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation InputTable($userid: Int!, $tokens: Long!) {\nInputTable(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nevent_time\n}\n\n}",
-            "queryName" : "InputTable",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/InputTable"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
@@ -809,8 +809,16 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Events($id: Long!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEvents(id: $id, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
+            "queryName" : "Events",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Events{?offset,likeCount_offset,limit,id,likeCount_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -886,15 +894,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Events($id: Long!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEvents(id: $id, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
-            "queryName" : "Events",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Events{?offset,likeCount_offset,limit,id,likeCount_limit}"
+          }
         },
         {
           "function" : {
@@ -923,8 +923,16 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query EventsLiked($userid: String!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEventsLiked(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
+            "queryName" : "EventsLiked",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/EventsLiked{?offset,likeCount_offset,limit,likeCount_limit,userid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1000,15 +1008,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query EventsLiked($userid: String!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEventsLiked(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
-            "queryName" : "EventsLiked",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/EventsLiked{?offset,likeCount_offset,limit,likeCount_limit,userid}"
+          }
         },
         {
           "function" : {
@@ -1035,8 +1035,16 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query PersonalizedEventSearch($query: String!, $userid: String!, $limit: Int = 10, $offset: Int = 0) {\nPersonalizedEventSearch(query: $query, userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
+            "queryName" : "PersonalizedEventSearch",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/PersonalizedEventSearch{?offset,query,limit,userid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1098,15 +1106,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query PersonalizedEventSearch($query: String!, $userid: String!, $limit: Int = 10, $offset: Int = 0) {\nPersonalizedEventSearch(query: $query, userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
-            "queryName" : "PersonalizedEventSearch",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/PersonalizedEventSearch{?offset,query,limit,userid}"
+          }
         },
         {
           "function" : {
@@ -1129,8 +1129,16 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query RecommendedEvents($userid: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendedEvents(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
+            "queryName" : "RecommendedEvents",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/RecommendedEvents{?offset,limit,userid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1192,15 +1200,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query RecommendedEvents($userid: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendedEvents(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
-            "queryName" : "RecommendedEvents",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/RecommendedEvents{?offset,limit,userid}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
@@ -809,6 +809,83 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "date" : {
+                  "type" : "string"
+                },
+                "time" : {
+                  "type" : "string"
+                },
+                "title" : {
+                  "type" : "string"
+                },
+                "abstract" : {
+                  "type" : "string"
+                },
+                "location" : {
+                  "type" : "string"
+                },
+                "speakers" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "title" : {
+                        "type" : "string"
+                      },
+                      "company" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "last_updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "full_text" : {
+                  "type" : "string"
+                },
+                "startTime" : {
+                  "type" : "string"
+                },
+                "startTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "likeCount" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "eventid" : {
+                        "type" : "integer"
+                      },
+                      "num" : {
+                        "type" : "integer"
+                      },
+                      "test" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Events($id: Long!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEvents(id: $id, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
@@ -846,6 +923,83 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "date" : {
+                  "type" : "string"
+                },
+                "time" : {
+                  "type" : "string"
+                },
+                "title" : {
+                  "type" : "string"
+                },
+                "abstract" : {
+                  "type" : "string"
+                },
+                "location" : {
+                  "type" : "string"
+                },
+                "speakers" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "title" : {
+                        "type" : "string"
+                      },
+                      "company" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "last_updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "full_text" : {
+                  "type" : "string"
+                },
+                "startTime" : {
+                  "type" : "string"
+                },
+                "startTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "likeCount" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "eventid" : {
+                        "type" : "integer"
+                      },
+                      "num" : {
+                        "type" : "integer"
+                      },
+                      "test" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query EventsLiked($userid: String!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEventsLiked(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
@@ -881,6 +1035,69 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "date" : {
+                  "type" : "string"
+                },
+                "time" : {
+                  "type" : "string"
+                },
+                "title" : {
+                  "type" : "string"
+                },
+                "abstract" : {
+                  "type" : "string"
+                },
+                "location" : {
+                  "type" : "string"
+                },
+                "speakers" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "title" : {
+                        "type" : "string"
+                      },
+                      "company" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "last_updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "full_text" : {
+                  "type" : "string"
+                },
+                "startTime" : {
+                  "type" : "string"
+                },
+                "startTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "score" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query PersonalizedEventSearch($query: String!, $userid: String!, $limit: Int = 10, $offset: Int = 0) {\nPersonalizedEventSearch(query: $query, userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
@@ -910,6 +1127,69 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               "required" : [
                 "userid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "date" : {
+                  "type" : "string"
+                },
+                "time" : {
+                  "type" : "string"
+                },
+                "title" : {
+                  "type" : "string"
+                },
+                "abstract" : {
+                  "type" : "string"
+                },
+                "location" : {
+                  "type" : "string"
+                },
+                "speakers" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "title" : {
+                        "type" : "string"
+                      },
+                      "company" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "last_updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "full_text" : {
+                  "type" : "string"
+                },
+                "startTime" : {
+                  "type" : "string"
+                },
+                "startTimestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "score" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
@@ -809,6 +809,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -886,7 +887,6 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Events($id: Long!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEvents(id: $id, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
             "queryName" : "Events",
@@ -923,6 +923,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1000,7 +1001,6 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query EventsLiked($userid: String!, $limit: Int = 10, $offset: Int = 0$likeCount_limit: Int = 10, $likeCount_offset: Int = 0) {\nEventsLiked(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nlikeCount(limit: $likeCount_limit, offset: $likeCount_offset) {\neventid\nnum\ntest\n}\n}\n\n}",
             "queryName" : "EventsLiked",
@@ -1035,6 +1035,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1098,7 +1099,6 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query PersonalizedEventSearch($query: String!, $userid: String!, $limit: Int = 10, $offset: Int = 0) {\nPersonalizedEventSearch(query: $query, userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
             "queryName" : "PersonalizedEventSearch",
@@ -1129,6 +1129,7 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1192,7 +1193,6 @@ CREATE INDEX IF NOT EXISTS "Events_text_c3c4" ON "Events" USING GIN (to_tsvector
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query RecommendedEvents($userid: String!, $limit: Int = 10, $offset: Int = 0) {\nRecommendedEvents(userid: $userid, limit: $limit, offset: $offset) {\nurl\ndate\ntime\ntitle\nabstract\nlocation\nspeakers {\nname\ntitle\ncompany\n}\nlast_updated\nid\nfull_text\nstartTime\nstartTimestamp\nscore\n}\n\n}",
             "queryName" : "RecommendedEvents",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
@@ -543,6 +543,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -557,7 +558,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query iceberg_parquet_table($limit: Int = 10, $offset: Int = 0) {\niceberg_parquet_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "iceberg_parquet_table",
@@ -583,6 +583,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -597,7 +598,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_avro_table($limit: Int = 10, $offset: Int = 0) {\nkafka_avro_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "kafka_avro_table",
@@ -623,6 +623,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -637,7 +638,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_debezium_table($limit: Int = 10, $offset: Int = 0) {\nkafka_debezium_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "kafka_debezium_table",
@@ -663,6 +663,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -677,7 +678,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_safe_csv_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_csv_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "kafka_safe_csv_table",
@@ -703,6 +703,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -717,7 +718,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_safe_json_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_json_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "kafka_safe_json_table",
@@ -743,6 +743,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -757,7 +758,6 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query upsert_kafka_confluent_avro($limit: Int = 10, $offset: Int = 0) {\nupsert_kafka_confluent_avro(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
             "queryName" : "upsert_kafka_confluent_avro",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
@@ -543,8 +543,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query iceberg_parquet_table($limit: Int = 10, $offset: Int = 0) {\niceberg_parquet_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "iceberg_parquet_table",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/iceberg_parquet_table{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -557,15 +565,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query iceberg_parquet_table($limit: Int = 10, $offset: Int = 0) {\niceberg_parquet_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "iceberg_parquet_table",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/iceberg_parquet_table{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -583,8 +583,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query kafka_avro_table($limit: Int = 10, $offset: Int = 0) {\nkafka_avro_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "kafka_avro_table",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/kafka_avro_table{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -597,15 +605,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query kafka_avro_table($limit: Int = 10, $offset: Int = 0) {\nkafka_avro_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "kafka_avro_table",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/kafka_avro_table{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -623,8 +623,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query kafka_debezium_table($limit: Int = 10, $offset: Int = 0) {\nkafka_debezium_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "kafka_debezium_table",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/kafka_debezium_table{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -637,15 +645,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query kafka_debezium_table($limit: Int = 10, $offset: Int = 0) {\nkafka_debezium_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "kafka_debezium_table",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/kafka_debezium_table{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -663,8 +663,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query kafka_safe_csv_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_csv_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "kafka_safe_csv_table",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/kafka_safe_csv_table{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -677,15 +685,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query kafka_safe_csv_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_csv_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "kafka_safe_csv_table",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/kafka_safe_csv_table{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -703,8 +703,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query kafka_safe_json_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_json_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "kafka_safe_json_table",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/kafka_safe_json_table{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -717,15 +725,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query kafka_safe_json_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_json_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "kafka_safe_json_table",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/kafka_safe_json_table{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -743,8 +743,16 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query upsert_kafka_confluent_avro($limit: Int = 10, $offset: Int = 0) {\nupsert_kafka_confluent_avro(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
+            "queryName" : "upsert_kafka_confluent_avro",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/upsert_kafka_confluent_avro{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -757,15 +765,7 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query upsert_kafka_confluent_avro($limit: Int = 10, $offset: Int = 0) {\nupsert_kafka_confluent_avro(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
-            "queryName" : "upsert_kafka_confluent_avro",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/upsert_kafka_confluent_avro{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
@@ -543,6 +543,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query iceberg_parquet_table($limit: Int = 10, $offset: Int = 0) {\niceberg_parquet_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
@@ -567,6 +581,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -595,6 +623,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_debezium_table($limit: Int = 10, $offset: Int = 0) {\nkafka_debezium_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
@@ -619,6 +661,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -647,6 +703,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query kafka_safe_json_table($limit: Int = 10, $offset: Int = 0) {\nkafka_safe_json_table(limit: $limit, offset: $offset) {\nuser_id\nname\n}\n\n}",
@@ -671,6 +741,20 @@ CREATE TABLE IF NOT EXISTS "upsert_kafka_confluent_avro" ("user_id" INTEGER NOT 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "user_id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
@@ -409,6 +409,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -423,7 +424,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable1",
@@ -449,6 +449,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -463,7 +464,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable2",
@@ -489,6 +489,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -503,7 +504,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable3",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
@@ -409,6 +409,20 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
@@ -435,6 +449,20 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
@@ -459,6 +487,20 @@ FROM "_MyApplications2"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
@@ -409,8 +409,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable1{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -423,15 +431,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -449,8 +449,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable2{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -463,15 +471,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -489,8 +489,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable3{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -503,15 +511,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable3{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
@@ -407,8 +407,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable1",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable1{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -421,15 +429,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable1",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable1{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -447,8 +447,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable2",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable2{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -461,15 +469,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable2",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable2{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -487,8 +487,16 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
+            "queryName" : "MyTable3",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable3{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -501,15 +509,7 @@ FROM "_MyApplications2"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
-            "queryName" : "MyTable3",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable3{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
@@ -407,6 +407,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -421,7 +422,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable1",
@@ -447,6 +447,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -461,7 +462,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable2",
@@ -487,6 +487,7 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -501,7 +502,6 @@ FROM "_MyApplications2"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable3($limit: Int = 10, $offset: Int = 0) {\nMyTable3(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
             "queryName" : "MyTable3",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
@@ -407,6 +407,20 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable1($limit: Int = 10, $offset: Int = 0) {\nMyTable1(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
@@ -433,6 +447,20 @@ FROM "_MyApplications2"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable2($limit: Int = 10, $offset: Int = 0) {\nMyTable2(limit: $limit, offset: $offset) {\nid\nhello\n}\n\n}",
@@ -457,6 +485,20 @@ FROM "_MyApplications2"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "hello" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
@@ -261,8 +261,16 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query DistinctOrders($limit: Int = 10, $offset: Int = 0) {\nDistinctOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
+            "queryName" : "DistinctOrders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DistinctOrders{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -288,15 +296,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query DistinctOrders($limit: Int = 10, $offset: Int = 0) {\nDistinctOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
-            "queryName" : "DistinctOrders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DistinctOrders{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -314,8 +314,16 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -341,15 +349,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
@@ -261,6 +261,33 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "unit_price" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctOrders($limit: Int = 10, $offset: Int = 0) {\nDistinctOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
@@ -285,6 +312,33 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "unit_price" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
@@ -261,6 +261,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -288,7 +289,6 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query DistinctOrders($limit: Int = 10, $offset: Int = 0) {\nDistinctOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
             "queryName" : "DistinctOrders",
@@ -314,6 +314,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -341,7 +342,6 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
             "queryName" : "Orders",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
@@ -479,6 +479,23 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "listagg_example" : {
+                  "type" : "string"
+                },
+                "arrayagg_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
@@ -503,6 +520,391 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "log2_example" : {
+                  "type" : "number"
+                },
+                "log_nat_example" : {
+                  "type" : "number"
+                },
+                "log_base_example" : {
+                  "type" : "number"
+                },
+                "e_example" : {
+                  "type" : "number"
+                },
+                "rand_example" : {
+                  "type" : "boolean"
+                },
+                "rand_int_example" : {
+                  "type" : "boolean"
+                },
+                "uuid_example" : {
+                  "type" : "boolean"
+                },
+                "bin_example" : {
+                  "type" : "string"
+                },
+                "hex_numeric_example" : {
+                  "type" : "string"
+                },
+                "hex_string_example" : {
+                  "type" : "string"
+                },
+                "truncate_scale_example" : {
+                  "type" : "number"
+                },
+                "truncate_default_example" : {
+                  "type" : "number"
+                },
+                "printf_example" : {
+                  "type" : "string"
+                },
+                "startswith_example" : {
+                  "type" : "boolean"
+                },
+                "endswith_example" : {
+                  "type" : "boolean"
+                },
+                "substring_example" : {
+                  "type" : "string"
+                },
+                "substr_example" : {
+                  "type" : "string"
+                },
+                "regexp_extract_example" : {
+                  "type" : "string"
+                },
+                "regexp_extract_group_example" : {
+                  "type" : "string"
+                },
+                "regexp_extract_all_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "regexp_replace_example" : {
+                  "type" : "string"
+                },
+                "regexp_count_example" : {
+                  "type" : "integer"
+                },
+                "regexp_instr_example" : {
+                  "type" : "integer"
+                },
+                "decode_example" : {
+                  "type" : "string"
+                },
+                "encode_example" : {
+                  "type" : "boolean"
+                },
+                "from_base64_example" : {
+                  "type" : "string"
+                },
+                "to_base64_example" : {
+                  "type" : "string"
+                },
+                "instr_example" : {
+                  "type" : "integer"
+                },
+                "locate_example" : {
+                  "type" : "integer"
+                },
+                "regexp_example" : {
+                  "type" : "boolean"
+                },
+                "split_index_example" : {
+                  "type" : "string"
+                },
+                "json_quote_example" : {
+                  "type" : "string"
+                },
+                "json_object_kv_example" : {
+                  "type" : "string"
+                },
+                "elt_example" : {
+                  "type" : "string"
+                },
+                "try_cast_to_int_example" : {
+                  "type" : "integer"
+                },
+                "try_cast_to_bigint_example" : {
+                  "type" : "integer"
+                },
+                "try_cast_to_bool_example" : {
+                  "type" : "boolean"
+                },
+                "try_cast_to_text_example" : {
+                  "type" : "string"
+                },
+                "try_cast_to_decimal_example" : {
+                  "type" : "number"
+                },
+                "try_cast_to_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "try_cast_to_timestamptz_example" : {
+                  "type" : "boolean"
+                },
+                "try_cast_fail_example" : {
+                  "type" : "integer"
+                },
+                "try_cast_timestampdiff_decimal_example" : {
+                  "type" : "number"
+                },
+                "cast_timestampdiff_decimal_example" : {
+                  "type" : "number"
+                },
+                "case_timestampdiff_nullif_example" : {
+                  "type" : "number"
+                },
+                "now_example" : {
+                  "type" : "boolean"
+                },
+                "local_time_example" : {
+                  "type" : "boolean"
+                },
+                "local_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "current_time_example" : {
+                  "type" : "boolean"
+                },
+                "current_date_example" : {
+                  "type" : "boolean"
+                },
+                "current_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "year_example" : {
+                  "type" : "integer"
+                },
+                "quarter_example" : {
+                  "type" : "integer"
+                },
+                "month_example" : {
+                  "type" : "integer"
+                },
+                "week_example" : {
+                  "type" : "integer"
+                },
+                "dayofyear_example" : {
+                  "type" : "integer"
+                },
+                "dayofmonth_example" : {
+                  "type" : "integer"
+                },
+                "dayofweek_example" : {
+                  "type" : "integer"
+                },
+                "hour_example" : {
+                  "type" : "integer"
+                },
+                "minute_example" : {
+                  "type" : "integer"
+                },
+                "second_example" : {
+                  "type" : "integer"
+                },
+                "date_format_example" : {
+                  "type" : "string"
+                },
+                "date_format_replace_t_space_pattern_example" : {
+                  "type" : "string"
+                },
+                "date_format_empty_example" : {
+                  "type" : "string"
+                },
+                "date_format_blank_example" : {
+                  "type" : "string"
+                },
+                "date_format_invalid_example" : {
+                  "type" : "string"
+                },
+                "date_format_null_example" : {
+                  "type" : "string"
+                },
+                "timestampadd_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "timestampdiff_second_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_minute_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_hour_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_day_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_week_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_month_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_quarter_example" : {
+                  "type" : "integer"
+                },
+                "timestampdiff_year_example" : {
+                  "type" : "integer"
+                },
+                "convert_tz_example" : {
+                  "type" : "string"
+                },
+                "unix_timestamp_now_example" : {
+                  "type" : "boolean"
+                },
+                "to_timestamp_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_escaped_t_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_replace_t_space_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_replace_t_space_cast_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_invalid_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_invalid_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_empty_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_empty_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_blank_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_blank_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_null_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "to_timestamp_null_pattern_example" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "if_example" : {
+                  "type" : "string"
+                },
+                "ifnull_example" : {
+                  "type" : "string"
+                },
+                "is_alpha_example" : {
+                  "type" : "boolean"
+                },
+                "is_decimal_example" : {
+                  "type" : "boolean"
+                },
+                "is_digit_example" : {
+                  "type" : "boolean"
+                },
+                "element_example" : {
+                  "type" : "integer"
+                },
+                "cardinality_example" : {
+                  "type" : "integer"
+                },
+                "map_index_example" : {
+                  "type" : "integer"
+                },
+                "array_contains_example" : {
+                  "type" : "boolean"
+                },
+                "array_distinct_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_prepend_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_slice_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_concat_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_remove_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_remove_null_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_remove_null_cast_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_join_example" : {
+                  "type" : "string"
+                },
+                "split_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "sha1_example" : {
+                  "type" : "string"
+                },
+                "sha256_example" : {
+                  "type" : "string"
+                },
+                "the_end" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
@@ -479,8 +479,16 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
+            "queryName" : "ArrayFunctions",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ArrayFunctions{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -496,15 +504,7 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
-            "queryName" : "ArrayFunctions",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ArrayFunctions{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -522,8 +522,16 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nsubstring_example\nsubstr_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_replace_example\nregexp_count_example\nregexp_instr_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nlocate_example\nregexp_example\nsplit_index_example\njson_quote_example\njson_object_kv_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\ntry_cast_fail_example\ntry_cast_timestampdiff_decimal_example\ncast_timestampdiff_decimal_example\ncase_timestampdiff_nullif_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\ndate_format_example\ndate_format_replace_t_space_pattern_example\ndate_format_empty_example\ndate_format_blank_example\ndate_format_invalid_example\ndate_format_null_example\ntimestampadd_example\ntimestampdiff_second_example\ntimestampdiff_minute_example\ntimestampdiff_hour_example\ntimestampdiff_day_example\ntimestampdiff_week_example\ntimestampdiff_month_example\ntimestampdiff_quarter_example\ntimestampdiff_year_example\nconvert_tz_example\nunix_timestamp_now_example\nto_timestamp_example\nto_timestamp_pattern_example\nto_timestamp_escaped_t_pattern_example\nto_timestamp_replace_t_space_pattern_example\nto_timestamp_replace_t_space_cast_example\nto_timestamp_invalid_example\nto_timestamp_invalid_pattern_example\nto_timestamp_empty_example\nto_timestamp_empty_pattern_example\nto_timestamp_blank_example\nto_timestamp_blank_pattern_example\nto_timestamp_null_example\nto_timestamp_null_pattern_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\ncardinality_example\nmap_index_example\narray_contains_example\narray_distinct_example\narray_prepend_example\narray_slice_example\narray_concat_example\narray_remove_example\narray_remove_null_example\narray_remove_null_cast_example\narray_join_example\nsplit_example\nsha1_example\nsha256_example\nthe_end\n}\n\n}",
+            "queryName" : "FunctionCalls",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FunctionCalls{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -907,15 +915,7 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nsubstring_example\nsubstr_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_replace_example\nregexp_count_example\nregexp_instr_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nlocate_example\nregexp_example\nsplit_index_example\njson_quote_example\njson_object_kv_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\ntry_cast_fail_example\ntry_cast_timestampdiff_decimal_example\ncast_timestampdiff_decimal_example\ncase_timestampdiff_nullif_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\ndate_format_example\ndate_format_replace_t_space_pattern_example\ndate_format_empty_example\ndate_format_blank_example\ndate_format_invalid_example\ndate_format_null_example\ntimestampadd_example\ntimestampdiff_second_example\ntimestampdiff_minute_example\ntimestampdiff_hour_example\ntimestampdiff_day_example\ntimestampdiff_week_example\ntimestampdiff_month_example\ntimestampdiff_quarter_example\ntimestampdiff_year_example\nconvert_tz_example\nunix_timestamp_now_example\nto_timestamp_example\nto_timestamp_pattern_example\nto_timestamp_escaped_t_pattern_example\nto_timestamp_replace_t_space_pattern_example\nto_timestamp_replace_t_space_cast_example\nto_timestamp_invalid_example\nto_timestamp_invalid_pattern_example\nto_timestamp_empty_example\nto_timestamp_empty_pattern_example\nto_timestamp_blank_example\nto_timestamp_blank_pattern_example\nto_timestamp_null_example\nto_timestamp_null_pattern_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\ncardinality_example\nmap_index_example\narray_contains_example\narray_distinct_example\narray_prepend_example\narray_slice_example\narray_concat_example\narray_remove_example\narray_remove_null_example\narray_remove_null_cast_example\narray_join_example\nsplit_example\nsha1_example\nsha256_example\nthe_end\n}\n\n}",
-            "queryName" : "FunctionCalls",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FunctionCalls{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-duckdb-package.txt
@@ -479,6 +479,7 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -496,7 +497,6 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
             "queryName" : "ArrayFunctions",
@@ -522,6 +522,7 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -907,7 +908,6 @@ CREATE TABLE IF NOT EXISTS "_InputData" ("dummy" INTEGER)
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nsubstring_example\nsubstr_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_replace_example\nregexp_count_example\nregexp_instr_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nlocate_example\nregexp_example\nsplit_index_example\njson_quote_example\njson_object_kv_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\ntry_cast_fail_example\ntry_cast_timestampdiff_decimal_example\ncast_timestampdiff_decimal_example\ncase_timestampdiff_nullif_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\ndate_format_example\ndate_format_replace_t_space_pattern_example\ndate_format_empty_example\ndate_format_blank_example\ndate_format_invalid_example\ndate_format_null_example\ntimestampadd_example\ntimestampdiff_second_example\ntimestampdiff_minute_example\ntimestampdiff_hour_example\ntimestampdiff_day_example\ntimestampdiff_week_example\ntimestampdiff_month_example\ntimestampdiff_quarter_example\ntimestampdiff_year_example\nconvert_tz_example\nunix_timestamp_now_example\nto_timestamp_example\nto_timestamp_pattern_example\nto_timestamp_escaped_t_pattern_example\nto_timestamp_replace_t_space_pattern_example\nto_timestamp_replace_t_space_cast_example\nto_timestamp_invalid_example\nto_timestamp_invalid_pattern_example\nto_timestamp_empty_example\nto_timestamp_empty_pattern_example\nto_timestamp_blank_example\nto_timestamp_blank_pattern_example\nto_timestamp_null_example\nto_timestamp_null_pattern_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\ncardinality_example\nmap_index_example\narray_contains_example\narray_distinct_example\narray_prepend_example\narray_slice_example\narray_concat_example\narray_remove_example\narray_remove_null_example\narray_remove_null_cast_example\narray_join_example\nsplit_example\nsha1_example\nsha256_example\nthe_end\n}\n\n}",
             "queryName" : "FunctionCalls",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
@@ -372,6 +372,23 @@ FROM "_InputData"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "listagg_example" : {
+                  "type" : "string"
+                },
+                "arrayagg_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
@@ -396,6 +413,245 @@ FROM "_InputData"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "log2_example" : {
+                  "type" : "number"
+                },
+                "log_nat_example" : {
+                  "type" : "number"
+                },
+                "log_base_example" : {
+                  "type" : "number"
+                },
+                "e_example" : {
+                  "type" : "number"
+                },
+                "rand_example" : {
+                  "type" : "boolean"
+                },
+                "rand_int_example" : {
+                  "type" : "boolean"
+                },
+                "uuid_example" : {
+                  "type" : "boolean"
+                },
+                "bin_example" : {
+                  "type" : "string"
+                },
+                "hex_numeric_example" : {
+                  "type" : "string"
+                },
+                "hex_string_example" : {
+                  "type" : "string"
+                },
+                "truncate_scale_example" : {
+                  "type" : "number"
+                },
+                "truncate_default_example" : {
+                  "type" : "number"
+                },
+                "printf_example" : {
+                  "type" : "string"
+                },
+                "startswith_example" : {
+                  "type" : "boolean"
+                },
+                "endswith_example" : {
+                  "type" : "boolean"
+                },
+                "regexp_extract_example" : {
+                  "type" : "string"
+                },
+                "regexp_extract_group_example" : {
+                  "type" : "string"
+                },
+                "regexp_extract_all_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "regexp_extract_all_group_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "decode_example" : {
+                  "type" : "string"
+                },
+                "encode_example" : {
+                  "type" : "boolean"
+                },
+                "from_base64_example" : {
+                  "type" : "string"
+                },
+                "to_base64_example" : {
+                  "type" : "string"
+                },
+                "instr_example" : {
+                  "type" : "integer"
+                },
+                "regexp_example" : {
+                  "type" : "boolean"
+                },
+                "split_index_example" : {
+                  "type" : "string"
+                },
+                "split_index_expr_example" : {
+                  "type" : "string"
+                },
+                "elt_example" : {
+                  "type" : "string"
+                },
+                "try_cast_to_int_example" : {
+                  "type" : "integer"
+                },
+                "try_cast_to_bigint_example" : {
+                  "type" : "integer"
+                },
+                "try_cast_to_bool_example" : {
+                  "type" : "boolean"
+                },
+                "try_cast_to_text_example" : {
+                  "type" : "string"
+                },
+                "try_cast_to_decimal_example" : {
+                  "type" : "number"
+                },
+                "try_cast_to_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "try_cast_to_timestamptz_example" : {
+                  "type" : "boolean"
+                },
+                "now_example" : {
+                  "type" : "boolean"
+                },
+                "local_time_example" : {
+                  "type" : "boolean"
+                },
+                "local_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "current_time_example" : {
+                  "type" : "boolean"
+                },
+                "current_date_example" : {
+                  "type" : "boolean"
+                },
+                "current_timestamp_example" : {
+                  "type" : "boolean"
+                },
+                "year_example" : {
+                  "type" : "integer"
+                },
+                "quarter_example" : {
+                  "type" : "integer"
+                },
+                "month_example" : {
+                  "type" : "integer"
+                },
+                "week_example" : {
+                  "type" : "integer"
+                },
+                "dayofyear_example" : {
+                  "type" : "integer"
+                },
+                "dayofmonth_example" : {
+                  "type" : "integer"
+                },
+                "dayofweek_example" : {
+                  "type" : "integer"
+                },
+                "hour_example" : {
+                  "type" : "integer"
+                },
+                "minute_example" : {
+                  "type" : "integer"
+                },
+                "second_example" : {
+                  "type" : "integer"
+                },
+                "convert_tz_example" : {
+                  "type" : "string"
+                },
+                "unix_timestamp_now_example" : {
+                  "type" : "boolean"
+                },
+                "if_example" : {
+                  "type" : "string"
+                },
+                "ifnull_example" : {
+                  "type" : "string"
+                },
+                "is_alpha_example" : {
+                  "type" : "boolean"
+                },
+                "is_decimal_example" : {
+                  "type" : "boolean"
+                },
+                "is_digit_example" : {
+                  "type" : "boolean"
+                },
+                "element_example" : {
+                  "type" : "integer"
+                },
+                "array_contains_example" : {
+                  "type" : "boolean"
+                },
+                "array_prepend_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_concat_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_remove_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "array_join_example" : {
+                  "type" : "string"
+                },
+                "split_example" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "sha1_example" : {
+                  "type" : "string"
+                },
+                "sha224_example" : {
+                  "type" : "string"
+                },
+                "sha256_example" : {
+                  "type" : "string"
+                },
+                "sha384_example" : {
+                  "type" : "string"
+                },
+                "sha512_example" : {
+                  "type" : "string"
+                },
+                "the_end" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
@@ -372,8 +372,16 @@ FROM "_InputData"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
+            "queryName" : "ArrayFunctions",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ArrayFunctions{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -389,15 +397,7 @@ FROM "_InputData"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
-            "queryName" : "ArrayFunctions",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ArrayFunctions{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -415,8 +415,16 @@ FROM "_InputData"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_extract_all_group_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nregexp_example\nsplit_index_example\nsplit_index_expr_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\nconvert_tz_example\nunix_timestamp_now_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\narray_contains_example\narray_prepend_example\narray_concat_example\narray_remove_example\narray_join_example\nsplit_example\nsha1_example\nsha224_example\nsha256_example\nsha384_example\nsha512_example\nthe_end\n}\n\n}",
+            "queryName" : "FunctionCalls",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FunctionCalls{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -654,15 +662,7 @@ FROM "_InputData"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_extract_all_group_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nregexp_example\nsplit_index_example\nsplit_index_expr_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\nconvert_tz_example\nunix_timestamp_now_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\narray_contains_example\narray_prepend_example\narray_concat_example\narray_remove_example\narray_join_example\nsplit_example\nsha1_example\nsha224_example\nsha256_example\nsha384_example\nsha512_example\nthe_end\n}\n\n}",
-            "queryName" : "FunctionCalls",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FunctionCalls{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
@@ -372,6 +372,7 @@ FROM "_InputData"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -389,7 +390,6 @@ FROM "_InputData"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ArrayFunctions($limit: Int = 10, $offset: Int = 0) {\nArrayFunctions(limit: $limit, offset: $offset) {\nlistagg_example\narrayagg_example\n}\n\n}",
             "queryName" : "ArrayFunctions",
@@ -415,6 +415,7 @@ FROM "_InputData"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -654,7 +655,6 @@ FROM "_InputData"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query FunctionCalls($limit: Int = 10, $offset: Int = 0) {\nFunctionCalls(limit: $limit, offset: $offset) {\nlog2_example\nlog_nat_example\nlog_base_example\ne_example\nrand_example\nrand_int_example\nuuid_example\nbin_example\nhex_numeric_example\nhex_string_example\ntruncate_scale_example\ntruncate_default_example\nprintf_example\nstartswith_example\nendswith_example\nregexp_extract_example\nregexp_extract_group_example\nregexp_extract_all_example\nregexp_extract_all_group_example\ndecode_example\nencode_example\nfrom_base64_example\nto_base64_example\ninstr_example\nregexp_example\nsplit_index_example\nsplit_index_expr_example\nelt_example\ntry_cast_to_int_example\ntry_cast_to_bigint_example\ntry_cast_to_bool_example\ntry_cast_to_text_example\ntry_cast_to_decimal_example\ntry_cast_to_timestamp_example\ntry_cast_to_timestamptz_example\nnow_example\nlocal_time_example\nlocal_timestamp_example\ncurrent_time_example\ncurrent_date_example\ncurrent_timestamp_example\nyear_example\nquarter_example\nmonth_example\nweek_example\ndayofyear_example\ndayofmonth_example\ndayofweek_example\nhour_example\nminute_example\nsecond_example\nconvert_tz_example\nunix_timestamp_now_example\nif_example\nifnull_example\nis_alpha_example\nis_decimal_example\nis_digit_example\nelement_example\narray_contains_example\narray_prepend_example\narray_concat_example\narray_remove_example\narray_join_example\nsplit_example\nsha1_example\nsha224_example\nsha256_example\nsha384_example\nsha512_example\nthe_end\n}\n\n}",
             "queryName" : "FunctionCalls",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
@@ -346,8 +346,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyStringTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyStringTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -357,15 +365,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyStringTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyStringTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -383,8 +383,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -394,15 +402,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -420,8 +420,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthMyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthMyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -431,15 +439,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthMyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthMyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -457,8 +457,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthMyTableValues",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthMyTableValues{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -468,15 +476,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthMyTableValues",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthMyTableValues{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -494,8 +494,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthStringMyTableValues",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthStringMyTableValues{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -505,15 +513,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthStringMyTableValues",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthStringMyTableValues{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
@@ -346,6 +346,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -370,6 +381,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -398,6 +420,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -424,6 +457,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -448,6 +492,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
@@ -346,6 +346,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -357,7 +358,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyStringTable",
@@ -383,6 +383,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -394,7 +395,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyTable",
@@ -420,6 +420,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -431,7 +432,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthMyTable",
@@ -457,6 +457,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -468,7 +469,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthMyTableValues",
@@ -494,6 +494,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -505,7 +506,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthStringMyTableValues",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -526,6 +526,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -537,7 +538,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyStringTable",
@@ -563,6 +563,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -574,7 +575,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyTable",
@@ -600,6 +600,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -611,7 +612,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthMyTable",
@@ -637,6 +637,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -648,7 +649,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthMyTableValues",
@@ -674,6 +674,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -685,7 +686,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthStringMyTableValues",
@@ -706,6 +706,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -722,7 +723,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation AuthInputData($payload: JSON) {\nAuthInputData(event: { payload: $payload }) {\nevent_id\nval\npayload\nevent_time\n}\n\n}",
             "queryName" : "AuthInputData",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -526,6 +526,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -550,6 +561,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -578,6 +600,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -602,6 +635,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -630,6 +674,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -649,6 +704,22 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 "payload" : { }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "event_id" : {
+                "type" : "string"
+              },
+              "val" : {
+                "type" : "integer"
+              },
+              "payload" : { },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -526,8 +526,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyStringTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyStringTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -537,15 +545,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyStringTable($limit: Int = 10, $offset: Int = 0) {\nMyStringTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyStringTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyStringTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -563,8 +563,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -574,15 +582,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -600,8 +600,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthMyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthMyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -611,15 +619,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthMyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthMyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -637,8 +637,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthMyTableValues",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthMyTableValues{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -648,15 +656,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthMyTableValues",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthMyTableValues{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -674,8 +674,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthStringMyTableValues",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthStringMyTableValues{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -685,15 +693,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthStringMyTableValues($limit: Int = 10, $offset: Int = 0) {\nAuthStringMyTableValues(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthStringMyTableValues",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthStringMyTableValues{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -706,8 +706,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation AuthInputData($payload: JSON) {\nAuthInputData(event: { payload: $payload }) {\nevent_id\nval\npayload\nevent_time\n}\n\n}",
+            "queryName" : "AuthInputData",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/AuthInputData",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "event_id" : {
@@ -722,15 +730,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation AuthInputData($payload: JSON) {\nAuthInputData(event: { payload: $payload }) {\nevent_id\nval\npayload\nevent_time\n}\n\n}",
-            "queryName" : "AuthInputData",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/AuthInputData"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
@@ -186,6 +186,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -210,6 +221,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
@@ -186,6 +186,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -197,7 +198,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyTable",
@@ -223,6 +223,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -234,7 +235,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "AuthMyTable",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
@@ -186,8 +186,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -197,15 +205,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -223,8 +223,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "AuthMyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AuthMyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -234,15 +242,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AuthMyTable($limit: Int = 10, $offset: Int = 0) {\nAuthMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "AuthMyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AuthMyTable{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
@@ -133,6 +133,20 @@ CREATE TABLE IF NOT EXISTS "FunctionApplied" ("id" INTEGER NOT NULL, "fct_result
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "fct_result" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query FunctionApplied($limit: Int = 10, $offset: Int = 0) {\nFunctionApplied(limit: $limit, offset: $offset) {\nid\nfct_result\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
@@ -133,8 +133,16 @@ CREATE TABLE IF NOT EXISTS "FunctionApplied" ("id" INTEGER NOT NULL, "fct_result
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query FunctionApplied($limit: Int = 10, $offset: Int = 0) {\nFunctionApplied(limit: $limit, offset: $offset) {\nid\nfct_result\n}\n\n}",
+            "queryName" : "FunctionApplied",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FunctionApplied{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -147,15 +155,7 @@ CREATE TABLE IF NOT EXISTS "FunctionApplied" ("id" INTEGER NOT NULL, "fct_result
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query FunctionApplied($limit: Int = 10, $offset: Int = 0) {\nFunctionApplied(limit: $limit, offset: $offset) {\nid\nfct_result\n}\n\n}",
-            "queryName" : "FunctionApplied",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FunctionApplied{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
@@ -133,6 +133,7 @@ CREATE TABLE IF NOT EXISTS "FunctionApplied" ("id" INTEGER NOT NULL, "fct_result
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -147,7 +148,6 @@ CREATE TABLE IF NOT EXISTS "FunctionApplied" ("id" INTEGER NOT NULL, "fct_result
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query FunctionApplied($limit: Int = 10, $offset: Int = 0) {\nFunctionApplied(limit: $limit, offset: $offset) {\nid\nfct_result\n}\n\n}",
             "queryName" : "FunctionApplied",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
@@ -190,8 +190,16 @@ CREATE TABLE IF NOT EXISTS "FooOut" ("id" INTEGER NOT NULL, "label" TEXT, PRIMAR
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query FooOut($limit: Int = 10, $offset: Int = 0) {\nFooOut(limit: $limit, offset: $offset) {\nid\nlabel\n}\n\n}",
+            "queryName" : "FooOut",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FooOut{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -204,15 +212,7 @@ CREATE TABLE IF NOT EXISTS "FooOut" ("id" INTEGER NOT NULL, "label" TEXT, PRIMAR
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query FooOut($limit: Int = 10, $offset: Int = 0) {\nFooOut(limit: $limit, offset: $offset) {\nid\nlabel\n}\n\n}",
-            "queryName" : "FooOut",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/FooOut{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
@@ -191,6 +191,20 @@ CREATE TABLE IF NOT EXISTS "FooOut" ("id" INTEGER NOT NULL, "label" TEXT, PRIMAR
             }
           },
           "format" : "JSON",
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "label" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "apiQuery" : {
             "query" : "query FooOut($limit: Int = 10, $offset: Int = 0) {\nFooOut(limit: $limit, offset: $offset) {\nid\nlabel\n}\n\n}",
             "queryName" : "FooOut",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
@@ -219,6 +219,7 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -246,7 +247,6 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
             "queryName" : "Product",
@@ -275,6 +275,7 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -302,7 +303,6 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Discount($discount: Int, $limit: Int = 10, $offset: Int = 0) {\nDiscount(discount: $discount, limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
             "queryName" : "Discount",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
@@ -219,6 +219,33 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "price" : {
+                  "type" : "number"
+                },
+                "discount" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
@@ -246,6 +273,33 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "price" : {
+                  "type" : "number"
+                },
+                "discount" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
@@ -219,8 +219,16 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
+            "queryName" : "Product",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Product{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -246,15 +254,7 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Product($limit: Int = 10, $offset: Int = 0) {\nProduct(limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
-            "queryName" : "Product",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Product{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -275,8 +275,16 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Discount($discount: Int, $limit: Int = 10, $offset: Int = 0) {\nDiscount(discount: $discount, limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
+            "queryName" : "Discount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Discount{?offset,limit,discount}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -302,15 +310,7 @@ CREATE INDEX IF NOT EXISTS "Product_hash_c4" ON "Product" USING hash ("discount"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Discount($discount: Int, $limit: Int = 10, $offset: Int = 0) {\nDiscount(discount: $discount, limit: $limit, offset: $offset) {\nid\nname\ncategory\nprice\ndiscount\ntimestamp\n}\n\n}",
-            "queryName" : "Discount",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Discount{?offset,limit,discount}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
@@ -187,6 +187,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -216,6 +227,17 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [
                 "maxResults"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
@@ -187,8 +187,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -198,15 +206,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -229,8 +229,16 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTableQuery($maxResults: Int!, $limit: Int = 10, $offset: Int = 0) {\nMyTableQuery(maxResults: $maxResults, limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "MyTableQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTableQuery{?offset,maxResults,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -240,15 +248,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTableQuery($maxResults: Int!, $limit: Int = 10, $offset: Int = 0) {\nMyTableQuery(maxResults: $maxResults, limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "MyTableQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTableQuery{?offset,maxResults,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
@@ -187,6 +187,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -198,7 +199,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyTable",
@@ -229,6 +229,7 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -240,7 +241,6 @@ CREATE TABLE IF NOT EXISTS "MyTable" ("val" INTEGER NOT NULL, PRIMARY KEY ("val"
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTableQuery($maxResults: Int!, $limit: Int = 10, $offset: Int = 0) {\nMyTableQuery(maxResults: $maxResults, limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "MyTableQuery",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
@@ -361,8 +361,16 @@ CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("manag
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Employees($employeeid: Long, $name: String, $limit: Int = 10, $offset: Int = 0$allReports_limit: Int = 10, $allReports_offset: Int = 0) {\nEmployees(employeeid: $employeeid, name: $name, limit: $limit, offset: $offset) {\nemployeeid\nname\nemail\nupdatedDate\nallReports(limit: $allReports_limit, offset: $allReports_offset) {\nemployeeid\nname\nlevel\n}\n}\n\n}",
+            "queryName" : "Employees",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Employees{?allReports_limit,offset,name,limit,employeeid,allReports_offset}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -400,15 +408,7 @@ CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("manag
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Employees($employeeid: Long, $name: String, $limit: Int = 10, $offset: Int = 0$allReports_limit: Int = 10, $allReports_offset: Int = 0) {\nEmployees(employeeid: $employeeid, name: $name, limit: $limit, offset: $offset) {\nemployeeid\nname\nemail\nupdatedDate\nallReports(limit: $allReports_limit, offset: $allReports_offset) {\nemployeeid\nname\nlevel\n}\n}\n\n}",
-            "queryName" : "Employees",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Employees{?allReports_limit,offset,name,limit,employeeid,allReports_offset}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
@@ -361,6 +361,7 @@ CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("manag
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -400,7 +401,6 @@ CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("manag
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Employees($employeeid: Long, $name: String, $limit: Int = 10, $offset: Int = 0$allReports_limit: Int = 10, $allReports_offset: Int = 0) {\nEmployees(employeeid: $employeeid, name: $name, limit: $limit, offset: $offset) {\nemployeeid\nname\nemail\nupdatedDate\nallReports(limit: $allReports_limit, offset: $allReports_offset) {\nemployeeid\nname\nlevel\n}\n}\n\n}",
             "queryName" : "Employees",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
@@ -361,6 +361,45 @@ CREATE INDEX IF NOT EXISTS "Reporting_hash_c1" ON "Reporting" USING hash ("manag
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "employeeid" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "updatedDate" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "allReports" : {
+                  "type" : "array",
+                  "description" : "Returns all employees reporting to the given employee following down the reporting chain",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "employeeid" : {
+                        "type" : "integer"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "level" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Employees($employeeid: Long, $name: String, $limit: Int = 10, $offset: Int = 0$allReports_limit: Int = 10, $allReports_offset: Int = 0) {\nEmployees(employeeid: $employeeid, name: $name, limit: $limit, offset: $offset) {\nemployeeid\nname\nemail\nupdatedDate\nallReports(limit: $allReports_limit, offset: $allReports_offset) {\nemployeeid\nname\nlevel\n}\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
@@ -264,6 +264,23 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "maxTemp" : {
+                  "type" : "number"
+                },
+                "avgTemp" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorAggregate($limit: Int = 10, $offset: Int = 0) {\nSensorAggregate(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\navgTemp\n}\n\n}",
@@ -288,6 +305,23 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -319,6 +353,23 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [
                 "sensorid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
@@ -264,8 +264,16 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorAggregate($limit: Int = 10, $offset: Int = 0) {\nSensorAggregate(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\navgTemp\n}\n\n}",
+            "queryName" : "SensorAggregate",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorAggregate{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -281,15 +289,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorAggregate($limit: Int = 10, $offset: Int = 0) {\nSensorAggregate(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\navgTemp\n}\n\n}",
-            "queryName" : "SensorAggregate",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorAggregate{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -307,8 +307,16 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -324,15 +332,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -355,8 +355,16 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReadingById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReadingById{?offset,limit,sensorid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -372,15 +380,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReadingById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReadingById{?offset,limit,sensorid}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
@@ -264,6 +264,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -281,7 +282,6 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorAggregate($limit: Int = 10, $offset: Int = 0) {\nSensorAggregate(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\navgTemp\n}\n\n}",
             "queryName" : "SensorAggregate",
@@ -307,6 +307,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -324,7 +325,6 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",
@@ -355,6 +355,7 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -372,7 +373,6 @@ FROM (SELECT "sensorid", MAX("temperature") AS "maxTemp", AVG("temperature") AS 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReadingById",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
@@ -526,8 +526,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Detail($limit: Int = 10, $offset: Int = 0) {\nDetail(limit: $limit, offset: $offset) {\nid\ninfo\n}\n\n}",
+            "queryName" : "Detail",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Detail{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -540,15 +548,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Detail($limit: Int = 10, $offset: Int = 0) {\nDetail(limit: $limit, offset: $offset) {\nid\ninfo\n}\n\n}",
-            "queryName" : "Detail",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Detail{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -566,8 +566,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Thing($limit: Int = 10, $offset: Int = 0) {\nThing(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "Thing",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Thing{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -591,15 +599,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Thing($limit: Int = 10, $offset: Int = 0) {\nThing(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
-            "queryName" : "Thing",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Thing{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -617,8 +617,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Tombstone($limit: Int = 10, $offset: Int = 0) {\nTombstone(limit: $limit, offset: $offset) {\nid\n}\n\n}",
+            "queryName" : "Tombstone",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Tombstone{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -628,15 +636,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Tombstone($limit: Int = 10, $offset: Int = 0) {\nTombstone(limit: $limit, offset: $offset) {\nid\n}\n\n}",
-            "queryName" : "Tombstone",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Tombstone{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -654,8 +654,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query cleanQuery($limit: Int = 10, $offset: Int = 0) {\ncleanQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "cleanQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/cleanQuery{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -679,15 +687,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query cleanQuery($limit: Int = 10, $offset: Int = 0) {\ncleanQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
-            "queryName" : "cleanQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/cleanQuery{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -705,8 +705,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query joinQuery($limit: Int = 10, $offset: Int = 0) {\njoinQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "joinQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/joinQuery{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -730,15 +738,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query joinQuery($limit: Int = 10, $offset: Int = 0) {\njoinQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
-            "queryName" : "joinQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/joinQuery{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -756,8 +756,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query subqueryQuery($limit: Int = 10, $offset: Int = 0) {\nsubqueryQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "subqueryQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/subqueryQuery{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -781,15 +789,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query subqueryQuery($limit: Int = 10, $offset: Int = 0) {\nsubqueryQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
-            "queryName" : "subqueryQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/subqueryQuery{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -812,8 +812,16 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query sortedQuery($minId: String!, $limit: Int = 10, $offset: Int = 0) {\nsortedQuery(minId: $minId, limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
+            "queryName" : "sortedQuery",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/sortedQuery{?offset,limit,minId}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -837,15 +845,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query sortedQuery($minId: String!, $limit: Int = 10, $offset: Int = 0) {\nsortedQuery(minId: $minId, limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
-            "queryName" : "sortedQuery",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/sortedQuery{?offset,limit,minId}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
@@ -526,6 +526,20 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "info" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Detail($limit: Int = 10, $offset: Int = 0) {\nDetail(limit: $limit, offset: $offset) {\nid\ninfo\n}\n\n}",
@@ -550,6 +564,31 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "label" : {
+                  "type" : "string"
+                },
+                "detail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "info" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -578,6 +617,17 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Tombstone($limit: Int = 10, $offset: Int = 0) {\nTombstone(limit: $limit, offset: $offset) {\nid\n}\n\n}",
@@ -602,6 +652,31 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "label" : {
+                  "type" : "string"
+                },
+                "detail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "info" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -630,6 +705,31 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "label" : {
+                  "type" : "string"
+                },
+                "detail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "info" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query joinQuery($limit: Int = 10, $offset: Int = 0) {\njoinQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
@@ -654,6 +754,31 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "label" : {
+                  "type" : "string"
+                },
+                "detail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "info" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -685,6 +810,31 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [
                 "minId"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string"
+                },
+                "label" : {
+                  "type" : "string"
+                },
+                "detail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "info" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
@@ -526,6 +526,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -540,7 +541,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Detail($limit: Int = 10, $offset: Int = 0) {\nDetail(limit: $limit, offset: $offset) {\nid\ninfo\n}\n\n}",
             "queryName" : "Detail",
@@ -566,6 +566,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -591,7 +592,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Thing($limit: Int = 10, $offset: Int = 0) {\nThing(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
             "queryName" : "Thing",
@@ -617,6 +617,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -628,7 +629,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Tombstone($limit: Int = 10, $offset: Int = 0) {\nTombstone(limit: $limit, offset: $offset) {\nid\n}\n\n}",
             "queryName" : "Tombstone",
@@ -654,6 +654,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -679,7 +680,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query cleanQuery($limit: Int = 10, $offset: Int = 0) {\ncleanQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
             "queryName" : "cleanQuery",
@@ -705,6 +705,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -730,7 +731,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query joinQuery($limit: Int = 10, $offset: Int = 0) {\njoinQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
             "queryName" : "joinQuery",
@@ -756,6 +756,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -781,7 +782,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query subqueryQuery($limit: Int = 10, $offset: Int = 0) {\nsubqueryQuery(limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
             "queryName" : "subqueryQuery",
@@ -812,6 +812,7 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -837,7 +838,6 @@ CREATE TABLE IF NOT EXISTS "subqueryQuery" ("id" TEXT NOT NULL, "label" TEXT NOT
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query sortedQuery($minId: String!, $limit: Int = 10, $offset: Int = 0) {\nsortedQuery(minId: $minId, limit: $limit, offset: $offset) {\nid\nlabel\ndetail {\nid\ninfo\n}\n}\n\n}",
             "queryName" : "sortedQuery",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -539,8 +539,16 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Package($name: String!, $limit: Int = 10, $offset: Int = 0$versions_version: String!, $versions_variant: String!, $versions_limit: Int = 10, $versions_offset: Int = 0) {\nPackage(name: $name, limit: $limit, offset: $offset) {\nname\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\nversions(version: $versions_version, variant: $versions_variant, limit: $versions_limit, offset: $versions_offset) {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
+            "queryName" : "Package",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Package{?versions_version,versions_offset,offset,name,limit,versions_limit,versions_variant}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -671,15 +679,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Package($name: String!, $limit: Int = 10, $offset: Int = 0$versions_version: String!, $versions_variant: String!, $versions_limit: Int = 10, $versions_offset: Int = 0) {\nPackage(name: $name, limit: $limit, offset: $offset) {\nname\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\nversions(version: $versions_version, variant: $versions_variant, limit: $versions_limit, offset: $versions_offset) {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
-            "queryName" : "Package",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Package{?versions_version,versions_offset,offset,name,limit,versions_limit,versions_variant}"
+          }
         },
         {
           "function" : {
@@ -700,8 +700,16 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query TopicSearch($topicName: String, $limit: Int = 10, $offset: Int = 0) {\nTopicSearch(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\nnumPackages\n}\n\n}",
+            "queryName" : "TopicSearch",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TopicSearch{?offset,limit,topicName}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -714,15 +722,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query TopicSearch($topicName: String, $limit: Int = 10, $offset: Int = 0) {\nTopicSearch(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\nnumPackages\n}\n\n}",
-            "queryName" : "TopicSearch",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TopicSearch{?offset,limit,topicName}"
+          }
         },
         {
           "function" : {
@@ -745,8 +745,16 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query TopicPackages($topicName: String! = \"example\", $limit: Int = 10, $offset: Int = 0) {\nTopicPackages(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\npkgName\nlastSubmission\nnumSubmissions\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
+            "queryName" : "TopicPackages",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TopicPackages{?offset,limit,topicName}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -824,15 +832,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query TopicPackages($topicName: String! = \"example\", $limit: Int = 10, $offset: Int = 0) {\nTopicPackages(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\npkgName\nlastSubmission\nnumSubmissions\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
-            "queryName" : "TopicPackages",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TopicPackages{?offset,limit,topicName}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -539,6 +539,138 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "latest" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "version" : {
+                      "type" : "string"
+                    },
+                    "variant" : {
+                      "type" : "string"
+                    },
+                    "latest" : {
+                      "type" : "boolean"
+                    },
+                    "type" : {
+                      "type" : "string"
+                    },
+                    "license" : {
+                      "type" : "string"
+                    },
+                    "repository" : {
+                      "type" : "string"
+                    },
+                    "homepage" : {
+                      "type" : "string"
+                    },
+                    "documentation" : {
+                      "type" : "string"
+                    },
+                    "readme" : {
+                      "type" : "string"
+                    },
+                    "description" : {
+                      "type" : "string"
+                    },
+                    "uniqueId" : {
+                      "type" : "string"
+                    },
+                    "keywords" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string"
+                      }
+                    },
+                    "repoURL" : {
+                      "type" : "string"
+                    },
+                    "file" : {
+                      "type" : "string"
+                    },
+                    "hash" : {
+                      "type" : "string"
+                    },
+                    "submissionTime" : {
+                      "type" : "string"
+                    }
+                  }
+                },
+                "versions" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "version" : {
+                        "type" : "string"
+                      },
+                      "variant" : {
+                        "type" : "string"
+                      },
+                      "latest" : {
+                        "type" : "boolean"
+                      },
+                      "type" : {
+                        "type" : "string"
+                      },
+                      "license" : {
+                        "type" : "string"
+                      },
+                      "repository" : {
+                        "type" : "string"
+                      },
+                      "homepage" : {
+                        "type" : "string"
+                      },
+                      "documentation" : {
+                        "type" : "string"
+                      },
+                      "readme" : {
+                        "type" : "string"
+                      },
+                      "description" : {
+                        "type" : "string"
+                      },
+                      "uniqueId" : {
+                        "type" : "string"
+                      },
+                      "keywords" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "string"
+                        }
+                      },
+                      "repoURL" : {
+                        "type" : "string"
+                      },
+                      "file" : {
+                        "type" : "string"
+                      },
+                      "hash" : {
+                        "type" : "string"
+                      },
+                      "submissionTime" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Package($name: String!, $limit: Int = 10, $offset: Int = 0$versions_version: String!, $versions_variant: String!, $versions_limit: Int = 10, $versions_offset: Int = 0) {\nPackage(name: $name, limit: $limit, offset: $offset) {\nname\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\nversions(version: $versions_version, variant: $versions_variant, limit: $versions_limit, offset: $versions_offset) {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
@@ -566,6 +698,20 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "topicName" : {
+                  "type" : "string"
+                },
+                "numPackages" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -597,6 +743,85 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               "required" : [
                 "topicName"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "topicName" : {
+                  "type" : "string"
+                },
+                "pkgName" : {
+                  "type" : "string"
+                },
+                "lastSubmission" : {
+                  "type" : "string"
+                },
+                "numSubmissions" : {
+                  "type" : "integer"
+                },
+                "latest" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "version" : {
+                      "type" : "string"
+                    },
+                    "variant" : {
+                      "type" : "string"
+                    },
+                    "latest" : {
+                      "type" : "boolean"
+                    },
+                    "type" : {
+                      "type" : "string"
+                    },
+                    "license" : {
+                      "type" : "string"
+                    },
+                    "repository" : {
+                      "type" : "string"
+                    },
+                    "homepage" : {
+                      "type" : "string"
+                    },
+                    "documentation" : {
+                      "type" : "string"
+                    },
+                    "readme" : {
+                      "type" : "string"
+                    },
+                    "description" : {
+                      "type" : "string"
+                    },
+                    "uniqueId" : {
+                      "type" : "string"
+                    },
+                    "keywords" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string"
+                      }
+                    },
+                    "repoURL" : {
+                      "type" : "string"
+                    },
+                    "file" : {
+                      "type" : "string"
+                    },
+                    "hash" : {
+                      "type" : "string"
+                    },
+                    "submissionTime" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -539,6 +539,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -671,7 +672,6 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Package($name: String!, $limit: Int = 10, $offset: Int = 0$versions_version: String!, $versions_variant: String!, $versions_limit: Int = 10, $versions_offset: Int = 0) {\nPackage(name: $name, limit: $limit, offset: $offset) {\nname\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\nversions(version: $versions_version, variant: $versions_variant, limit: $versions_limit, offset: $versions_offset) {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
             "queryName" : "Package",
@@ -700,6 +700,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -714,7 +715,6 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query TopicSearch($topicName: String, $limit: Int = 10, $offset: Int = 0) {\nTopicSearch(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\nnumPackages\n}\n\n}",
             "queryName" : "TopicSearch",
@@ -745,6 +745,7 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -824,7 +825,6 @@ CREATE INDEX IF NOT EXISTS "Submission_btree_c0c3" ON "Submission" USING btree (
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query TopicPackages($topicName: String! = \"example\", $limit: Int = 10, $offset: Int = 0) {\nTopicPackages(topicName: $topicName, limit: $limit, offset: $offset) {\ntopicName\npkgName\nlastSubmission\nnumSubmissions\nlatest {\nname\nversion\nvariant\nlatest\ntype\nlicense\nrepository\nhomepage\ndocumentation\nreadme\ndescription\nuniqueId\nkeywords\nrepoURL\nfile\nhash\nsubmissionTime\n}\n}\n\n}",
             "queryName" : "TopicPackages",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
@@ -244,6 +244,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -261,7 +262,6 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCount($limit: Int = 10, $offset: Int = 0) {\nOrderCount(limit: $limit, offset: $offset) {\nid\nnumber\nvolume\n}\n\n}",
             "queryName" : "OrderCount",
@@ -287,6 +287,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -324,7 +325,6 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
             "queryName" : "Orders",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
@@ -244,8 +244,16 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query OrderCount($limit: Int = 10, $offset: Int = 0) {\nOrderCount(limit: $limit, offset: $offset) {\nid\nnumber\nvolume\n}\n\n}",
+            "queryName" : "OrderCount",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderCount{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -261,15 +269,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query OrderCount($limit: Int = 10, $offset: Int = 0) {\nOrderCount(limit: $limit, offset: $offset) {\nid\nnumber\nvolume\n}\n\n}",
-            "queryName" : "OrderCount",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/OrderCount{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -287,8 +287,16 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -324,15 +332,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
@@ -244,6 +244,23 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "number" : {
+                  "type" : "integer"
+                },
+                "volume" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query OrderCount($limit: Int = 10, $offset: Int = 0) {\nOrderCount(limit: $limit, offset: $offset) {\nid\nnumber\nvolume\n}\n\n}",
@@ -268,6 +285,43 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string"
+                },
+                "items" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
@@ -1255,6 +1255,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1415,7 +1416,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
             "queryName" : "Customers",
@@ -1471,6 +1471,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1631,7 +1632,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
             "queryName" : "Orders",
@@ -1662,6 +1662,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1695,7 +1696,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
             "queryName" : "Products",
@@ -1726,6 +1726,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1749,7 +1750,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
             "queryName" : "ProductsByCountry",
@@ -1780,6 +1780,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1816,7 +1817,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
             "queryName" : "ProductSearch",
@@ -1851,6 +1851,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1884,7 +1885,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
             "queryName" : "ProductSearchWithId",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
@@ -1255,8 +1255,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
+            "queryName" : "Customers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customers{?order_stats_offset,offset,past_purchases_limit,purchases_offset,purchases_limit,purchases_totals_offset,spending_offset,spending_limit,order_stats_limit,limit,purchases_totals_limit,id,email,past_purchases_offset}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1415,15 +1423,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
-            "queryName" : "Customers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customers{?order_stats_offset,offset,past_purchases_limit,purchases_offset,purchases_limit,purchases_totals_offset,spending_offset,spending_limit,order_stats_limit,limit,purchases_totals_limit,id,email,past_purchases_offset}"
+          }
         },
         {
           "function" : {
@@ -1471,8 +1471,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?customer_past_purchases_limit,customer_past_purchases_offset,totals_limit,offset,customer_order_stats_offset,totals_offset,customer_limit,limit,customer_order_stats_limit,customer_offset,customer_spending_offset,customer_spending_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1631,15 +1639,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?customer_past_purchases_limit,customer_past_purchases_offset,totals_limit,offset,customer_order_stats_offset,totals_offset,customer_limit,limit,customer_order_stats_limit,customer_offset,customer_spending_offset,customer_spending_limit}"
+          }
         },
         {
           "function" : {
@@ -1662,8 +1662,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
+            "queryName" : "Products",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Products{?offset,limit,id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1695,15 +1703,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
-            "queryName" : "Products",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Products{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -1726,8 +1726,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
+            "queryName" : "ProductsByCountry",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductsByCountry{?productid,offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1749,15 +1757,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
-            "queryName" : "ProductsByCountry",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductsByCountry{?productid,offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1780,8 +1780,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
+            "queryName" : "ProductSearch",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductSearch{?offset,query,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1816,15 +1824,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
-            "queryName" : "ProductSearch",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductSearch{?offset,query,limit}"
+          }
         },
         {
           "function" : {
@@ -1851,8 +1851,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
+            "queryName" : "ProductSearchWithId",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductSearchWithId{?offset,query,limit,id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1884,15 +1892,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
-            "queryName" : "ProductSearchWithId",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductSearchWithId{?offset,query,limit,id}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
@@ -1255,6 +1255,166 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "first_name" : {
+                  "type" : "string"
+                },
+                "last_name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "ip_address" : {
+                  "type" : "string"
+                },
+                "country" : {
+                  "type" : "string"
+                },
+                "changed_on" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "order_stats" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "first_order" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "total_spend" : {
+                        "type" : "number"
+                      },
+                      "total_saved" : {
+                        "type" : "number"
+                      },
+                      "num_orders" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                },
+                "past_purchases" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "num_orders" : {
+                        "type" : "integer"
+                      },
+                      "total_quantity" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                },
+                "purchases" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "items" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "quantity" : {
+                              "type" : "integer"
+                            },
+                            "unit_price" : {
+                              "type" : "number"
+                            },
+                            "discount" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      },
+                      "totals" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "integer"
+                            },
+                            "time" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "price" : {
+                              "type" : "number"
+                            },
+                            "saving" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "spending" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "week" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "spend" : {
+                        "type" : "number"
+                      },
+                      "saved" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
@@ -1311,6 +1471,166 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "items" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "customer" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "first_name" : {
+                        "type" : "string"
+                      },
+                      "last_name" : {
+                        "type" : "string"
+                      },
+                      "email" : {
+                        "type" : "string"
+                      },
+                      "ip_address" : {
+                        "type" : "string"
+                      },
+                      "country" : {
+                        "type" : "string"
+                      },
+                      "changed_on" : {
+                        "type" : "integer"
+                      },
+                      "timestamp" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "order_stats" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "first_order" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "total_spend" : {
+                              "type" : "number"
+                            },
+                            "total_saved" : {
+                              "type" : "number"
+                            },
+                            "num_orders" : {
+                              "type" : "integer"
+                            }
+                          }
+                        }
+                      },
+                      "past_purchases" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "num_orders" : {
+                              "type" : "integer"
+                            },
+                            "total_quantity" : {
+                              "type" : "integer"
+                            }
+                          }
+                        }
+                      },
+                      "spending" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "week" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "spend" : {
+                              "type" : "number"
+                            },
+                            "saved" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "totals" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "price" : {
+                        "type" : "number"
+                      },
+                      "saving" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
@@ -1340,6 +1660,39 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1373,6 +1726,29 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "country" : {
+                  "type" : "string"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "spend" : {
+                  "type" : "number"
+                },
+                "weight" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
@@ -1402,6 +1778,42 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [
                 "query"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "score" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1437,6 +1849,39 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 "query",
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
@@ -1255,6 +1255,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1415,7 +1416,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
             "queryName" : "Customers",
@@ -1471,6 +1471,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1631,7 +1632,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
             "queryName" : "Orders",
@@ -1662,6 +1662,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1695,7 +1696,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
             "queryName" : "Products",
@@ -1726,6 +1726,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1749,7 +1750,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
             "queryName" : "ProductsByCountry",
@@ -1780,6 +1780,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1816,7 +1817,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
             "queryName" : "ProductSearch",
@@ -1851,6 +1851,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1884,7 +1885,6 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
             "queryName" : "ProductSearchWithId",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
@@ -1255,8 +1255,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
+            "queryName" : "Customers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customers{?order_stats_offset,offset,past_purchases_limit,purchases_offset,purchases_limit,purchases_totals_offset,spending_offset,spending_limit,order_stats_limit,limit,purchases_totals_limit,id,email,past_purchases_offset}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1415,15 +1423,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
-            "queryName" : "Customers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customers{?order_stats_offset,offset,past_purchases_limit,purchases_offset,purchases_limit,purchases_totals_offset,spending_offset,spending_limit,order_stats_limit,limit,purchases_totals_limit,id,email,past_purchases_offset}"
+          }
         },
         {
           "function" : {
@@ -1471,8 +1471,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?customer_past_purchases_limit,customer_past_purchases_offset,totals_limit,offset,customer_order_stats_offset,totals_offset,customer_limit,limit,customer_order_stats_limit,customer_offset,customer_spending_offset,customer_spending_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1631,15 +1639,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?customer_past_purchases_limit,customer_past_purchases_offset,totals_limit,offset,customer_order_stats_offset,totals_offset,customer_limit,limit,customer_order_stats_limit,customer_offset,customer_spending_offset,customer_spending_limit}"
+          }
         },
         {
           "function" : {
@@ -1662,8 +1662,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
+            "queryName" : "Products",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Products{?offset,limit,id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1695,15 +1703,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Products($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nProducts(id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
-            "queryName" : "Products",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Products{?offset,limit,id}"
+          }
         },
         {
           "function" : {
@@ -1726,8 +1726,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
+            "queryName" : "ProductsByCountry",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductsByCountry{?productid,offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1749,15 +1757,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
-            "queryName" : "ProductsByCountry",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductsByCountry{?productid,offset,limit}"
+          }
         },
         {
           "function" : {
@@ -1780,8 +1780,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
+            "queryName" : "ProductSearch",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductSearch{?offset,query,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1816,15 +1824,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductSearch($query: String!, $limit: Int = 10, $offset: Int = 0) {\nProductSearch(query: $query, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\nscore\n}\n\n}",
-            "queryName" : "ProductSearch",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductSearch{?offset,query,limit}"
+          }
         },
         {
           "function" : {
@@ -1851,8 +1851,16 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
+            "queryName" : "ProductSearchWithId",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ProductSearchWithId{?offset,query,limit,id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1884,15 +1892,7 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query ProductSearchWithId($query: String!, $id: Int!, $limit: Int = 10, $offset: Int = 0) {\nProductSearchWithId(query: $query, id: $id, limit: $limit, offset: $offset) {\nid\nname\nsizing\nweight_in_gram\ntype\ncategory\nusda_id\nupdated\n}\n\n}",
-            "queryName" : "ProductSearchWithId",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/ProductSearchWithId{?offset,query,limit,id}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
@@ -1255,6 +1255,166 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "first_name" : {
+                  "type" : "string"
+                },
+                "last_name" : {
+                  "type" : "string"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "ip_address" : {
+                  "type" : "string"
+                },
+                "country" : {
+                  "type" : "string"
+                },
+                "changed_on" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "order_stats" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "first_order" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "total_spend" : {
+                        "type" : "number"
+                      },
+                      "total_saved" : {
+                        "type" : "number"
+                      },
+                      "num_orders" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                },
+                "past_purchases" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "num_orders" : {
+                        "type" : "integer"
+                      },
+                      "total_quantity" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                },
+                "purchases" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "items" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "quantity" : {
+                              "type" : "integer"
+                            },
+                            "unit_price" : {
+                              "type" : "number"
+                            },
+                            "discount" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      },
+                      "totals" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "integer"
+                            },
+                            "time" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "price" : {
+                              "type" : "number"
+                            },
+                            "saving" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "spending" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "week" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "spend" : {
+                        "type" : "number"
+                      },
+                      "saved" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($id: Long, $email: String, $limit: Int = 10, $offset: Int = 0$order_stats_limit: Int = 10, $order_stats_offset: Int = 0$past_purchases_limit: Int = 10, $past_purchases_offset: Int = 0$purchases_limit: Int = 10, $purchases_offset: Int = 0$purchases_totals_limit: Int = 10, $purchases_totals_offset: Int = 0$spending_limit: Int = 10, $spending_offset: Int = 0) {\nCustomers(id: $id, email: $email, limit: $limit, offset: $offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $order_stats_limit, offset: $order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $past_purchases_limit, offset: $past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\npurchases(limit: $purchases_limit, offset: $purchases_offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ntotals(limit: $purchases_totals_limit, offset: $purchases_totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\nspending(limit: $spending_limit, offset: $spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\n\n}",
@@ -1311,6 +1471,166 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "items" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "customer" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "first_name" : {
+                        "type" : "string"
+                      },
+                      "last_name" : {
+                        "type" : "string"
+                      },
+                      "email" : {
+                        "type" : "string"
+                      },
+                      "ip_address" : {
+                        "type" : "string"
+                      },
+                      "country" : {
+                        "type" : "string"
+                      },
+                      "changed_on" : {
+                        "type" : "integer"
+                      },
+                      "timestamp" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "order_stats" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "first_order" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "total_spend" : {
+                              "type" : "number"
+                            },
+                            "total_saved" : {
+                              "type" : "number"
+                            },
+                            "num_orders" : {
+                              "type" : "integer"
+                            }
+                          }
+                        }
+                      },
+                      "past_purchases" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "productid" : {
+                              "type" : "integer"
+                            },
+                            "num_orders" : {
+                              "type" : "integer"
+                            },
+                            "total_quantity" : {
+                              "type" : "integer"
+                            }
+                          }
+                        }
+                      },
+                      "spending" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "customerid" : {
+                              "type" : "integer"
+                            },
+                            "week" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "spend" : {
+                              "type" : "number"
+                            },
+                            "saved" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "totals" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "customerid" : {
+                        "type" : "integer"
+                      },
+                      "price" : {
+                        "type" : "number"
+                      },
+                      "saving" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0$customer_limit: Int = 10, $customer_offset: Int = 0$customer_order_stats_limit: Int = 10, $customer_order_stats_offset: Int = 0$customer_past_purchases_limit: Int = 10, $customer_past_purchases_offset: Int = 0$customer_spending_limit: Int = 10, $customer_spending_offset: Int = 0$totals_limit: Int = 10, $totals_offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nitems {\nproductid\nquantity\nunit_price\ndiscount\n}\ncustomer(limit: $customer_limit, offset: $customer_offset) {\nid\nfirst_name\nlast_name\nemail\nip_address\ncountry\nchanged_on\ntimestamp\norder_stats(limit: $customer_order_stats_limit, offset: $customer_order_stats_offset) {\ncustomerid\nfirst_order\ntotal_spend\ntotal_saved\nnum_orders\n}\npast_purchases(limit: $customer_past_purchases_limit, offset: $customer_past_purchases_offset) {\ncustomerid\nproductid\nnum_orders\ntotal_quantity\n}\nspending(limit: $customer_spending_limit, offset: $customer_spending_offset) {\ncustomerid\nweek\nspend\nsaved\n}\n}\ntotals(limit: $totals_limit, offset: $totals_offset) {\nid\ntime\ncustomerid\nprice\nsaving\n}\n}\n\n}",
@@ -1340,6 +1660,39 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1373,6 +1726,29 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "productid" : {
+                  "type" : "integer"
+                },
+                "country" : {
+                  "type" : "string"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "spend" : {
+                  "type" : "number"
+                },
+                "weight" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query ProductsByCountry($productid: Long!, $limit: Int = 10, $offset: Int = 0) {\nProductsByCountry(productid: $productid, limit: $limit, offset: $offset) {\nproductid\ncountry\nquantity\nspend\nweight\n}\n\n}",
@@ -1402,6 +1778,42 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
               "required" : [
                 "query"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "score" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -1437,6 +1849,39 @@ CREATE INDEX IF NOT EXISTS "Products_text_c1c5" ON "Products" USING GIN (to_tsve
                 "query",
                 "id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "sizing" : {
+                  "type" : "string"
+                },
+                "weight_in_gram" : {
+                  "type" : "integer"
+                },
+                "type" : {
+                  "type" : "string"
+                },
+                "category" : {
+                  "type" : "string"
+                },
+                "usda_id" : {
+                  "type" : "integer"
+                },
+                "updated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -416,6 +416,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -434,7 +435,6 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTempLastMin($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMin(limit: $limit, offset: $offset) {\nsensorid\nendOfMin\navg_temperature\n}\n\n}",
             "queryName" : "SensorMaxTempLastMin",
@@ -466,6 +466,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -483,7 +484,6 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorAnalysisById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorAnalysisById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\navg_temperatures\nmax_temperature\n}\n\n}",
             "queryName" : "SensorAnalysisById",
@@ -515,6 +515,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -536,7 +537,6 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReadingById",
@@ -565,6 +565,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -583,7 +584,6 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature }) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -416,8 +416,16 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorMaxTempLastMin($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMin(limit: $limit, offset: $offset) {\nsensorid\nendOfMin\navg_temperature\n}\n\n}",
+            "queryName" : "SensorMaxTempLastMin",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorMaxTempLastMin{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -434,15 +442,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorMaxTempLastMin($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMin(limit: $limit, offset: $offset) {\nsensorid\nendOfMin\navg_temperature\n}\n\n}",
-            "queryName" : "SensorMaxTempLastMin",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorMaxTempLastMin{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -466,8 +466,16 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorAnalysisById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorAnalysisById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\navg_temperatures\nmax_temperature\n}\n\n}",
+            "queryName" : "SensorAnalysisById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorAnalysisById{?offset,limit,sensorid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -483,15 +491,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorAnalysisById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorAnalysisById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\navg_temperatures\nmax_temperature\n}\n\n}",
-            "queryName" : "SensorAnalysisById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorAnalysisById{?offset,limit,sensorid}"
+          }
         },
         {
           "function" : {
@@ -515,8 +515,16 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReadingById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReadingById{?offset,limit,sensorid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -536,15 +544,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReadingById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReadingById{?offset,limit,sensorid}"
+          }
         },
         {
           "function" : {
@@ -565,8 +565,16 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature }) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SensorReading",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "uuid" : {
@@ -583,15 +591,7 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature }) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SensorReading"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -416,6 +416,24 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "endOfMin" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avg_temperature" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTempLastMin($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTempLastMin(limit: $limit, offset: $offset) {\nsensorid\nendOfMin\navg_temperature\n}\n\n}",
@@ -446,6 +464,23 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               "required" : [
                 "sensorid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "avg_temperatures" : {
+                  "type" : "number"
+                },
+                "max_temperature" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -480,6 +515,27 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "uuid" : {
+                  "type" : "string"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReadingById($sensorid: Int!, $limit: Int = 10, $offset: Int = 0) {\nSensorReadingById(sensorid: $sensorid, limit: $limit, offset: $offset) {\nuuid\nsensorid\ntemperature\nevent_time\n}\n\n}",
@@ -507,6 +563,24 @@ CREATE INDEX IF NOT EXISTS "SensorReading_hash_c1" ON "SensorReading" USING hash
                 "sensorid",
                 "temperature"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "uuid" : {
+                "type" : "string"
+              },
+              "sensorid" : {
+                "type" : "integer"
+              },
+              "temperature" : {
+                "type" : "number"
+              },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
@@ -723,8 +723,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query HighTemp($limit: Int = 10, $offset: Int = 0) {\nHighTemp(limit: $limit, offset: $offset) {\nmachineId\nsensorid\ntemp\ntimeSec\n}\n\n}",
+            "queryName" : "HighTemp",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/HighTemp{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -744,15 +752,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query HighTemp($limit: Int = 10, $offset: Int = 0) {\nHighTemp(limit: $limit, offset: $offset) {\nmachineId\nsensorid\ntemp\ntimeSec\n}\n\n}",
-            "queryName" : "HighTemp",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/HighTemp{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -788,8 +788,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Machine($limit: Int = 10, $offset: Int = 0$sensors_limit: Int = 10, $sensors_offset: Int = 0$sensors_lastHour_limit: Int = 10, $sensors_lastHour_offset: Int = 0$sensors_readings_limit: Int = 10, $sensors_readings_offset: Int = 0) {\nMachine(limit: $limit, offset: $offset) {\nmachineId\nmaxTemp\navgTemp\nsensors(limit: $sensors_limit, offset: $sensors_offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $sensors_lastHour_limit, offset: $sensors_lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $sensors_readings_limit, offset: $sensors_readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n}\n\n}",
+            "queryName" : "Machine",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Machine{?sensors_lastHour_offset,offset,sensors_readings_offset,sensors_limit,limit,sensors_readings_limit,sensors_offset,sensors_lastHour_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -865,15 +873,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Machine($limit: Int = 10, $offset: Int = 0$sensors_limit: Int = 10, $sensors_offset: Int = 0$sensors_lastHour_limit: Int = 10, $sensors_lastHour_offset: Int = 0$sensors_readings_limit: Int = 10, $sensors_readings_offset: Int = 0) {\nMachine(limit: $limit, offset: $offset) {\nmachineId\nmaxTemp\navgTemp\nsensors(limit: $sensors_limit, offset: $sensors_offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $sensors_lastHour_limit, offset: $sensors_lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $sensors_readings_limit, offset: $sensors_readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n}\n\n}",
-            "queryName" : "Machine",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Machine{?sensors_lastHour_offset,offset,sensors_readings_offset,sensors_limit,limit,sensors_readings_limit,sensors_offset,sensors_lastHour_limit}"
+          }
         },
         {
           "function" : {
@@ -891,8 +891,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SecReading($limit: Int = 10, $offset: Int = 0) {\nSecReading(limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
+            "queryName" : "SecReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SecReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -909,15 +917,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SecReading($limit: Int = 10, $offset: Int = 0) {\nSecReading(limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
-            "queryName" : "SecReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SecReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -935,8 +935,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorLastHour($limit: Int = 10, $offset: Int = 0) {\nSensorLastHour(limit: $limit, offset: $offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\n\n}",
+            "queryName" : "SensorLastHour",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorLastHour{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -956,15 +964,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorLastHour($limit: Int = 10, $offset: Int = 0) {\nSensorLastHour(limit: $limit, offset: $offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\n\n}",
-            "queryName" : "SensorLastHour",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorLastHour{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -994,8 +994,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0$lastHour_limit: Int = 10, $lastHour_offset: Int = 0$readings_limit: Int = 10, $readings_offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $lastHour_limit, offset: $lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $readings_limit, offset: $readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n\n}",
+            "queryName" : "Sensors",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Sensors{?offset,readings_limit,limit,readings_offset,lastHour_offset,lastHour_limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1054,15 +1062,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0$lastHour_limit: Int = 10, $lastHour_offset: Int = 0$readings_limit: Int = 10, $readings_offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $lastHour_limit, offset: $lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $readings_limit, offset: $readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n\n}",
-            "queryName" : "Sensors",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Sensors{?offset,readings_limit,limit,readings_offset,lastHour_offset,lastHour_limit}"
+          }
         },
         {
           "function" : {
@@ -1085,8 +1085,16 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SecReadingByTemp($temp: Int!, $limit: Int = 10, $offset: Int = 0) {\nSecReadingByTemp(temp: $temp, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
+            "queryName" : "SecReadingByTemp",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SecReadingByTemp{?temp,offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -1103,15 +1111,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SecReadingByTemp($temp: Int!, $limit: Int = 10, $offset: Int = 0) {\nSecReadingByTemp(temp: $temp, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
-            "queryName" : "SecReadingByTemp",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SecReadingByTemp{?temp,offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
@@ -723,6 +723,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -744,7 +745,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query HighTemp($limit: Int = 10, $offset: Int = 0) {\nHighTemp(limit: $limit, offset: $offset) {\nmachineId\nsensorid\ntemp\ntimeSec\n}\n\n}",
             "queryName" : "HighTemp",
@@ -788,6 +788,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -865,7 +866,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Machine($limit: Int = 10, $offset: Int = 0$sensors_limit: Int = 10, $sensors_offset: Int = 0$sensors_lastHour_limit: Int = 10, $sensors_lastHour_offset: Int = 0$sensors_readings_limit: Int = 10, $sensors_readings_offset: Int = 0) {\nMachine(limit: $limit, offset: $offset) {\nmachineId\nmaxTemp\navgTemp\nsensors(limit: $sensors_limit, offset: $sensors_offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $sensors_lastHour_limit, offset: $sensors_lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $sensors_readings_limit, offset: $sensors_readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n}\n\n}",
             "queryName" : "Machine",
@@ -891,6 +891,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -909,7 +910,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SecReading($limit: Int = 10, $offset: Int = 0) {\nSecReading(limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
             "queryName" : "SecReading",
@@ -935,6 +935,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -956,7 +957,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorLastHour($limit: Int = 10, $offset: Int = 0) {\nSensorLastHour(limit: $limit, offset: $offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\n\n}",
             "queryName" : "SensorLastHour",
@@ -994,6 +994,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1054,7 +1055,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Sensors($limit: Int = 10, $offset: Int = 0$lastHour_limit: Int = 10, $lastHour_offset: Int = 0$readings_limit: Int = 10, $readings_offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $lastHour_limit, offset: $lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $readings_limit, offset: $readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n\n}",
             "queryName" : "Sensors",
@@ -1085,6 +1085,7 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -1103,7 +1104,6 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SecReadingByTemp($temp: Int!, $limit: Int = 10, $offset: Int = 0) {\nSecReadingByTemp(temp: $temp, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
             "queryName" : "SecReadingByTemp",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
@@ -723,6 +723,27 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineId" : {
+                  "type" : "integer"
+                },
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temp" : {
+                  "type" : "number"
+                },
+                "timeSec" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query HighTemp($limit: Int = 10, $offset: Int = 0) {\nHighTemp(limit: $limit, offset: $offset) {\nmachineId\nsensorid\ntemp\ntimeSec\n}\n\n}",
@@ -767,6 +788,83 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "machineId" : {
+                  "type" : "integer"
+                },
+                "maxTemp" : {
+                  "type" : "number"
+                },
+                "avgTemp" : {
+                  "type" : "number"
+                },
+                "sensors" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "machineId" : {
+                        "type" : "integer"
+                      },
+                      "placed" : {
+                        "type" : "integer"
+                      },
+                      "timestamp" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "lastHour" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "sensorid" : {
+                              "type" : "integer"
+                            },
+                            "window_time" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "avgTemp" : {
+                              "type" : "number"
+                            },
+                            "maxTemp" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      },
+                      "readings" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "sensorid" : {
+                              "type" : "integer"
+                            },
+                            "timeSec" : {
+                              "type" : "string",
+                              "format" : "date-time"
+                            },
+                            "temp" : {
+                              "type" : "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Machine($limit: Int = 10, $offset: Int = 0$sensors_limit: Int = 10, $sensors_offset: Int = 0$sensors_lastHour_limit: Int = 10, $sensors_lastHour_offset: Int = 0$sensors_readings_limit: Int = 10, $sensors_readings_offset: Int = 0) {\nMachine(limit: $limit, offset: $offset) {\nmachineId\nmaxTemp\navgTemp\nsensors(limit: $sensors_limit, offset: $sensors_offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $sensors_lastHour_limit, offset: $sensors_lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $sensors_readings_limit, offset: $sensors_readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n}\n\n}",
@@ -793,6 +891,24 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "timeSec" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "temp" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SecReading($limit: Int = 10, $offset: Int = 0) {\nSecReading(limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntemp\n}\n\n}",
@@ -817,6 +933,27 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "avgTemp" : {
+                  "type" : "number"
+                },
+                "maxTemp" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -857,6 +994,66 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "machineId" : {
+                  "type" : "integer"
+                },
+                "placed" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "lastHour" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "sensorid" : {
+                        "type" : "integer"
+                      },
+                      "window_time" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "avgTemp" : {
+                        "type" : "number"
+                      },
+                      "maxTemp" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                },
+                "readings" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "sensorid" : {
+                        "type" : "integer"
+                      },
+                      "timeSec" : {
+                        "type" : "string",
+                        "format" : "date-time"
+                      },
+                      "temp" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Sensors($limit: Int = 10, $offset: Int = 0$lastHour_limit: Int = 10, $lastHour_offset: Int = 0$readings_limit: Int = 10, $readings_offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\nlastHour(limit: $lastHour_limit, offset: $lastHour_offset) {\nsensorid\nwindow_time\navgTemp\nmaxTemp\n}\nreadings(limit: $readings_limit, offset: $readings_offset) {\nsensorid\ntimeSec\ntemp\n}\n}\n\n}",
@@ -886,6 +1083,24 @@ CREATE INDEX IF NOT EXISTS "Sensors_hash_c1" ON "Sensors" USING hash ("machineId
               "required" : [
                 "temp"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "timeSec" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "temp" : {
+                  "type" : "number"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -419,6 +419,24 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query HighTempAlert($limit: Int = 10, $offset: Int = 0) {\nHighTempAlert(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
@@ -445,6 +463,20 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "maxTemp" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTemp($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\n}\n\n}",
@@ -469,6 +501,24 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -509,6 +559,24 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [
                 "event"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -419,8 +419,16 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query HighTempAlert($limit: Int = 10, $offset: Int = 0) {\nHighTempAlert(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "HighTempAlert",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/HighTempAlert{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -437,15 +445,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query HighTempAlert($limit: Int = 10, $offset: Int = 0) {\nHighTempAlert(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "HighTempAlert",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/HighTempAlert{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -463,8 +463,16 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorMaxTemp($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\n}\n\n}",
+            "queryName" : "SensorMaxTemp",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorMaxTemp{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -477,15 +485,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorMaxTemp($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\n}\n\n}",
-            "queryName" : "SensorMaxTemp",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorMaxTemp{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -503,8 +503,16 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -521,15 +529,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -561,8 +561,16 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation SensorReading($event: [SensorReadingInput!]!) {\nSensorReading(event: $event) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "NONE",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SensorReading",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -579,15 +587,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation SensorReading($event: [SensorReadingInput!]!) {\nSensorReading(event: $event) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "NONE",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SensorReading"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -419,6 +419,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -437,7 +438,6 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query HighTempAlert($limit: Int = 10, $offset: Int = 0) {\nHighTempAlert(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "HighTempAlert",
@@ -463,6 +463,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -477,7 +478,6 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTemp($limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(limit: $limit, offset: $offset) {\nsensorid\nmaxTemp\n}\n\n}",
             "queryName" : "SensorMaxTemp",
@@ -503,6 +503,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -521,7 +522,6 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",
@@ -561,6 +561,7 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -579,7 +580,6 @@ CREATE TABLE IF NOT EXISTS "SensorReading" ("sensorid" INTEGER NOT NULL, "temper
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation SensorReading($event: [SensorReadingInput!]!) {\nSensorReading(event: $event) {\nsensorid\ntemperature\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
@@ -559,8 +559,16 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MachineGroup($limit: Int = 10, $offset: Int = 0) {\nMachineGroup(limit: $limit, offset: $offset) {\ngroupId\ngroupName\ncreated\nmachines {\nmachineId\n}\n}\n\n}",
+            "queryName" : "MachineGroup",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MachineGroup{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -588,15 +596,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MachineGroup($limit: Int = 10, $offset: Int = 0) {\nMachineGroup(limit: $limit, offset: $offset) {\ngroupId\ngroupName\ncreated\nmachines {\nmachineId\n}\n}\n\n}",
-            "queryName" : "MachineGroup",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MachineGroup{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -620,8 +620,16 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SecReading($sensorid: Long!, $limit: Int = 10, $offset: Int = 0) {\nSecReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntimeStart\ntimeEnd\ntemp\n}\n\n}",
+            "queryName" : "SecReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SecReading{?offset,limit,sensorid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -646,15 +654,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SecReading($sensorid: Long!, $limit: Int = 10, $offset: Int = 0) {\nSecReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntimeStart\ntimeEnd\ntemp\n}\n\n}",
-            "queryName" : "SecReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SecReading{?offset,limit,sensorid}"
+          }
         },
         {
           "function" : {
@@ -676,8 +676,16 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorMaxTemp($sensorid: Long, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nwindow_time\nmaxTemp\n}\n\n}",
+            "queryName" : "SensorMaxTemp",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorMaxTemp{?offset,limit,sensorid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -694,15 +702,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorMaxTemp($sensorid: Long, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nwindow_time\nmaxTemp\n}\n\n}",
-            "queryName" : "SensorMaxTemp",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorMaxTemp{?offset,limit,sensorid}"
+          }
         },
         {
           "function" : {
@@ -720,8 +720,16 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntime\ntemperature\nhumidity\ntimestamp\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -744,15 +752,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntime\ntemperature\nhumidity\ntimestamp\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -770,8 +770,16 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\n}\n\n}",
+            "queryName" : "Sensors",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Sensors{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -791,15 +799,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Sensors($limit: Int = 10, $offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\n}\n\n}",
-            "queryName" : "Sensors",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Sensors{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
@@ -559,6 +559,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -588,7 +589,6 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineGroup($limit: Int = 10, $offset: Int = 0) {\nMachineGroup(limit: $limit, offset: $offset) {\ngroupId\ngroupName\ncreated\nmachines {\nmachineId\n}\n}\n\n}",
             "queryName" : "MachineGroup",
@@ -620,6 +620,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -646,7 +647,6 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SecReading($sensorid: Long!, $limit: Int = 10, $offset: Int = 0) {\nSecReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntimeStart\ntimeEnd\ntemp\n}\n\n}",
             "queryName" : "SecReading",
@@ -676,6 +676,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -694,7 +695,6 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTemp($sensorid: Long, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nwindow_time\nmaxTemp\n}\n\n}",
             "queryName" : "SensorMaxTemp",
@@ -720,6 +720,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -744,7 +745,6 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntime\ntemperature\nhumidity\ntimestamp\n}\n\n}",
             "queryName" : "SensorReading",
@@ -770,6 +770,7 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -791,7 +792,6 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Sensors($limit: Int = 10, $offset: Int = 0) {\nSensors(limit: $limit, offset: $offset) {\nid\nmachineId\nplaced\ntimestamp\n}\n\n}",
             "queryName" : "Sensors",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
@@ -559,6 +559,35 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "groupId" : {
+                  "type" : "integer"
+                },
+                "groupName" : {
+                  "type" : "string"
+                },
+                "created" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "machines" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "machineId" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MachineGroup($limit: Int = 10, $offset: Int = 0) {\nMachineGroup(limit: $limit, offset: $offset) {\ngroupId\ngroupName\ncreated\nmachines {\nmachineId\n}\n}\n\n}",
@@ -591,6 +620,32 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "timeSec" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "timeStart" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "timeEnd" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "temp" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SecReading($sensorid: Long!, $limit: Int = 10, $offset: Int = 0) {\nSecReading(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\ntimeSec\ntimeStart\ntimeEnd\ntemp\n}\n\n}",
@@ -621,6 +676,24 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "window_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "maxTemp" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorMaxTemp($sensorid: Long, $limit: Int = 10, $offset: Int = 0) {\nSensorMaxTemp(sensorid: $sensorid, limit: $limit, offset: $offset) {\nsensorid\nwindow_time\nmaxTemp\n}\n\n}",
@@ -647,6 +720,30 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "humidity" : {
+                  "type" : "number"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntime\ntemperature\nhumidity\ntimestamp\n}\n\n}",
@@ -671,6 +768,27 @@ CREATE TABLE IF NOT EXISTS "Sensors" ("id" BIGINT NOT NULL, "machineId" BIGINT N
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "machineId" : {
+                  "type" : "integer"
+                },
+                "placed" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
@@ -279,8 +279,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customers",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customers{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -303,15 +311,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "Customers",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Customers{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -338,8 +338,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CustomersById($a: Long!, $b: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomersById(a: $a, b: $b, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomersById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersById{?a,b,offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -362,15 +370,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CustomersById($a: Long!, $b: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomersById(a: $a, b: $b, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomersById",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersById{?a,b,offset,limit}"
+          }
         },
         {
           "function" : {
@@ -393,8 +393,16 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "CustomersByName",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomersByName{?offset,limit,inputName}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -417,15 +425,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
-            "queryName" : "CustomersByName",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CustomersByName{?offset,limit,inputName}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -303,7 +304,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "Customers",
@@ -338,6 +338,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -362,7 +363,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersById($a: Long!, $b: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomersById(a: $a, b: $b, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "CustomersById",
@@ -393,6 +393,7 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -417,7 +418,6 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersByName($inputName: String!, $limit: Int = 10, $offset: Int = 0) {\nCustomersByName(inputName: $inputName, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
             "queryName" : "CustomersByName",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
@@ -279,6 +279,30 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Customers($limit: Int = 10, $offset: Int = 0) {\nCustomers(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -314,6 +338,30 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CustomersById($a: Long!, $b: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomersById(a: $a, b: $b, limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
@@ -343,6 +391,30 @@ CREATE TABLE IF NOT EXISTS "Customers" ("customerid" BIGINT NOT NULL, "email" TE
               "required" : [
                 "inputName"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -195,7 +196,6 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
             "queryName" : "Orders",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
@@ -168,6 +168,33 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "productid" : {
+                  "type" : "integer"
+                },
+                "quantity" : {
+                  "type" : "integer"
+                },
+                "unit_price" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
@@ -168,8 +168,16 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -195,15 +203,7 @@ CREATE TABLE IF NOT EXISTS "Orders" ("id" BIGINT NOT NULL, "customerid" BIGINT N
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nproductid\nquantity\nunit_price\n}\n\n}",
-            "queryName" : "Orders",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Orders{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
@@ -240,6 +240,24 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "val" : {
+                  "type" : "string"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query Json($limit: Int = 10, $offset: Int = 0) {\nJson(limit: $limit, offset: $offset) {\nid\nval\ntimestamp\n}\n\n}",
@@ -264,6 +282,24 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "val" : {
+                  "type" : "string"
+                },
+                "json_col" : { },
+                "json_col_2" : { },
+                "json_col_3" : { },
+                "json_col_4" : { }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
@@ -240,8 +240,16 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query Json($limit: Int = 10, $offset: Int = 0) {\nJson(limit: $limit, offset: $offset) {\nid\nval\ntimestamp\n}\n\n}",
+            "queryName" : "Json",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Json{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -258,15 +266,7 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query Json($limit: Int = 10, $offset: Int = 0) {\nJson(limit: $limit, offset: $offset) {\nid\nval\ntimestamp\n}\n\n}",
-            "queryName" : "Json",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/Json{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -284,8 +284,16 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query UnmodifiedJsonData($limit: Int = 10, $offset: Int = 0) {\nUnmodifiedJsonData(limit: $limit, offset: $offset) {\nid\nval\njson_col\njson_col_2\njson_col_3\njson_col_4\n}\n\n}",
+            "queryName" : "UnmodifiedJsonData",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/UnmodifiedJsonData{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -302,15 +310,7 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
                 "json_col_4" : { }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query UnmodifiedJsonData($limit: Int = 10, $offset: Int = 0) {\nUnmodifiedJsonData(limit: $limit, offset: $offset) {\nid\nval\njson_col\njson_col_2\njson_col_3\njson_col_4\n}\n\n}",
-            "queryName" : "UnmodifiedJsonData",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/UnmodifiedJsonData{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
@@ -240,6 +240,7 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -258,7 +259,6 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query Json($limit: Int = 10, $offset: Int = 0) {\nJson(limit: $limit, offset: $offset) {\nid\nval\ntimestamp\n}\n\n}",
             "queryName" : "Json",
@@ -284,6 +284,7 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -302,7 +303,6 @@ CREATE TABLE IF NOT EXISTS "UnmodifiedJsonData" ("id" BIGINT NOT NULL, "val" TEX
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query UnmodifiedJsonData($limit: Int = 10, $offset: Int = 0) {\nUnmodifiedJsonData(limit: $limit, offset: $offset) {\nid\nval\njson_col\njson_col_2\njson_col_3\njson_col_4\n}\n\n}",
             "queryName" : "UnmodifiedJsonData",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
@@ -177,8 +177,16 @@ CREATE TABLE IF NOT EXISTS "MathFunctions" ("d" NUMERIC NOT NULL, "b" INTEGER NO
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MathFunctions($limit: Int = 10, $offset: Int = 0) {\nMathFunctions(limit: $limit, offset: $offset) {\nd\nb\ncbrt\ncopy_sign\nexpm1\nhypot\nlog1p\nnext_after\nscalb\nulp\nbinomial_distribution\nexponential_distribution\nnormal_distribution\npoisson_distribution\n}\n\n}",
+            "queryName" : "MathFunctions",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MathFunctions{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -227,15 +235,7 @@ CREATE TABLE IF NOT EXISTS "MathFunctions" ("d" NUMERIC NOT NULL, "b" INTEGER NO
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MathFunctions($limit: Int = 10, $offset: Int = 0) {\nMathFunctions(limit: $limit, offset: $offset) {\nd\nb\ncbrt\ncopy_sign\nexpm1\nhypot\nlog1p\nnext_after\nscalb\nulp\nbinomial_distribution\nexponential_distribution\nnormal_distribution\npoisson_distribution\n}\n\n}",
-            "queryName" : "MathFunctions",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MathFunctions{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
@@ -177,6 +177,7 @@ CREATE TABLE IF NOT EXISTS "MathFunctions" ("d" NUMERIC NOT NULL, "b" INTEGER NO
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -227,7 +228,6 @@ CREATE TABLE IF NOT EXISTS "MathFunctions" ("d" NUMERIC NOT NULL, "b" INTEGER NO
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MathFunctions($limit: Int = 10, $offset: Int = 0) {\nMathFunctions(limit: $limit, offset: $offset) {\nd\nb\ncbrt\ncopy_sign\nexpm1\nhypot\nlog1p\nnext_after\nscalb\nulp\nbinomial_distribution\nexponential_distribution\nnormal_distribution\npoisson_distribution\n}\n\n}",
             "queryName" : "MathFunctions",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
@@ -177,6 +177,56 @@ CREATE TABLE IF NOT EXISTS "MathFunctions" ("d" NUMERIC NOT NULL, "b" INTEGER NO
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "d" : {
+                  "type" : "number"
+                },
+                "b" : {
+                  "type" : "integer"
+                },
+                "cbrt" : {
+                  "type" : "number"
+                },
+                "copy_sign" : {
+                  "type" : "number"
+                },
+                "expm1" : {
+                  "type" : "number"
+                },
+                "hypot" : {
+                  "type" : "number"
+                },
+                "log1p" : {
+                  "type" : "number"
+                },
+                "next_after" : {
+                  "type" : "number"
+                },
+                "scalb" : {
+                  "type" : "number"
+                },
+                "ulp" : {
+                  "type" : "number"
+                },
+                "binomial_distribution" : {
+                  "type" : "number"
+                },
+                "exponential_distribution" : {
+                  "type" : "number"
+                },
+                "normal_distribution" : {
+                  "type" : "number"
+                },
+                "poisson_distribution" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MathFunctions($limit: Int = 10, $offset: Int = 0) {\nMathFunctions(limit: $limit, offset: $offset) {\nd\nb\ncbrt\ncopy_sign\nexpm1\nhypot\nlog1p\nnext_after\nscalb\nulp\nbinomial_distribution\nexponential_distribution\nnormal_distribution\npoisson_distribution\n}\n\n}",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
@@ -202,6 +202,17 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -226,6 +237,23 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "completions_result" : {
+                  "type" : "string"
+                },
+                "extract_json_result_response" : {
+                  "type" : "string"
+                },
+                "extract_json_result_with_schema_response" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
@@ -202,8 +202,16 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "data",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/data{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -213,15 +221,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "data",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/data{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -239,8 +239,16 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
+            "queryName" : "results",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/results{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -256,15 +264,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
-            "queryName" : "results",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/results{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
@@ -202,6 +202,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -213,7 +214,6 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "data",
@@ -239,6 +239,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -256,7 +257,6 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
             "queryName" : "results",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
@@ -202,6 +202,17 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
@@ -226,6 +237,23 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "completions_result" : {
+                  "type" : "string"
+                },
+                "extract_json_result_response" : {
+                  "type" : "string"
+                },
+                "extract_json_result_with_schema_response" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
@@ -202,8 +202,16 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
+            "queryName" : "data",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/data{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -213,15 +221,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
-            "queryName" : "data",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/data{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -239,8 +239,16 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
+            "queryName" : "results",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/results{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -256,15 +264,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
-            "queryName" : "results",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/results{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
@@ -202,6 +202,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -213,7 +214,6 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query data($limit: Int = 10, $offset: Int = 0) {\ndata(limit: $limit, offset: $offset) {\nval\n}\n\n}",
             "queryName" : "data",
@@ -239,6 +239,7 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -256,7 +257,6 @@ CREATE TABLE IF NOT EXISTS "results" ("completions_result" TEXT, "extract_json_r
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query results($limit: Int = 10, $offset: Int = 0) {\nresults(limit: $limit, offset: $offset) {\ncompletions_result\nextract_json_result_response\nextract_json_result_with_schema_response\n}\n\n}",
             "queryName" : "results",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
@@ -324,8 +324,16 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query CategoryCentroids($category_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nCategoryCentroids(category_id: $category_id, limit: $limit, offset: $offset) {\ncategory_id\ncenter_vector\n}\n\n}",
+            "queryName" : "CategoryCentroids",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CategoryCentroids{?category_id,offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -341,15 +349,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query CategoryCentroids($category_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nCategoryCentroids(category_id: $category_id, limit: $limit, offset: $offset) {\ncategory_id\ncenter_vector\n}\n\n}",
-            "queryName" : "CategoryCentroids",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/CategoryCentroids{?category_id,offset,limit}"
+          }
         },
         {
           "function" : {
@@ -367,8 +367,16 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query VectorData($limit: Int = 10, $offset: Int = 0) {\nVectorData(limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
+            "queryName" : "VectorData",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/VectorData{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -381,15 +389,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query VectorData($limit: Int = 10, $offset: Int = 0) {\nVectorData(limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
-            "queryName" : "VectorData",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/VectorData{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -412,8 +412,16 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query DocumentSimilarity($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarity(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\nscore\n}\n\n}",
+            "queryName" : "DocumentSimilarity",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DocumentSimilarity{?offset,limit,doc_id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -426,15 +434,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query DocumentSimilarity($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarity(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\nscore\n}\n\n}",
-            "queryName" : "DocumentSimilarity",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DocumentSimilarity{?offset,limit,doc_id}"
+          }
         },
         {
           "function" : {
@@ -457,8 +457,16 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query DocumentSimilarityIndex($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarityIndex(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
+            "queryName" : "DocumentSimilarityIndex",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/DocumentSimilarityIndex{?offset,limit,doc_id}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -471,15 +479,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query DocumentSimilarityIndex($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarityIndex(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
-            "queryName" : "DocumentSimilarityIndex",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/DocumentSimilarityIndex{?offset,limit,doc_id}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
@@ -324,6 +324,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -341,7 +342,6 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query CategoryCentroids($category_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nCategoryCentroids(category_id: $category_id, limit: $limit, offset: $offset) {\ncategory_id\ncenter_vector\n}\n\n}",
             "queryName" : "CategoryCentroids",
@@ -367,6 +367,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -381,7 +382,6 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query VectorData($limit: Int = 10, $offset: Int = 0) {\nVectorData(limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
             "queryName" : "VectorData",
@@ -412,6 +412,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -426,7 +427,6 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query DocumentSimilarity($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarity(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\nscore\n}\n\n}",
             "queryName" : "DocumentSimilarity",
@@ -457,6 +457,7 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -471,7 +472,6 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query DocumentSimilarityIndex($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarityIndex(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\ncategory_id\n}\n\n}",
             "queryName" : "DocumentSimilarityIndex",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
@@ -324,6 +324,23 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "category_id" : {
+                  "type" : "integer"
+                },
+                "center_vector" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "number"
+                  }
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query CategoryCentroids($category_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nCategoryCentroids(category_id: $category_id, limit: $limit, offset: $offset) {\ncategory_id\ncenter_vector\n}\n\n}",
@@ -348,6 +365,20 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "doc_id" : {
+                  "type" : "integer"
+                },
+                "category_id" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -381,6 +412,20 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "doc_id" : {
+                  "type" : "integer"
+                },
+                "score" : {
+                  "type" : "number"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query DocumentSimilarity($doc_id: Int!, $limit: Int = 10, $offset: Int = 0) {\nDocumentSimilarity(doc_id: $doc_id, limit: $limit, offset: $offset) {\ndoc_id\nscore\n}\n\n}",
@@ -410,6 +455,20 @@ CREATE INDEX IF NOT EXISTS "VectorData_vector_cosine_c2" ON "VectorData" USING H
               "required" : [
                 "doc_id"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "doc_id" : {
+                  "type" : "integer"
+                },
+                "category_id" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -474,8 +474,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query EnrichedSensorReading($limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
+            "queryName" : "EnrichedSensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/EnrichedSensorReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -498,15 +506,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query EnrichedSensorReading($limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
-            "queryName" : "EnrichedSensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/EnrichedSensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -524,8 +524,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorReading{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -549,15 +557,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorReading{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -575,8 +575,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query SensorUpdates($limit: Int = 10, $offset: Int = 0) {\nSensorUpdates(limit: $limit, offset: $offset) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
+            "queryName" : "SensorUpdates",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/SensorUpdates{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -593,15 +601,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query SensorUpdates($limit: Int = 10, $offset: Int = 0) {\nSensorUpdates(limit: $limit, offset: $offset) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
-            "queryName" : "SensorUpdates",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/SensorUpdates{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -628,8 +628,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query EnrichedSensorReadingByPlacement($placement: Placements!, $limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReadingByPlacement(placement: $placement, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
+            "queryName" : "EnrichedSensorReadingByPlacement",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/EnrichedSensorReadingByPlacement{?offset,limit,placement}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -652,15 +660,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query EnrichedSensorReadingByPlacement($placement: Placements!, $limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReadingByPlacement(placement: $placement, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
-            "queryName" : "EnrichedSensorReadingByPlacement",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/EnrichedSensorReadingByPlacement{?offset,limit,placement}"
+          }
         },
         {
           "function" : {
@@ -689,8 +689,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!, $placement: Placements!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature, placement: $placement }) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
+            "queryName" : "SensorReading",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SensorReading",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "sensorid" : {
@@ -711,15 +719,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!, $placement: Placements!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature, placement: $placement }) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
-            "queryName" : "SensorReading",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SensorReading"
+          }
         },
         {
           "function" : {
@@ -740,8 +740,16 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation SensorUpdates($sensorid: Int!, $sensor_name: String!) {\nSensorUpdates(event: { sensorid: $sensorid, sensor_name: $sensor_name }) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
+            "queryName" : "SensorUpdates",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/SensorUpdates",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "sensorid" : {
@@ -755,15 +763,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation SensorUpdates($sensorid: Int!, $sensor_name: String!) {\nSensorUpdates(event: { sensorid: $sensorid, sensor_name: $sensor_name }) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
-            "queryName" : "SensorUpdates",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/SensorUpdates"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -474,6 +474,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -498,7 +499,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query EnrichedSensorReading($limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
             "queryName" : "EnrichedSensorReading",
@@ -524,6 +524,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -549,7 +550,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",
@@ -575,6 +575,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -593,7 +594,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorUpdates($limit: Int = 10, $offset: Int = 0) {\nSensorUpdates(limit: $limit, offset: $offset) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
             "queryName" : "SensorUpdates",
@@ -628,6 +628,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -652,7 +653,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query EnrichedSensorReadingByPlacement($placement: Placements!, $limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReadingByPlacement(placement: $placement, limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
             "queryName" : "EnrichedSensorReadingByPlacement",
@@ -689,6 +689,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -711,7 +712,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!, $placement: Placements!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature, placement: $placement }) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
             "queryName" : "SensorReading",
@@ -740,6 +740,7 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -755,7 +756,6 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation SensorUpdates($sensorid: Int!, $sensor_name: String!) {\nSensorUpdates(event: { sensorid: $sensorid, sensor_name: $sensor_name }) {\nsensorid\nsensor_name\nlastUpdated\n}\n\n}",
             "queryName" : "SensorUpdates",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -474,6 +474,30 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "placement" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "sensor_name" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query EnrichedSensorReading($limit: Int = 10, $offset: Int = 0) {\nEnrichedSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\nsensor_name\n}\n\n}",
@@ -500,6 +524,31 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "placement" : {
+                  "type" : "string",
+                  "enum" : [
+                    "DOWNSTAIRS",
+                    "UPSTAIRS"
+                  ]
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query SensorReading($limit: Int = 10, $offset: Int = 0) {\nSensorReading(limit: $limit, offset: $offset) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
@@ -524,6 +573,24 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "sensor_name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -559,6 +626,30 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               "required" : [
                 "placement"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "sensorid" : {
+                  "type" : "integer"
+                },
+                "temperature" : {
+                  "type" : "number"
+                },
+                "placement" : {
+                  "type" : "string"
+                },
+                "event_time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "sensor_name" : {
+                  "type" : "string"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -598,6 +689,28 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
               ]
             }
           },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "sensorid" : {
+                "type" : "integer"
+              },
+              "temperature" : {
+                "type" : "number"
+              },
+              "placement" : {
+                "type" : "string",
+                "enum" : [
+                  "DOWNSTAIRS",
+                  "UPSTAIRS"
+                ]
+              },
+              "event_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation SensorReading($sensorid: Int!, $temperature: Float!, $placement: Placements!) {\nSensorReading(event: { sensorid: $sensorid, temperature: $temperature, placement: $placement }) {\nsensorid\ntemperature\nplacement\nevent_time\n}\n\n}",
@@ -625,6 +738,21 @@ CREATE TABLE IF NOT EXISTS "SensorUpdates" ("sensorid" INTEGER NOT NULL, "sensor
                 "sensorid",
                 "sensor_name"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "sensorid" : {
+                "type" : "integer"
+              },
+              "sensor_name" : {
+                "type" : "string"
+              },
+              "lastUpdated" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
@@ -223,6 +223,7 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -237,7 +238,6 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query AppendStream($limit: Int = 10, $offset: Int = 0) {\nAppendStream(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
             "queryName" : "AppendStream",
@@ -263,6 +263,7 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -277,7 +278,6 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query InputAgg($limit: Int = 10, $offset: Int = 0) {\nInputAgg(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
             "queryName" : "InputAgg",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
@@ -223,8 +223,16 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query AppendStream($limit: Int = 10, $offset: Int = 0) {\nAppendStream(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
+            "queryName" : "AppendStream",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/AppendStream{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -237,15 +245,7 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query AppendStream($limit: Int = 10, $offset: Int = 0) {\nAppendStream(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
-            "queryName" : "AppendStream",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/AppendStream{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -263,8 +263,16 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query InputAgg($limit: Int = 10, $offset: Int = 0) {\nInputAgg(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
+            "queryName" : "InputAgg",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/InputAgg{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -277,15 +285,7 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query InputAgg($limit: Int = 10, $offset: Int = 0) {\nInputAgg(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
-            "queryName" : "InputAgg",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/InputAgg{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
@@ -223,6 +223,20 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "k" : {
+                  "type" : "string"
+                },
+                "v_sum" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query AppendStream($limit: Int = 10, $offset: Int = 0) {\nAppendStream(limit: $limit, offset: $offset) {\nk\nv_sum\n}\n\n}",
@@ -247,6 +261,20 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "k" : {
+                  "type" : "string"
+                },
+                "v_sum" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
@@ -351,6 +351,20 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "string"
+                },
+                "myFnc" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyAsyncTable($limit: Int = 10, $offset: Int = 0) {\nMyAsyncTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
@@ -375,6 +389,20 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                },
+                "myFnc" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -403,6 +431,20 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                },
+                "myFnc" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTableAnother($limit: Int = 10, $offset: Int = 0) {\nMyTableAnother(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
@@ -427,6 +469,20 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               },
               "required" : [ ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "val" : {
+                  "type" : "integer"
+                },
+                "fn" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
@@ -351,8 +351,16 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyAsyncTable($limit: Int = 10, $offset: Int = 0) {\nMyAsyncTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
+            "queryName" : "MyAsyncTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyAsyncTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -365,15 +373,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyAsyncTable($limit: Int = 10, $offset: Int = 0) {\nMyAsyncTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
-            "queryName" : "MyAsyncTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyAsyncTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -391,8 +391,16 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
+            "queryName" : "MyTable",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTable{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -405,15 +413,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
-            "queryName" : "MyTable",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTable{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -431,8 +431,16 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTableAnother($limit: Int = 10, $offset: Int = 0) {\nMyTableAnother(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
+            "queryName" : "MyTableAnother",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTableAnother{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -445,15 +453,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTableAnother($limit: Int = 10, $offset: Int = 0) {\nMyTableAnother(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
-            "queryName" : "MyTableAnother",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTableAnother{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -471,8 +471,16 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query MyTableDifferentCase($limit: Int = 10, $offset: Int = 0) {\nMyTableDifferentCase(limit: $limit, offset: $offset) {\nval\nfn\n}\n\n}",
+            "queryName" : "MyTableDifferentCase",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/MyTableDifferentCase{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -485,15 +493,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query MyTableDifferentCase($limit: Int = 10, $offset: Int = 0) {\nMyTableDifferentCase(limit: $limit, offset: $offset) {\nval\nfn\n}\n\n}",
-            "queryName" : "MyTableDifferentCase",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/MyTableDifferentCase{?offset,limit}"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
@@ -351,6 +351,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -365,7 +366,6 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyAsyncTable($limit: Int = 10, $offset: Int = 0) {\nMyAsyncTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
             "queryName" : "MyAsyncTable",
@@ -391,6 +391,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -405,7 +406,6 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTable($limit: Int = 10, $offset: Int = 0) {\nMyTable(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
             "queryName" : "MyTable",
@@ -431,6 +431,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -445,7 +446,6 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTableAnother($limit: Int = 10, $offset: Int = 0) {\nMyTableAnother(limit: $limit, offset: $offset) {\nval\nmyFnc\n}\n\n}",
             "queryName" : "MyTableAnother",
@@ -471,6 +471,7 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -485,7 +486,6 @@ CREATE TABLE IF NOT EXISTS "MyTableDifferentCase" ("val" INTEGER NOT NULL, "fn" 
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query MyTableDifferentCase($limit: Int = 10, $offset: Int = 0) {\nMyTableDifferentCase(limit: $limit, offset: $offset) {\nval\nfn\n}\n\n}",
             "queryName" : "MyTableDifferentCase",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
@@ -418,8 +418,16 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               "required" : [ ]
             }
           },
+          "apiQuery" : {
+            "query" : "query TotalOrgTokens($limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokens(limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
+            "queryName" : "TotalOrgTokens",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TotalOrgTokens{?offset,limit}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -435,15 +443,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query TotalOrgTokens($limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokens(limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
-            "queryName" : "TotalOrgTokens",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TotalOrgTokens{?offset,limit}"
+          }
         },
         {
           "function" : {
@@ -466,8 +466,16 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query TotalUserTokens($userid: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalUserTokens(userid: $userid, limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\ntotal_requests\n}\n\n}",
+            "queryName" : "TotalUserTokens",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TotalUserTokens{?offset,limit,userid}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -483,15 +491,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query TotalUserTokens($userid: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalUserTokens(userid: $userid, limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\ntotal_requests\n}\n\n}",
-            "queryName" : "TotalUserTokens",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TotalUserTokens{?offset,limit,userid}"
+          }
         },
         {
           "function" : {
@@ -518,8 +518,16 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "query TotalOrgTokensByRange($minTokens: Long!, $maxTokens: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokensByRange(minTokens: $minTokens, maxTokens: $maxTokens, limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
+            "queryName" : "TotalOrgTokensByRange",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/TotalOrgTokensByRange{?offset,maxTokens,limit,minTokens}",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "array",
             "items" : {
               "type" : "object",
@@ -535,15 +543,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
                 }
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "query TotalOrgTokensByRange($minTokens: Long!, $maxTokens: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokensByRange(minTokens: $minTokens, maxTokens: $maxTokens, limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
-            "queryName" : "TotalOrgTokensByRange",
-            "operationType" : "QUERY"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "GET",
-          "uriTemplate" : "queries/TotalOrgTokensByRange{?offset,maxTokens,limit,minTokens}"
+          }
         },
         {
           "function" : {
@@ -564,8 +564,16 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "apiQuery" : {
+            "query" : "mutation UserTokens($userid: Long!, $tokens: Long!) {\nUserTokens(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nrequest_time\n}\n\n}",
+            "queryName" : "UserTokens",
+            "operationType" : "MUTATION"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "POST",
+          "uriTemplate" : "mutations/UserTokens",
           "format" : "JSON",
-          "result" : {
+          "resultDefinition" : {
             "type" : "object",
             "properties" : {
               "userid" : {
@@ -579,15 +587,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
                 "format" : "date-time"
               }
             }
-          },
-          "apiQuery" : {
-            "query" : "mutation UserTokens($userid: Long!, $tokens: Long!) {\nUserTokens(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nrequest_time\n}\n\n}",
-            "queryName" : "UserTokens",
-            "operationType" : "MUTATION"
-          },
-          "mcpMethod" : "TOOL",
-          "restMethod" : "POST",
-          "uriTemplate" : "mutations/UserTokens"
+          }
         }
       ],
       "schema" : {

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
@@ -418,6 +418,23 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               "required" : [ ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orgid" : {
+                  "type" : "integer"
+                },
+                "total_tokens" : {
+                  "type" : "integer"
+                },
+                "total_requests" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TotalOrgTokens($limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokens(limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
@@ -447,6 +464,23 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               "required" : [
                 "userid"
               ]
+            }
+          },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "userid" : {
+                  "type" : "integer"
+                },
+                "total_tokens" : {
+                  "type" : "integer"
+                },
+                "total_requests" : {
+                  "type" : "integer"
+                }
+              }
             }
           },
           "format" : "JSON",
@@ -484,6 +518,23 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "result" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "orgid" : {
+                  "type" : "integer"
+                },
+                "total_tokens" : {
+                  "type" : "integer"
+                },
+                "total_requests" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
           "format" : "JSON",
           "apiQuery" : {
             "query" : "query TotalOrgTokensByRange($minTokens: Long!, $maxTokens: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokensByRange(minTokens: $minTokens, maxTokens: $maxTokens, limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
@@ -511,6 +562,21 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
                 "userid",
                 "tokens"
               ]
+            }
+          },
+          "result" : {
+            "type" : "object",
+            "properties" : {
+              "userid" : {
+                "type" : "integer"
+              },
+              "tokens" : {
+                "type" : "integer"
+              },
+              "request_time" : {
+                "type" : "string",
+                "format" : "date-time"
+              }
             }
           },
           "format" : "JSON",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
@@ -418,6 +418,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               "required" : [ ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -435,7 +436,6 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query TotalOrgTokens($limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokens(limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
             "queryName" : "TotalOrgTokens",
@@ -466,6 +466,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -483,7 +484,6 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query TotalUserTokens($userid: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalUserTokens(userid: $userid, limit: $limit, offset: $offset) {\nuserid\ntotal_tokens\ntotal_requests\n}\n\n}",
             "queryName" : "TotalUserTokens",
@@ -518,6 +518,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "array",
             "items" : {
@@ -535,7 +536,6 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "query TotalOrgTokensByRange($minTokens: Long!, $maxTokens: Long!, $limit: Int = 10, $offset: Int = 0) {\nTotalOrgTokensByRange(minTokens: $minTokens, maxTokens: $maxTokens, limit: $limit, offset: $offset) {\norgid\ntotal_tokens\ntotal_requests\n}\n\n}",
             "queryName" : "TotalOrgTokensByRange",
@@ -564,6 +564,7 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               ]
             }
           },
+          "format" : "JSON",
           "result" : {
             "type" : "object",
             "properties" : {
@@ -579,7 +580,6 @@ CREATE INDEX IF NOT EXISTS "TotalOrgTokens_btree_c1" ON "TotalOrgTokens" USING b
               }
             }
           },
-          "format" : "JSON",
           "apiQuery" : {
             "query" : "mutation UserTokens($userid: Long!, $tokens: Long!) {\nUserTokens(event: { userid: $userid, tokens: $tokens }) {\nuserid\ntokens\nrequest_time\n}\n\n}",
             "queryName" : "UserTokens",


### PR DESCRIPTION
## Key Changes

- Generate a versioned OpenAPI specification during compilation and package it as a deployment artifact.
- Support an optional OpenAPI specification in API configuration and validate generated specifications for backwards compatibility.
- Serve the compiled OpenAPI artifact at runtime and update its server URL from the incoming request host.
- Fall back to generating OpenAPI with the request host when the artifact is unavailable or invalid.
- Derive and persist GraphQL operation response schemas for OpenAPI response documentation.
- Refactor server-model generation into `ServerModelManager`.
- Split URI parameter extraction into query and path handling.
- Make POST operations handle path parameters and JSON body parameters.
- Reject POST requests when a path parameter conflicts with the corresponding body value.