### PR TITLE
feat: Configurable pg_partman premake and historical start partition

### DIFF
--- a/documentation/docs/configuration-default.md
+++ b/documentation/docs/configuration-default.md
@@ -41,7 +41,8 @@ The following is the [default configuration file](https://raw.githubusercontent.
       "scan-cte-cardinality-divisor": 1
     },
     "postgres": {
-      "partition-ttl-divisor": 100
+      "partition-ttl-divisor": 100,
+      "partition-premake": 4
     },
     "kafka": {
       "retention": null,

--- a/documentation/docs/configuration-engine/postgres.md
+++ b/documentation/docs/configuration-engine/postgres.md
@@ -9,6 +9,7 @@ No mandatory configuration keys are required. Physical DDL (tables, indexes, vie
 | Key                     | Type        | Default | Description                                                                                                    |
 |-------------------------|-------------|---------|----------------------------------------------------------------------------------------------------------------|
 | `partition-ttl-divisor` | **integer** | `100`   | Controls the number of partitions for range-partitioned tables with a TTL (see [Partitioning](#partitioning)). |
+| `partition-premake`     | **integer** | `4`     | Number of future partitions pg_partman pre-creates ahead of the current one (`p_premake`).                     |
 
 ## Basic Configuration
 
@@ -34,6 +35,8 @@ Tables annotated with `partition_key` on a timestamp column and a `ttl` hint are
 - The result is snapped down to the closest calendar-aligned width from: 15 min, 30 min, 1, 2, 4, 6, 8, 12 hours, 1, 2, 4 days, 1, 2, 4, 8, 12 weeks.
 
 For example, `ttl(14 days)` with the default divisor produces 1-day partitions.
+
+At setup time, pg_partman pre-creates the historical partitions covering the full TTL window (via `p_start_partition`), so replayed or late-arriving data within the retention period lands in a dated partition rather than the DEFAULT partition. The `partition-premake` key controls how many future partitions are created ahead of the current one.
 
 ## Cloud Deployment
 

--- a/sqrl-planner/src/main/java/com/datasqrl/config/EngineConfigImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/EngineConfigImpl.java
@@ -36,17 +36,29 @@ public class EngineConfigImpl implements PackageJson.EngineConfig {
   }
 
   @Override
-  public String getSetting(String key, Optional<String> defaultValue) {
-    var result = sqrlConfig.asString(key);
+  public String getProperty(String key, Optional<String> defaultValue) {
+    return getPropertyAs(key, String.class, defaultValue);
+  }
+
+  @Override
+  public <T> T getPropertyAs(String key, Class<T> valueClass, Optional<T> defaultValue) {
+    var result = sqrlConfig.as(key, valueClass);
     if (defaultValue.isPresent()) {
       result = result.withDefault(defaultValue.get());
     }
+
     return result.get();
   }
 
   @Override
-  public Optional<String> getSettingOptional(String key) {
-    var result = sqrlConfig.asString(key);
+  public Optional<String> getPropertyOptional(String key) {
+    return getPropertyAsOptional(key, String.class);
+  }
+
+  @Override
+  public <T> Optional<T> getPropertyAsOptional(String key, Class<T> valueClass) {
+    var result = sqrlConfig.as(key, valueClass);
+
     return result.getOptional();
   }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
@@ -146,13 +146,21 @@ public interface PackageJson {
 
     String getEngineName();
 
-    default String getSetting(String key) {
-      return getSetting(key, Optional.empty());
+    default String getProperty(String key) {
+      return getProperty(key, Optional.empty());
     }
 
-    String getSetting(String key, Optional<String> defaultValue);
+    default <T> T getPropertyAs(String key, Class<T> valueClass) {
+      return getPropertyAs(key, valueClass, Optional.empty());
+    }
 
-    Optional<String> getSettingOptional(String key);
+    String getProperty(String key, Optional<String> defaultValue);
+
+    <T> T getPropertyAs(String key, Class<T> valueClass, Optional<T> defaultValue);
+
+    Optional<String> getPropertyOptional(String key);
+
+    <T> Optional<T> getPropertyAsOptional(String key, Class<T> valueClass);
 
     Map<String, Object> getConfig();
 
@@ -165,7 +173,12 @@ public interface PackageJson {
     String engineName;
 
     @Override
-    public String getSetting(String key, Optional<String> defaultValue) {
+    public String getProperty(String key, Optional<String> defaultValue) {
+      return getPropertyAs(key, String.class);
+    }
+
+    @Override
+    public <T> T getPropertyAs(String key, Class<T> valueClass, Optional<T> defaultValue) {
       return defaultValue.orElseThrow(
           () ->
               new IllegalArgumentException(
@@ -173,7 +186,12 @@ public interface PackageJson {
     }
 
     @Override
-    public Optional<String> getSettingOptional(String key) {
+    public Optional<String> getPropertyOptional(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> getPropertyAsOptional(String key, Class<T> valueClass) {
       return Optional.empty();
     }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDbStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/DuckDbStatementFactory.java
@@ -65,7 +65,7 @@ public class DuckDbStatementFactory extends AbstractJdbcStatementFactory {
             DuckDbSqlDialect.DEFAULT)); // Iceberg creates the tables, DuckDB only queries
 
     var scanCteCardinalityDivisor =
-        Integer.parseInt(engineConfig.getSetting(SCAN_CTE_CARDINALITY_DIVISOR));
+        Integer.parseInt(engineConfig.getProperty(SCAN_CTE_CARDINALITY_DIVISOR));
     checkArgument(
         Double.isFinite(scanCteCardinalityDivisor) && scanCteCardinalityDivisor > 0,
         "'%s' must be a positive finite number",

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.calcite.dialect.ExtendedPostgresSqlDialect;
+import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.deployment.model.JdbcStatementModel.Type;
@@ -51,16 +52,22 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
   public static final String PARTITION_TTL_DIVISOR_KEY = "partition-ttl-divisor";
 
   private final int partitionTtlDivisor;
+  private final EngineConfig engineConfig;
 
   public PostgresStatementFactory(EngineConfig engineConfig) {
-    this(Integer.parseInt(engineConfig.getSetting(PARTITION_TTL_DIVISOR_KEY)));
+    this(Integer.parseInt(engineConfig.getSetting(PARTITION_TTL_DIVISOR_KEY)), engineConfig);
   }
 
   public PostgresStatementFactory(int partitionTtlDivisor) {
+    this(partitionTtlDivisor, new PackageJson.EmptyEngineConfig("postgres"));
+  }
+
+  public PostgresStatementFactory(int partitionTtlDivisor, EngineConfig engineConfig) {
     super(Dialect.POSTGRES, new PostgresCreateTableDdlFactory(true));
     checkArgument(
         partitionTtlDivisor > 0, "%s must be a positive number", PARTITION_TTL_DIVISOR_KEY);
     this.partitionTtlDivisor = partitionTtlDivisor;
+    this.engineConfig = engineConfig;
   }
 
   @Override
@@ -115,7 +122,7 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
 
     var tableExtensions = ServiceLoaderDiscovery.getAll(DatabaseTableExtension.class);
     for (var ext : tableExtensions) {
-      var ddl = ext.getDdl(tables);
+      var ddl = ext.getDdl(tables, engineConfig);
 
       if (ddl != null && !ddl.isBlank()) {
         res.add(new GenericJdbcStatement(ext.getName(), Type.EXTENSION, ddl));

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/PostgresStatementFactory.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.calcite.dialect.ExtendedPostgresSqlDialect;
-import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.deployment.model.JdbcStatementModel.Type;
@@ -55,19 +54,11 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
   private final EngineConfig engineConfig;
 
   public PostgresStatementFactory(EngineConfig engineConfig) {
-    this(Integer.parseInt(engineConfig.getSetting(PARTITION_TTL_DIVISOR_KEY)), engineConfig);
-  }
-
-  public PostgresStatementFactory(int partitionTtlDivisor) {
-    this(partitionTtlDivisor, new PackageJson.EmptyEngineConfig("postgres"));
-  }
-
-  public PostgresStatementFactory(int partitionTtlDivisor, EngineConfig engineConfig) {
     super(Dialect.POSTGRES, new PostgresCreateTableDdlFactory(true));
+    this.engineConfig = engineConfig;
+    partitionTtlDivisor = engineConfig.getPropertyAs(PARTITION_TTL_DIVISOR_KEY, Integer.class);
     checkArgument(
         partitionTtlDivisor > 0, "%s must be a positive number", PARTITION_TTL_DIVISOR_KEY);
-    this.partitionTtlDivisor = partitionTtlDivisor;
-    this.engineConfig = engineConfig;
   }
 
   @Override
@@ -122,7 +113,7 @@ public class PostgresStatementFactory extends AbstractJdbcStatementFactory {
 
     var tableExtensions = ServiceLoaderDiscovery.getAll(DatabaseTableExtension.class);
     for (var ext : tableExtensions) {
-      var ddl = ext.getDdl(tables, engineConfig);
+      var ddl = ext.getDdl(tables, Optional.of(engineConfig));
 
       if (ddl != null && !ddl.isBlank()) {
         res.add(new GenericJdbcStatement(ext.getName(), Type.EXTENSION, ddl));

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
@@ -45,12 +45,12 @@ public class RedshiftStatementFactory extends AbstractJdbcStatementFactory {
   @Override
   protected SqlIdentifier getViewStatementIdentifier(String viewName) {
     var names = new ArrayList<String>();
-    var database = engineConfig.getSettingOptional("view-database");
+    var database = engineConfig.getPropertyOptional("view-database");
     if (database.isPresent()) {
       names.add(database.get());
-      names.add(engineConfig.getSettingOptional("view-schema").orElse("public"));
+      names.add(engineConfig.getPropertyOptional("view-schema").orElse("public"));
     } else {
-      engineConfig.getSettingOptional("view-schema").ifPresent(names::add);
+      engineConfig.getPropertyOptional("view-schema").ifPresent(names::add);
     }
     names.add(viewName);
 

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SnowflakeStatementFactory.java
@@ -49,7 +49,7 @@ public class SnowflakeStatementFactory extends AbstractJdbcStatementFactory {
   public String getSnowflakeCreateTable(String tableName) {
     SqlLiteral externalVolume =
         SqlLiteral.createCharString(
-            engineConfig.getSetting("external-volume", Optional.empty()), SqlParserPos.ZERO);
+            engineConfig.getProperty("external-volume", Optional.empty()), SqlParserPos.ZERO);
 
     var icebergTable =
         new SqlCreateIcebergTableFromObjectStorage(
@@ -59,7 +59,7 @@ public class SnowflakeStatementFactory extends AbstractJdbcStatementFactory {
             new SqlIdentifier(tableName, SqlParserPos.ZERO),
             externalVolume,
             SqlLiteral.createCharString(
-                engineConfig.getSetting("catalog-name", Optional.empty()), SqlParserPos.ZERO),
+                engineConfig.getProperty("catalog-name", Optional.empty()), SqlParserPos.ZERO),
             SqlLiteral.createCharString(tableName, SqlParserPos.ZERO),
             null,
             null,

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
@@ -45,12 +45,12 @@ public class SparkSqlStatementFactory extends AbstractJdbcStatementFactory {
   @Override
   protected SqlIdentifier getViewStatementIdentifier(String viewName) {
     var names = new ArrayList<String>();
-    var catalog = engineConfig.getSettingOptional("view-catalog");
+    var catalog = engineConfig.getPropertyOptional("view-catalog");
     if (catalog.isPresent()) {
       names.add(catalog.get());
-      names.add(engineConfig.getSettingOptional("view-database").orElse("default"));
+      names.add(engineConfig.getPropertyOptional("view-database").orElse("default"));
     } else {
-      engineConfig.getSettingOptional("view-database").ifPresent(names::add);
+      engineConfig.getPropertyOptional("view-database").ifPresent(names::add);
     }
     names.add(viewName);
     return new SqlIdentifier(names, SqlParserPos.ZERO);

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/log/kafka/KafkaLogEngine.java
@@ -106,18 +106,18 @@ public class KafkaLogEngine extends ExecutionEngine.Base implements LogEngine {
         connectorFactory.getConfig(KafkaLogEngineFactory.ENGINE_NAME + "-mutation");
     defaultTTL =
         engineConfig
-            .getSettingOptional(DEFAULT_TTL_KEY)
+            .getPropertyOptional(DEFAULT_TTL_KEY)
             .map(
                 value ->
                     value.equals("-1") ? Duration.ofMillis(-1) : TimeUtils.parseDuration(value));
-    useSourceWatermark = Boolean.parseBoolean(engineConfig.getSetting("use-source-watermark"));
+    useSourceWatermark = Boolean.parseBoolean(engineConfig.getProperty("use-source-watermark"));
     useTransactionSourceWatermark =
-        Boolean.parseBoolean(engineConfig.getSetting("use-transaction-source-watermark"));
-    defaultWatermark = TimeUtils.parseDuration(engineConfig.getSetting("watermark"));
+        Boolean.parseBoolean(engineConfig.getProperty("use-transaction-source-watermark"));
+    defaultWatermark = TimeUtils.parseDuration(engineConfig.getProperty("watermark"));
     transactionWatermark =
-        TimeUtils.parseDuration(engineConfig.getSetting("transaction-watermark"));
-    numPartitions = Integer.parseInt(engineConfig.getSetting("num-partitions"));
-    replicationFactor = Short.parseShort(engineConfig.getSetting("replication-factor"));
+        TimeUtils.parseDuration(engineConfig.getProperty("transaction-watermark"));
+    numPartitions = Integer.parseInt(engineConfig.getProperty("num-partitions"));
+    replicationFactor = Short.parseShort(engineConfig.getProperty("replication-factor"));
     format =
         String.valueOf(streamConnectorConf.toMap().get(FlinkConnectorConfigWrapper.FORMAT_KEY))
             .trim()

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
@@ -15,6 +15,8 @@
  */
 package com.datasqrl.function.translation.postgres.extensions;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
@@ -30,8 +32,7 @@ import java.util.Optional;
 @AutoService(DatabaseTableExtension.class)
 public class PgPartmanExtension implements DatabaseTableExtension {
 
-  public static final String PARTITION_PREMAKE_KEY = "partition-premake";
-  private static final String DEFAULT_PREMAKE = "4";
+  static final String PARTITION_PREMAKE_KEY = "partition-premake";
 
   @Override
   public String getName() {
@@ -40,12 +41,16 @@ public class PgPartmanExtension implements DatabaseTableExtension {
 
   @Override
   public String getDdl(
-      Collection<CreateTableJdbcStatement> createTables, EngineConfig engineConfig) {
-    var premake =
-        Integer.parseInt(
-            engineConfig.getSetting(PARTITION_PREMAKE_KEY, Optional.of(DEFAULT_PREMAKE)));
-    Preconditions.checkArgument(
-        premake >= 1, "%s must be a positive number", PARTITION_PREMAKE_KEY);
+      Collection<CreateTableJdbcStatement> createTables, Optional<EngineConfig> engineConfig) {
+
+    int premake =
+        engineConfig
+            .map(ec -> ec.getPropertyAs(PARTITION_PREMAKE_KEY, Integer.class))
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Config option '%s' has to be set for pg_partman"));
+    checkArgument(premake >= 1, "%s must be a positive number", PARTITION_PREMAKE_KEY);
 
     var partmanTables =
         createTables.stream()
@@ -81,7 +86,6 @@ public class PgPartmanExtension implements DatabaseTableExtension {
 
     var retention = formatRetention(ttl);
 
-    // p_type was removed in pg_partman 5.x; the default (range) is what we need.
     // p_start_partition pre-creates the historical partitions covering the retention window so
     // that catch-up replay does not land in the DEFAULT partition.
     sb.append(

--- a/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtension.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.function.translation.postgres.extensions;
 
+import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import com.datasqrl.sql.DatabaseTableExtension;
@@ -23,10 +24,14 @@ import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Optional;
 
 /** Generates the pg_partman setup SQL for RANGE-partitioned tables with a TTL. */
 @AutoService(DatabaseTableExtension.class)
 public class PgPartmanExtension implements DatabaseTableExtension {
+
+  public static final String PARTITION_PREMAKE_KEY = "partition-premake";
+  private static final String DEFAULT_PREMAKE = "4";
 
   @Override
   public String getName() {
@@ -34,7 +39,14 @@ public class PgPartmanExtension implements DatabaseTableExtension {
   }
 
   @Override
-  public String getDdl(Collection<CreateTableJdbcStatement> createTables) {
+  public String getDdl(
+      Collection<CreateTableJdbcStatement> createTables, EngineConfig engineConfig) {
+    var premake =
+        Integer.parseInt(
+            engineConfig.getSetting(PARTITION_PREMAKE_KEY, Optional.of(DEFAULT_PREMAKE)));
+    Preconditions.checkArgument(
+        premake >= 1, "%s must be a positive number", PARTITION_PREMAKE_KEY);
+
     var partmanTables =
         createTables.stream()
             .filter(createTable -> !isNotPartmanTable(createTable))
@@ -49,12 +61,12 @@ public class PgPartmanExtension implements DatabaseTableExtension {
     sb.append("CREATE SCHEMA IF NOT EXISTS partman;\n");
     sb.append("CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;\n\n");
 
-    partmanTables.forEach(createTable -> appendTableDdl(sb, createTable));
+    partmanTables.forEach(createTable -> appendTableDdl(sb, createTable, premake));
 
     return sb.toString().trim();
   }
 
-  private void appendTableDdl(StringBuilder sb, CreateTableJdbcStatement createTable) {
+  private void appendTableDdl(StringBuilder sb, CreateTableJdbcStatement createTable, int premake) {
 
     // pg_partman resolves p_parent_table by matching split_part(name, '.', 2) against
     // pg_class.relname, so the name must be schema-qualified but NOT identifier-quoted:
@@ -67,18 +79,24 @@ public class PgPartmanExtension implements DatabaseTableExtension {
             "Missing partition interval for partitioned table %s with TTL",
             createTable.getName());
 
-    // p_type was removed in pg_partman 5.x; the default (range) is what we need
+    var retention = formatRetention(ttl);
+
+    // p_type was removed in pg_partman 5.x; the default (range) is what we need.
+    // p_start_partition pre-creates the historical partitions covering the retention window so
+    // that catch-up replay does not land in the DEFAULT partition.
     sb.append(
         """
         SELECT partman.create_parent(
             p_parent_table => '%s',
             p_control => '%s',
             p_interval => '%s',
-            p_premake => 4
+            p_premake => %d,
+            p_start_partition => (now() - interval '%s')::text
         );
 
         """
-            .formatted(parentTable, createTable.getPartitionKey().get(0), interval));
+            .formatted(
+                parentTable, createTable.getPartitionKey().get(0), interval, premake, retention));
 
     sb.append(
         """
@@ -88,7 +106,7 @@ public class PgPartmanExtension implements DatabaseTableExtension {
          WHERE parent_table = '%s';
 
         """
-            .formatted(formatRetention(ttl), parentTable));
+            .formatted(retention, parentTable));
   }
 
   private boolean isNotPartmanTable(CreateTableJdbcStatement createTable) {

--- a/sqrl-planner/src/main/java/com/datasqrl/sql/DatabaseTableExtension.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/sql/DatabaseTableExtension.java
@@ -15,16 +15,17 @@
  */
 package com.datasqrl.sql;
 
+import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import java.util.Collection;
 
 /**
  * Service-loader extension point for database-specific DDL that depends on the full set of created
- * tables.
+ * tables. Extensions may read their own settings from the engine configuration.
  */
 public interface DatabaseTableExtension {
 
   String getName();
 
-  String getDdl(Collection<CreateTableJdbcStatement> createTables);
+  String getDdl(Collection<CreateTableJdbcStatement> createTables, EngineConfig engineConfig);
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/sql/DatabaseTableExtension.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/sql/DatabaseTableExtension.java
@@ -18,6 +18,7 @@ package com.datasqrl.sql;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Service-loader extension point for database-specific DDL that depends on the full set of created
@@ -27,5 +28,10 @@ public interface DatabaseTableExtension {
 
   String getName();
 
-  String getDdl(Collection<CreateTableJdbcStatement> createTables, EngineConfig engineConfig);
+  String getDdl(
+      Collection<CreateTableJdbcStatement> createTables, Optional<EngineConfig> engineConfig);
+
+  default String getDdl(Collection<CreateTableJdbcStatement> createTables) {
+    return getDdl(createTables, Optional.empty());
+  }
 }

--- a/sqrl-planner/src/main/resources/default-package.json
+++ b/sqrl-planner/src/main/resources/default-package.json
@@ -36,7 +36,8 @@
       "scan-cte-cardinality-divisor": 1
     },
     "postgres": {
-      "partition-ttl-divisor": 100
+      "partition-ttl-divisor": 100,
+      "partition-premake": 4
     },
     "kafka": {
       "retention": null,

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -300,6 +300,10 @@
               "description": "Divisor applied to a table's TTL to cap the number of pg_partman partitions.",
               "type": "integer"
             },
+            "partition-premake": {
+              "description": "Number of future partitions pg_partman pre-creates ahead of the current one (p_premake).",
+              "type": "integer"
+            },
             "config": {
               "type": "object",
               "minProperties": 1

--- a/sqrl-planner/src/test/java/com/datasqrl/config/EngineConfigImplTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/EngineConfigImplTest.java
@@ -53,20 +53,20 @@ class EngineConfigImplTest {
   }
 
   @Test
-  void givenConfigWithCustomSetting_whenGetSetting_thenReturnsValue() {
+  void givenConfigWithCustomSetting_whenGetProperty_thenReturnsValue() {
     config.setProperty("custom-setting", "customValue");
 
     var engineConfig = new EngineConfigImpl(config);
 
-    var value = engineConfig.getSetting("custom-setting", Optional.empty());
+    var value = engineConfig.getProperty("custom-setting", Optional.empty());
     assertThat(value).isEqualTo("customValue");
   }
 
   @Test
-  void givenConfigWithoutSetting_whenGetSettingWithDefault_thenReturnsDefault() {
+  void givenConfigWithoutSetting_whenGetPropertyWithDefault_thenReturnsDefault() {
     var engineConfig = new EngineConfigImpl(config);
 
-    var value = engineConfig.getSetting("missing-setting", Optional.of("default"));
+    var value = engineConfig.getProperty("missing-setting", Optional.of("default"));
 
     assertThat(value).isEqualTo("default");
   }

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/PostgresStatementFactoryTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/PostgresStatementFactoryTest.java
@@ -28,9 +28,17 @@ import org.junit.jupiter.api.Test;
 
 class PostgresStatementFactoryTest {
 
+  private static EngineConfig config(int partitionTtlDivisor) {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getPropertyAs(
+            PostgresStatementFactory.PARTITION_TTL_DIVISOR_KEY, Integer.class))
+        .thenReturn(partitionTtlDivisor);
+    return engineConfig;
+  }
+
   @Test
   void givenNonRangeOrNoTtl_whenDeriveInterval_thenEmpty() {
-    var factory = new PostgresStatementFactory(100);
+    var factory = new PostgresStatementFactory(config(100));
 
     assertThat(
             factory.derivePartitionInterval(
@@ -45,7 +53,7 @@ class PostgresStatementFactoryTest {
 
   @Test
   void givenRangeAndTtl_whenDeriveInterval_thenWidthReturned() {
-    var factory = new PostgresStatementFactory(100);
+    var factory = new PostgresStatementFactory(config(100));
 
     assertThat(
             factory.derivePartitionInterval(
@@ -55,10 +63,7 @@ class PostgresStatementFactoryTest {
 
   @Test
   void givenConfiguredDivisor_whenCreate_thenDivisorApplied() {
-    var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSetting(PostgresStatementFactory.PARTITION_TTL_DIVISOR_KEY))
-        .thenReturn("4");
-    var factory = new PostgresStatementFactory(engineConfig);
+    var factory = new PostgresStatementFactory(config(4));
 
     assertThat(
             factory.derivePartitionInterval(
@@ -68,14 +73,7 @@ class PostgresStatementFactoryTest {
 
   @Test
   void givenInvalidDivisor_whenCreate_thenThrows() {
-    var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSetting(PostgresStatementFactory.PARTITION_TTL_DIVISOR_KEY))
-        .thenReturn("not-a-number");
-
-    assertThatThrownBy(() -> new PostgresStatementFactory(engineConfig))
-        .isInstanceOf(NumberFormatException.class);
-
-    assertThatThrownBy(() -> new PostgresStatementFactory(0))
+    assertThatThrownBy(() -> new PostgresStatementFactory(config(0)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("partition-ttl-divisor");
   }

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
@@ -27,7 +27,11 @@ class ViewStatementIdentifierTest {
 
   @Test
   void givenDefaultStatementFactory_whenGettingViewIdentifier_thenReturnsViewNameOnly() {
-    var factory = new PostgresStatementFactory(1);
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getPropertyAs(
+            PostgresStatementFactory.PARTITION_TTL_DIVISOR_KEY, Integer.class))
+        .thenReturn(1);
+    var factory = new PostgresStatementFactory(engineConfig);
 
     assertThat(factory.getViewStatementIdentifier("Orders").names).containsExactly("Orders");
   }
@@ -35,8 +39,8 @@ class ViewStatementIdentifierTest {
   @Test
   void givenSparkViewLocation_whenGettingViewIdentifier_thenPrependsCatalogAndDatabase() {
     var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSettingOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
-    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getPropertyOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
+    when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.of("analytics"));
     var factory = new SparkSqlStatementFactory(engineConfig);
 
     assertThat(factory.getViewStatementIdentifier("Orders").names)
@@ -46,8 +50,8 @@ class ViewStatementIdentifierTest {
   @Test
   void givenSparkViewCatalogWithoutDatabase_whenGettingViewIdentifier_thenUsesDefaultDatabase() {
     var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSettingOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
-    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.empty());
+    when(engineConfig.getPropertyOptional("view-catalog")).thenReturn(Optional.of("spark_catalog"));
+    when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.empty());
     var factory = new SparkSqlStatementFactory(engineConfig);
 
     assertThat(factory.getViewStatementIdentifier("Orders").names)
@@ -57,8 +61,8 @@ class ViewStatementIdentifierTest {
   @Test
   void givenRedshiftViewLocation_whenGettingViewIdentifier_thenPrependsDatabaseAndSchema() {
     var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
-    when(engineConfig.getSettingOptional("view-schema")).thenReturn(Optional.of("reporting"));
+    when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.of("reporting"));
     var factory = new RedshiftStatementFactory(engineConfig);
 
     assertThat(factory.getViewStatementIdentifier("Orders").names)
@@ -68,8 +72,8 @@ class ViewStatementIdentifierTest {
   @Test
   void givenRedshiftViewDatabaseWithoutSchema_whenGettingViewIdentifier_thenUsesPublicSchema() {
     var engineConfig = mock(EngineConfig.class);
-    when(engineConfig.getSettingOptional("view-database")).thenReturn(Optional.of("analytics"));
-    when(engineConfig.getSettingOptional("view-schema")).thenReturn(Optional.empty());
+    when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.empty());
     var factory = new RedshiftStatementFactory(engineConfig);
 
     assertThat(factory.getViewStatementIdentifier("Orders").names)

--- a/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
@@ -16,16 +16,30 @@
 package com.datasqrl.function.translation.postgres.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.datasqrl.config.PackageJson;
+import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class PgPartmanExtensionTest {
 
   private final PgPartmanExtension extension = new PgPartmanExtension();
+  private final EngineConfig engineConfig = new PackageJson.EmptyEngineConfig("postgres");
+
+  private static EngineConfig premakeConfig(String premake) {
+    var config = mock(EngineConfig.class);
+    when(config.getSetting(PgPartmanExtension.PARTITION_PREMAKE_KEY, Optional.of("4")))
+        .thenReturn(premake);
+    return config;
+  }
 
   private static CreateTableJdbcStatement table(
       String name, PartitionType partitionType, List<String> partitionKey, Duration ttl) {
@@ -59,7 +73,8 @@ class PgPartmanExtensionTest {
                     table("hashed", PartitionType.HASH, List.of("id"), Duration.ofDays(30)),
                     table("noTtl", PartitionType.RANGE, List.of("time"), Duration.ZERO),
                     table("nullTtl", PartitionType.RANGE, List.of("time"), null),
-                    table("noPartitionKey", PartitionType.RANGE, List.of(), Duration.ofDays(30)))))
+                    table("noPartitionKey", PartitionType.RANGE, List.of(), Duration.ofDays(30))),
+                engineConfig))
         .isNull();
   }
 
@@ -68,7 +83,8 @@ class PgPartmanExtensionTest {
     assertThat(
             extension.getDdl(
                 List.of(
-                    table("Orders_1", PartitionType.RANGE, List.of("time"), Duration.ofDays(30)))))
+                    table("Orders_1", PartitionType.RANGE, List.of("time"), Duration.ofDays(30))),
+                engineConfig))
         .contains("CREATE SCHEMA IF NOT EXISTS partman")
         .contains("CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman")
         .contains("SELECT partman.create_parent")
@@ -76,6 +92,7 @@ class PgPartmanExtensionTest {
         .contains("p_control => 'time'")
         .contains("p_interval => '1 day'")
         .contains("p_premake => 4")
+        .contains("p_start_partition => (now() - interval '30 days')::text")
         .contains("UPDATE partman.part_config")
         .contains("retention = '30 days'")
         .contains("retention_keep_table = false")
@@ -90,7 +107,8 @@ class PgPartmanExtensionTest {
             List.of(
                 table("zebra", PartitionType.RANGE, List.of("ts"), Duration.ofDays(100)),
                 table("hashed", PartitionType.HASH, List.of("id"), Duration.ofDays(30)),
-                table("alpha", PartitionType.RANGE, List.of("time"), Duration.ofHours(12))));
+                table("alpha", PartitionType.RANGE, List.of("time"), Duration.ofHours(12))),
+            engineConfig);
 
     assertThat(sql).contains("CREATE SCHEMA IF NOT EXISTS partman");
     assertThat(sql).containsOnlyOnce("CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman");
@@ -109,9 +127,31 @@ class PgPartmanExtensionTest {
                         PartitionType.RANGE,
                         List.of("time"),
                         Duration.ofDays(14),
-                        "2 weeks"))))
+                        "2 weeks")),
+                engineConfig))
         .contains("p_interval => '2 weeks'")
         .contains("retention = '14 days'");
+  }
+
+  @Test
+  void givenConfiguredPremake_whenGetDdl_thenPremakeApplied() {
+    assertThat(
+            extension.getDdl(
+                List.of(table("Orders", PartitionType.RANGE, List.of("time"), Duration.ofDays(30))),
+                premakeConfig("1")))
+        .contains("p_premake => 1");
+  }
+
+  @Test
+  void givenInvalidPremake_whenGetDdl_thenThrows() {
+    var tables =
+        List.of(table("Orders", PartitionType.RANGE, List.of("time"), Duration.ofDays(30)));
+
+    assertThatThrownBy(() -> extension.getDdl(tables, premakeConfig("0")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("partition-premake");
+    assertThatThrownBy(() -> extension.getDdl(tables, premakeConfig("abc")))
+        .isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/function/translation/postgres/extensions/PgPartmanExtensionTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.datasqrl.config.PackageJson;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
@@ -32,13 +31,13 @@ import org.junit.jupiter.api.Test;
 class PgPartmanExtensionTest {
 
   private final PgPartmanExtension extension = new PgPartmanExtension();
-  private final EngineConfig engineConfig = new PackageJson.EmptyEngineConfig("postgres");
+  private final Optional<EngineConfig> engineConfig = premakeConfig(4);
 
-  private static EngineConfig premakeConfig(String premake) {
+  private static Optional<EngineConfig> premakeConfig(int premake) {
     var config = mock(EngineConfig.class);
-    when(config.getSetting(PgPartmanExtension.PARTITION_PREMAKE_KEY, Optional.of("4")))
+    when(config.getPropertyAs(PgPartmanExtension.PARTITION_PREMAKE_KEY, Integer.class))
         .thenReturn(premake);
-    return config;
+    return Optional.of(config);
   }
 
   private static CreateTableJdbcStatement table(
@@ -138,7 +137,7 @@ class PgPartmanExtensionTest {
     assertThat(
             extension.getDdl(
                 List.of(table("Orders", PartitionType.RANGE, List.of("time"), Duration.ofDays(30))),
-                premakeConfig("1")))
+                premakeConfig(1)))
         .contains("p_premake => 1");
   }
 
@@ -147,11 +146,9 @@ class PgPartmanExtensionTest {
     var tables =
         List.of(table("Orders", PartitionType.RANGE, List.of("time"), Duration.ofDays(30)));
 
-    assertThatThrownBy(() -> extension.getDdl(tables, premakeConfig("0")))
+    assertThatThrownBy(() -> extension.getDdl(tables, premakeConfig(0)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("partition-premake");
-    assertThatThrownBy(() -> extension.getDdl(tables, premakeConfig("abc")))
-        .isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -407,7 +407,7 @@ END
     {
       "name" : "partman",
       "type" : "EXTENSION",
-      "sql" : "CREATE SCHEMA IF NOT EXISTS partman;\nCREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.OrderMetrics_1',\n    p_control => 'time',\n    p_interval => '1 hour',\n    p_premake => 4\n);\n\nUPDATE partman.part_config\n   SET retention = '2 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.OrderMetrics_1';\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.OrderUpdates_2',\n    p_control => 'time',\n    p_interval => '1 day',\n    p_premake => 4\n);\n\nUPDATE partman.part_config\n   SET retention = '30 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.OrderUpdates_2';"
+      "sql" : "CREATE SCHEMA IF NOT EXISTS partman;\nCREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.OrderMetrics_1',\n    p_control => 'time',\n    p_interval => '1 hour',\n    p_premake => 4,\n    p_start_partition => (now() - interval '2 days')::text\n);\n\nUPDATE partman.part_config\n   SET retention = '2 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.OrderMetrics_1';\n\nSELECT partman.create_parent(\n    p_parent_table => 'public.OrderUpdates_2',\n    p_control => 'time',\n    p_interval => '1 day',\n    p_premake => 4,\n    p_start_partition => (now() - interval '30 days')::text\n);\n\nUPDATE partman.part_config\n   SET retention = '30 days',\n       retention_keep_table = false\n WHERE parent_table = 'public.OrderUpdates_2';"
     }
   ]
 }


### PR DESCRIPTION
## What was done
- Added `partition-premake` config key under `engines.postgres` (default 4) controlling `p_premake` in the generated pg_partman DDL
- Emit `p_start_partition => (now() - interval '<retention>')::text` in `create_parent` so historical partitions covering the retention window are created at setup time
- Passed the postgres `EngineConfig` through `DatabaseTableExtension.getDdl` so extensions can read their own settings
- Updated JSON schema, default package, docs, unit tests, and the DAGPlanner snapshot

## Why it was done
- `p_premake => 4` was hardcoded, always pre-creating 4 future daily partitions with no way to tune it
- Without `p_start_partition` no historical partitions exist, so catch-up replay after a blue-green deploy lands the full retention window in the DEFAULT partition, requiring a lock-heavy post-catch-up sweep and forcing full DEFAULT scans on every new partition attach