### PR TITLE
feat: Add Flink 2.3 insert conflict handling

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/DatabaseEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/DatabaseEngine.java
@@ -19,6 +19,7 @@ import com.datasqrl.engine.EnginePhysicalPlan;
 import com.datasqrl.engine.ExecutionEngine;
 import com.datasqrl.engine.export.ExportEngine;
 import com.datasqrl.planner.dag.plan.MaterializationStagePlan;
+import com.datasqrl.planner.tables.FlinkTableBuilder;
 
 /**
  * A {@link DatabaseEngine} is a {@link ExecutionEngine} that persists data for retrieval and uses
@@ -26,6 +27,11 @@ import com.datasqrl.planner.dag.plan.MaterializationStagePlan;
  * queries.
  */
 public interface DatabaseEngine extends ExecutionEngine, ExportEngine {
+
+  @Override
+  default boolean isUpsertSink(FlinkTableBuilder tableBuilder) {
+    return tableBuilder.hasPrimaryKey();
+  }
 
   EnginePhysicalPlan plan(MaterializationStagePlan stagePlan);
 

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
@@ -85,6 +85,12 @@ public class IcebergEngine extends AbstractJDBCTableFormatEngine {
   }
 
   @Override
+  public boolean isUpsertSink(FlinkTableBuilder tableBuilder) {
+    return tableBuilder.hasPrimaryKey()
+        && Boolean.parseBoolean(tableBuilder.getConnectorOptions().get(ICEBERG_UPSERT_ENABLED_KEY));
+  }
+
+  @Override
   protected Map<String, String> getConnectorOptions(
       Context.ContextBuilder ctxBuilder, TableAnalysis tableAnalysis) {
     var connectorOptions = super.getConnectorOptions(ctxBuilder, tableAnalysis);

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/export/ExportEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/export/ExportEngine.java
@@ -45,5 +45,9 @@ public interface ExportEngine extends ExecutionEngine {
       RelDataType relDataType,
       TableAnalysis tableAnalysis);
 
+  default boolean isUpsertSink(FlinkTableBuilder tableBuilder) {
+    return false;
+  }
+
   DataTypeMapping getTypeMapping();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
@@ -61,6 +61,7 @@ import org.apache.flink.sql.parser.ddl.table.SqlCreateTableLike;
 import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
 import org.apache.flink.sql.parser.ddl.view.SqlCreateView;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.sql.parser.type.SqlRawTypeNameSpec;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.types.logical.RawType;
@@ -94,18 +95,14 @@ public class FlinkSqlNodes {
         null);
   }
 
-  public static RichSqlInsert createInsert(SqlNode source, String target) {
-    return new RichSqlInsert(
-        SqlParserPos.ZERO,
-        SqlNodeList.EMPTY,
-        SqlNodeList.EMPTY,
-        identifier(target),
-        source,
-        null,
-        null);
+  public static RichSqlInsert createInsert(SqlNode source, ObjectIdentifier targetTable) {
+    return createInsert(source, targetTable, Optional.empty());
   }
 
-  public static RichSqlInsert createInsert(SqlNode source, ObjectIdentifier targetTable) {
+  public static RichSqlInsert createInsert(
+      SqlNode source,
+      ObjectIdentifier targetTable,
+      Optional<SqlInsertConflictBehavior> conflictBehavior) {
     return new RichSqlInsert(
         SqlParserPos.ZERO,
         SqlNodeList.EMPTY,
@@ -113,7 +110,8 @@ public class FlinkSqlNodes {
         identifier(targetTable),
         source,
         null,
-        null);
+        null,
+        conflictBehavior.map(cb -> cb.symbol(SqlParserPos.ZERO)).orElse(null));
   }
 
   public static SqlCreateFunction createFunction(String name, String clazz, boolean isSystem) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -96,6 +96,7 @@ import com.datasqrl.planner.parser.StatementParserException;
 import com.datasqrl.planner.tables.AccessVisibility;
 import com.datasqrl.planner.tables.FlinkTableBuilder;
 import com.datasqrl.planner.tables.SqrlTableFunction;
+import com.datasqrl.planner.util.SqlScriptPlannerUtil;
 import com.datasqrl.planner.util.SqlScriptWriter;
 import com.datasqrl.planner.util.SqlTableNameExtractor;
 import com.datasqrl.server.MutationInsertType;

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -112,6 +112,7 @@ import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
 import org.apache.flink.sql.parser.ddl.view.SqlAlterViewAs;
 import org.apache.flink.sql.parser.ddl.view.SqlCreateView;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -652,6 +653,7 @@ public class Sqrl2FlinkSQLTranslator {
             .originalSql(sql)
             .type(baseTable.getType())
             .primaryKey(baseTable.getPrimaryKey())
+            .insertConflictBehavior(baseTable.getInsertConflictBehavior())
             .optionalBaseTable(Optional.of(baseTable.getBaseTable()))
             .streamRoot(baseTable.getStreamRoot())
             .fromTables(List.of(baseTable))
@@ -988,14 +990,19 @@ public class Sqrl2FlinkSQLTranslator {
         .getTableIdentifier();
   }
 
-  public void insertInto(RelNode relNode, ObjectIdentifier sinkTableId) {
-    insertInto(relNode, sinkTableId, null);
-  }
-
   public void insertInto(
       RelNode relNode, ObjectIdentifier sinkTableId, @Nullable Integer batchIdx) {
     var selectQuery = RelToFlinkSql.convertToSqlNode(relNode);
     planBuilder.addInsert(FlinkSqlNodes.createInsert(selectQuery, sinkTableId), batchIdx);
+  }
+
+  public void insertInto(
+      RelNode relNode,
+      ObjectIdentifier sinkTableId,
+      Optional<SqlInsertConflictBehavior> conflictBehavior) {
+    var selectQuery = RelToFlinkSql.convertToSqlNode(relNode);
+    planBuilder.addInsert(
+        FlinkSqlNodes.createInsert(selectQuery, sinkTableId, conflictBehavior), null);
   }
 
   public void insertInto(RichSqlInsert insert, int batchIdx) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/RelNodeAnalysis.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/RelNodeAnalysis.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.calcite.rel.RelNode;
+import org.apache.flink.table.api.InsertConflictStrategy.ConflictBehavior;
 
 /**
  * Intermediate analysis used by the {@link SQRLLogicalPlanAnalyzer} to keep track of information as
@@ -41,4 +42,5 @@ public class RelNodeAnalysis implements RelHolder, AbstractAnalysis {
   @NonNull @Builder.Default PrimaryKeyMap primaryKey = PrimaryKeyMap.UNDEFINED;
   @Builder.Default Optional<TableAnalysis> streamRoot = Optional.empty();
   @Builder.Default boolean hasNowFilter = false;
+  @NonNull @Builder.Default Optional<ConflictBehavior> insertConflictBehavior = Optional.empty();
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -41,6 +41,7 @@ import com.datasqrl.planner.hint.PrimaryKeyHint;
 import com.datasqrl.planner.hint.RowCountHint;
 import com.datasqrl.planner.tables.SqrlTableFunction;
 import com.datasqrl.planner.util.Documented.Documentation;
+import com.datasqrl.planner.util.FlinkConflictBehaviorUtil;
 import com.datasqrl.util.CalciteUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.LinkedHashMultimap;
@@ -92,6 +93,7 @@ import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.flink.table.api.InsertConflictStrategy.ConflictBehavior;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
@@ -272,6 +274,7 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
             .originalRelnode(tableLookup.normalizeRelnode(originalRelnode))
             .type(analysis.getType())
             .primaryKey(analysis.primaryKey)
+            .insertConflictBehavior(analysis.getInsertConflictBehavior())
             .isMostRecentDistinct(isMostRecentDistinct)
             .optionalBaseTable(baseTable)
             .documentation(documentation)
@@ -456,6 +459,7 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
               .relNode(
                   updateRelnode(
                       functionScan, inputs.stream().map(RelNodeAnalysis::getRelNode).toList()))
+              .insertConflictBehavior(Optional.of(ConflictBehavior.DEDUPLICATE))
               .build());
     }
     // Generic table function call
@@ -832,7 +836,8 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
             resultType,
             joinedPk,
             rootTable,
-            leftIn.hasNowFilter || rightIn.hasNowFilter));
+            leftIn.hasNowFilter || rightIn.hasNowFilter,
+            FlinkConflictBehaviorUtil.combineInsertConflictBehaviors(leftIn, rightIn)));
   }
 
   private boolean identicalStreamRoots(
@@ -861,7 +866,8 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
             leftIn.type,
             pk,
             leftIn.getStreamRoot(),
-            leftIn.hasNowFilter || rightIn.hasNowFilter));
+            leftIn.hasNowFilter || rightIn.hasNowFilter,
+            FlinkConflictBehaviorUtil.combineInsertConflictBehaviors(leftIn, rightIn)));
   }
 
   /**
@@ -944,7 +950,8 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
             resultType,
             pk,
             streamRoot,
-            nowFilter));
+            nowFilter,
+            FlinkConflictBehaviorUtil.combineInsertConflictBehaviors(inputs)));
   }
 
   @Override
@@ -1011,7 +1018,12 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
     }
     return setProcessResult(
         new RelNodeAnalysis(
-            updateRelnode(aggregate, List.of(input.relNode)), resultType, pk, streamRoot, false));
+            updateRelnode(aggregate, List.of(input.relNode)),
+            resultType,
+            pk,
+            streamRoot,
+            false,
+            Optional.empty()));
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/TableAnalysis.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/TableAnalysis.java
@@ -37,6 +37,7 @@ import lombok.ToString.Exclude;
 import lombok.Value;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Sort;
+import org.apache.flink.table.api.InsertConflictStrategy.ConflictBehavior;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
 /**
@@ -69,6 +70,9 @@ public class TableAnalysis implements TableOrFunctionAnalysis, Documented {
 
   /** The inferred primary key of the table */
   @NonNull @Builder.Default PrimaryKeyMap primaryKey = PrimaryKeyMap.UNDEFINED;
+
+  /** Whether inserts into upsert sinks must use a conflict policy. */
+  @NonNull @Builder.Default Optional<ConflictBehavior> insertConflictBehavior = Optional.empty();
 
   /**
    * If this table selects from and has the identical rowtype to one of it's input tables we
@@ -190,7 +194,8 @@ public class TableAnalysis implements TableOrFunctionAnalysis, Documented {
   }
 
   public RelNodeAnalysis toRelNode(RelNode relNode) {
-    return new RelNodeAnalysis(relNode, type, primaryKey, getStreamRoot(), false);
+    return new RelNodeAnalysis(
+        relNode, type, primaryKey, getStreamRoot(), false, insertConflictBehavior);
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/TableOrFunctionAnalysis.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/TableOrFunctionAnalysis.java
@@ -56,9 +56,9 @@ public interface TableOrFunctionAnalysis extends AbstractAnalysis {
 
   UniqueIdentifier getIdentifier();
 
-  public TableType getType();
+  TableType getType();
 
-  public boolean isSourceOrSink();
+  boolean isSourceOrSink();
 
   /**
    * The base table on which this function is defined. This means, that this table or function

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
@@ -46,6 +46,7 @@ import com.datasqrl.planner.parser.AccessModifier;
 import com.datasqrl.planner.tables.AccessVisibility;
 import com.datasqrl.planner.tables.FlinkTableBuilder;
 import com.datasqrl.planner.tables.SqrlTableFunction;
+import com.datasqrl.planner.util.FlinkConflictBehaviorUtil;
 import com.datasqrl.util.CalciteUtil;
 import com.datasqrl.util.FlinkCompileException;
 import com.google.common.base.Preconditions;
@@ -97,6 +98,7 @@ import org.springframework.stereotype.Component;
 public class DAGPlanner {
 
   public static final String UNIQUE_TABLE_APPENDIX = "_"; // TODO: add $ to ensure uniqueness?
+  public static final String HASHED_PK_NAME = "__pk_hash";
 
   private static final FunctionDefinition HASH_COLUMNS = new hash_columns();
 
@@ -334,7 +336,10 @@ public class DAGPlanner {
                       new InputTableKey(exportStage, originalNodeTable.getObjectIdentifier()),
                       targetTable);
                   // Finally: add insert statement to sink into table
-                  sqrlEnv.insertInto(relBuilder.build(), targetTable);
+                  var conflictBehavior =
+                      FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                          originalNodeTable, exportEngine.isUpsertSink(tblBuilder));
+                  sqrlEnv.insertInto(relBuilder.build(), targetTable, conflictBehavior);
                 }
               }
             });
@@ -430,8 +435,6 @@ public class DAGPlanner {
 
     return planBuilder.build();
   }
-
-  public static final String HASHED_PK_NAME = "__pk_hash";
 
   /**
    * Determines the primary key for a table that is written to a data system. The primary key is

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtil.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtil.java
@@ -18,10 +18,13 @@ package com.datasqrl.planner.util;
 import com.datasqrl.planner.analyzer.RelNodeAnalysis;
 import com.datasqrl.planner.analyzer.TableAnalysis;
 import com.datasqrl.planner.analyzer.TableOrFunctionAnalysis;
+import com.datasqrl.planner.tables.SourceSinkTableAnalysis;
+import com.datasqrl.planner.tables.SqrlTableFunction;
 import java.util.List;
 import java.util.Optional;
 import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.table.api.InsertConflictStrategy;
+import org.apache.flink.table.catalog.ResolvedSchema;
 
 /**
  * Propagates explicit Flink {@code ON CONFLICT} behaviors and resolves final behavior for generated
@@ -58,7 +61,7 @@ public class FlinkConflictBehaviorUtil {
       case VERSIONED_STATE, STATE, STATIC -> Optional.of(SqlInsertConflictBehavior.DEDUPLICATE);
       case STREAM ->
           Optional.of(
-              hasSourceWatermarks(table)
+              hasWatermarkOnSource(table)
                   ? SqlInsertConflictBehavior.NOTHING
                   : SqlInsertConflictBehavior.DEDUPLICATE);
       default -> Optional.empty();
@@ -107,15 +110,40 @@ public class FlinkConflictBehaviorUtil {
     };
   }
 
-  private static boolean hasSourceWatermarks(TableOrFunctionAnalysis table) {
+  /**
+   * Returns whether every source upstream of a table or function declares a Flink watermark.
+   *
+   * <p>Derived tables are traversed through their {@code FROM} inputs, and table functions through
+   * their function analysis.
+   *
+   * @param table table or function analysis to inspect
+   * @return true when every upstream source has at least one watermark specification
+   */
+  private static boolean hasWatermarkOnSource(TableOrFunctionAnalysis table) {
     if (table instanceof TableAnalysis tableAnalysis
         && !tableAnalysis.isSourceOrSink()
         && !tableAnalysis.getFromTables().isEmpty()) {
 
       return tableAnalysis.getFromTables().stream()
-          .allMatch(FlinkConflictBehaviorUtil::hasSourceWatermarks);
+          .allMatch(FlinkConflictBehaviorUtil::hasWatermarkOnSource);
     }
 
-    return table.getRowTime().isPresent();
+    if (table instanceof SqrlTableFunction tableFn) {
+      return hasWatermarkOnSource(tableFn.getFunctionAnalysis());
+    }
+
+    boolean hasWatermarkOnSource = false;
+    if (table instanceof TableAnalysis srcTable) {
+      var watermarkSpecs =
+          srcTable
+              .getSourceSinkTable()
+              .map(SourceSinkTableAnalysis::schema)
+              .map(ResolvedSchema::getWatermarkSpecs)
+              .orElse(List.of());
+
+      hasWatermarkOnSource = !watermarkSpecs.isEmpty();
+    }
+
+    return hasWatermarkOnSource;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtil.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import com.datasqrl.planner.analyzer.RelNodeAnalysis;
+import com.datasqrl.planner.analyzer.TableAnalysis;
+import com.datasqrl.planner.analyzer.TableOrFunctionAnalysis;
+import java.util.List;
+import java.util.Optional;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
+import org.apache.flink.table.api.InsertConflictStrategy;
+
+/**
+ * Propagates explicit Flink {@code ON CONFLICT} behaviors and resolves final behavior for generated
+ * sink inserts.
+ */
+public class FlinkConflictBehaviorUtil {
+
+  /**
+   * Resolves the {@code ON CONFLICT} behavior for an insert into a Flink sink.
+   *
+   * <p>Append-only sinks cannot accept an {@code ON CONFLICT} clause. For upsert sinks, an explicit
+   * behavior recorded during relational analysis takes precedence. Otherwise, state, versioned
+   * state, and static tables deduplicate, while streams use {@code NOTHING} only when every leaf
+   * source has a watermark and deduplicate in all other cases.
+   *
+   * @param table analysis of the table being inserted
+   * @param isUpsertSink whether the resolved Flink sink accepts updates
+   * @return the behavior to render in an {@code ON CONFLICT} clause, or empty for no clause
+   */
+  public static Optional<SqlInsertConflictBehavior> resolveInsertConflictBehavior(
+      TableAnalysis table, boolean isUpsertSink) {
+
+    if (!isUpsertSink) {
+      return Optional.empty();
+    }
+
+    if (table.getInsertConflictBehavior().isPresent()) {
+      return table
+          .getInsertConflictBehavior()
+          .map(FlinkConflictBehaviorUtil::toSqlConflictBehavior);
+    }
+
+    return switch (table.getType()) {
+      case VERSIONED_STATE, STATE, STATIC -> Optional.of(SqlInsertConflictBehavior.DEDUPLICATE);
+      case STREAM ->
+          Optional.of(
+              hasSourceWatermarks(table)
+                  ? SqlInsertConflictBehavior.NOTHING
+                  : SqlInsertConflictBehavior.DEDUPLICATE);
+      default -> Optional.empty();
+    };
+  }
+
+  /**
+   * Combines the explicit insert-conflict behaviors of two relational inputs.
+   *
+   * <p>The first explicit behavior in left-to-right input order is propagated. The current planner
+   * only records {@code DEDUPLICATE} as an explicit behavior, so combining inputs cannot introduce
+   * conflicting policies.
+   *
+   * @param left analysis of the left input
+   * @param right analysis of the right input
+   * @return the first explicit behavior, or empty when neither input specifies one
+   */
+  public static Optional<InsertConflictStrategy.ConflictBehavior> combineInsertConflictBehaviors(
+      RelNodeAnalysis left, RelNodeAnalysis right) {
+    return combineInsertConflictBehaviors(List.of(left, right));
+  }
+
+  /**
+   * Combines the explicit insert-conflict behaviors of relational inputs.
+   *
+   * <p>The first explicit behavior in input order is propagated so that compound relational
+   * operators retain the conflict policy introduced by one of their inputs.
+   *
+   * @param inputs analyses of the operator inputs in relational input order
+   * @return the first explicit behavior, or empty when no input specifies one
+   */
+  public static Optional<InsertConflictStrategy.ConflictBehavior> combineInsertConflictBehaviors(
+      List<RelNodeAnalysis> inputs) {
+    return inputs.stream()
+        .map(RelNodeAnalysis::getInsertConflictBehavior)
+        .flatMap(Optional::stream)
+        .findFirst();
+  }
+
+  private static SqlInsertConflictBehavior toSqlConflictBehavior(
+      InsertConflictStrategy.ConflictBehavior behavior) {
+    return switch (behavior) {
+      case ERROR -> SqlInsertConflictBehavior.ERROR;
+      case NOTHING -> SqlInsertConflictBehavior.NOTHING;
+      case DEDUPLICATE -> SqlInsertConflictBehavior.DEDUPLICATE;
+    };
+  }
+
+  private static boolean hasSourceWatermarks(TableOrFunctionAnalysis table) {
+    if (table instanceof TableAnalysis tableAnalysis
+        && !tableAnalysis.isSourceOrSink()
+        && !tableAnalysis.getFromTables().isEmpty()) {
+
+      return tableAnalysis.getFromTables().stream()
+          .allMatch(FlinkConflictBehaviorUtil::hasSourceWatermarks);
+    }
+
+    return table.getRowTime().isPresent();
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqlScriptPlannerUtil.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/SqlScriptPlannerUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.planner;
+package com.datasqrl.planner.util;
 
 import com.datasqrl.planner.tables.SqrlFunctionParameter;
 import com.google.common.base.Preconditions;

--- a/sqrl-planner/src/main/resources/default-package.json
+++ b/sqrl-planner/src/main/resources/default-package.json
@@ -27,8 +27,7 @@
       "config": {
         "execution.runtime-mode": "STREAMING",
         "security.delegation.tokens.enabled": false,
-        "state.backend.type": "rocksdb",
-        "table.exec.sink.require-on-conflict": false
+        "state.backend.type": "rocksdb"
       }
     },
     "duckdb": {

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/stream/flink/plan/FlinkSqlNodesTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/stream/flink/plan/FlinkSqlNodesTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
@@ -36,7 +37,9 @@ import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.table.SqlCreateTableLike;
 import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.sql.parser.type.SqlRawTypeNameSpec;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.junit.jupiter.api.Test;
 
 class FlinkSqlNodesTest {
@@ -100,13 +103,51 @@ class FlinkSqlNodesTest {
             null,
             null);
 
-    var insert = FlinkSqlNodes.createInsert(select, targetTable);
+    var insert =
+        FlinkSqlNodes.createInsert(
+            select, ObjectIdentifier.of("default_catalog", "default_database", targetTable));
     var sql = unparse(insert);
     var expectedSql =
         """
-        INSERT INTO `target_table`
+        INSERT INTO `default_catalog`.`default_database`.`target_table`
         SELECT `*`
          FROM `source_table`""";
+    assertThat(sql.trim()).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void givenConflictBehavior_whenCreateInsert_thenIncludesOnConflictClause() {
+    var targetTable = ObjectIdentifier.of("default_catalog", "default_database", "target_table");
+    SqlNode fromTable = FlinkSqlNodes.identifier("source_table");
+    var selectList = new SqlNodeList(SqlParserPos.ZERO);
+    selectList.add(new SqlIdentifier("*", SqlParserPos.ZERO));
+    var select =
+        new SqlSelect(
+            SqlParserPos.ZERO,
+            null,
+            selectList,
+            fromTable,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var insert =
+        FlinkSqlNodes.createInsert(
+            select, targetTable, Optional.of(SqlInsertConflictBehavior.DEDUPLICATE));
+    var sql = unparse(insert);
+    var expectedSql =
+        """
+        INSERT INTO `default_catalog`.`default_database`.`target_table`
+        SELECT `*`
+         FROM `source_table`
+        ON CONFLICT DO DEDUPLICATE""";
+
     assertThat(sql.trim()).isEqualTo(expectedSql);
   }
 

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtilTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/util/FlinkConflictBehaviorUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.datasqrl.io.tables.TableType;
+import com.datasqrl.planner.analyzer.RelNodeAnalysis;
+import com.datasqrl.planner.analyzer.TableAnalysis;
+import java.util.Optional;
+import org.apache.calcite.rel.RelNode;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
+import org.apache.flink.table.api.InsertConflictStrategy.ConflictBehavior;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.junit.jupiter.api.Test;
+
+class FlinkConflictBehaviorUtilTest {
+
+  @Test
+  void givenAppendOnlySink_whenResolveInsertConflictBehavior_thenOmitsClause() {
+    var table = table(TableType.STATIC, Optional.of(ConflictBehavior.DEDUPLICATE));
+
+    assertThat(FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(table, false)).isEmpty();
+  }
+
+  @Test
+  void givenExplicitBehaviorAndUpsertSink_whenResolveInsertConflictBehavior_thenMapsBehavior() {
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                table(TableType.RELATION, Optional.of(ConflictBehavior.ERROR)), true))
+        .contains(SqlInsertConflictBehavior.ERROR);
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                table(TableType.RELATION, Optional.of(ConflictBehavior.NOTHING)), true))
+        .contains(SqlInsertConflictBehavior.NOTHING);
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                table(TableType.RELATION, Optional.of(ConflictBehavior.DEDUPLICATE)), true))
+        .contains(SqlInsertConflictBehavior.DEDUPLICATE);
+  }
+
+  @Test
+  void givenStateOrStaticTableAndUpsertSink_whenResolveInsertConflictBehavior_thenDeduplicates() {
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(table(TableType.STATE), true))
+        .contains(SqlInsertConflictBehavior.DEDUPLICATE);
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                table(TableType.VERSIONED_STATE), true))
+        .contains(SqlInsertConflictBehavior.DEDUPLICATE);
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(table(TableType.STATIC), true))
+        .contains(SqlInsertConflictBehavior.DEDUPLICATE);
+  }
+
+  @Test
+  void
+      givenStreamWithoutWatermarkAndUpsertSink_whenResolveInsertConflictBehavior_thenDeduplicates() {
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(table(TableType.STREAM), true))
+        .contains(SqlInsertConflictBehavior.DEDUPLICATE);
+  }
+
+  @Test
+  void givenRelationWithoutExplicitBehavior_whenResolveInsertConflictBehavior_thenOmitsClause() {
+    assertThat(
+            FlinkConflictBehaviorUtil.resolveInsertConflictBehavior(
+                table(TableType.RELATION), true))
+        .isEmpty();
+  }
+
+  @Test
+  void
+      givenTwoInputsWithExplicitBehaviors_whenCombineInsertConflictBehaviors_thenUsesLeftBehavior() {
+    var left = relationalInput(Optional.of(ConflictBehavior.DEDUPLICATE));
+    var right = relationalInput(Optional.of(ConflictBehavior.NOTHING));
+
+    assertThat(FlinkConflictBehaviorUtil.combineInsertConflictBehaviors(left, right))
+        .contains(ConflictBehavior.DEDUPLICATE);
+  }
+
+  @Test
+  void givenTwoInputsWithoutExplicitBehavior_whenCombineInsertConflictBehaviors_thenReturnsEmpty() {
+    var left = relationalInput(Optional.empty());
+    var right = relationalInput(Optional.empty());
+
+    assertThat(FlinkConflictBehaviorUtil.combineInsertConflictBehaviors(left, right)).isEmpty();
+  }
+
+  private static TableAnalysis table(TableType type) {
+    return table(type, Optional.empty());
+  }
+
+  private static TableAnalysis table(
+      TableType type, Optional<ConflictBehavior> insertConflictBehavior) {
+    return TableAnalysis.builder()
+        .objectIdentifier(ObjectIdentifier.of("catalog", "database", "table"))
+        .type(type)
+        .insertConflictBehavior(insertConflictBehavior)
+        .build();
+  }
+
+  private static RelNodeAnalysis relationalInput(
+      Optional<ConflictBehavior> insertConflictBehavior) {
+    return RelNodeAnalysis.builder()
+        .relNode(mock(RelNode.class))
+        .insertConflictBehavior(insertConflictBehavior)
+        .build();
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
@@ -197,14 +197,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_1`
 SELECT `id`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid`, `timestamp`, `col2`
 FROM `default_catalog`.`default_database`.`FilteredOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderIds_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderIds`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/addingSimpleColumns.txt
@@ -197,17 +197,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_1`
 SELECT `id`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid`, `timestamp`, `col2`
 FROM `default_catalog`.`default_database`.`FilteredOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderIds_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderIds`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
@@ -283,26 +283,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg1_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderAgg1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg2_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderAgg2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg3_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderAgg3`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg4_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderAgg4`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrdersState_6`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`OrdersState`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
@@ -327,18 +327,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerWithEmail_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerWithEmail`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/baseTableTest.txt
@@ -327,12 +327,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerWithEmail_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerWithEmail`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_3`
 SELECT *
@@ -342,7 +342,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Product_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
@@ -447,42 +447,42 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductFilter1_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`ProductFilter1`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductFilter2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`ProductFilter2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders1_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders1`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders2_7`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders3_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders3`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/complexConditions.txt
@@ -447,34 +447,42 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductFilter1_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`ProductFilter1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductFilter2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`ProductFilter2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders1_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders2_7`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders3_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectOrders3`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
@@ -1031,12 +1031,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1068,7 +1068,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1078,7 +1078,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1093,7 +1093,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1102,12 +1102,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/comprehensiveTest.txt
@@ -1031,10 +1031,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1043,14 +1045,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1063,26 +1068,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1091,10 +1102,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
@@ -171,12 +171,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/correlatedScalarSubqueryParameterTest.txt
@@ -171,10 +171,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
@@ -214,10 +214,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTable.txt
@@ -214,12 +214,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableCatalog.txt
@@ -86,6 +86,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Output_1`
 SELECT `key_col`, `int_col`, `hash_columns`(`key_col`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Output`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
@@ -131,10 +131,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_1`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorTempByHour_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorTempByHour`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableConnectorTest.txt
@@ -131,12 +131,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_1`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorTempByHour_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorTempByHour`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
@@ -202,17 +202,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_1`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingInput_2`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReadingInput`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingMutation_3`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReadingMutation`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/createTableLike.txt
@@ -202,14 +202,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_1`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingInput_2`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReadingInput`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingMutation_3`
 SELECT `uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`, `hash_columns`(`uuid`, `sensorid`, `epoch_timestamp`, `temperature`, `testField`, `recordedTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReadingMutation`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
@@ -151,7 +151,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SpecialOrderSummary_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/cteTest.txt
@@ -151,10 +151,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SpecialOrderSummary_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SpecialOrderSummary`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
@@ -135,7 +135,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`_OrderEntries_1`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`_OrderEntries`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/databasejoin-w-hash.txt
@@ -135,6 +135,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`_OrderEntries_1`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`_OrderEntries`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/deeplyNestedTableTest.txt
@@ -57,6 +57,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`NestedCustomers_1`
 SELECT `customer_id`, `to_jsonb`(`customer`) AS `customer`, `hash_columns`(`customer_id`, `customer`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`NestedCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
@@ -179,12 +179,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerUpdates_2`
 SELECT `customerid`, `endOfMin`, `total`, `hash_columns`(`customerid`, `endOfMin`, `total`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerUpdates`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomerUpdates_3`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctOnStream.txt
@@ -179,14 +179,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerUpdates_2`
 SELECT `customerid`, `endOfMin`, `total`, `hash_columns`(`customerid`, `endOfMin`, `total`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomerUpdates_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
@@ -501,38 +501,47 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultiple_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerByMultiple`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTimeAsc_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerByTimeAsc`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByUpdated_7`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerByUpdated`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByUpdatedAsc_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerByUpdatedAsc`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/distinctTest.txt
@@ -501,7 +501,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultiple_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
@@ -188,7 +188,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`_Input_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`_Input`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/duplicatePKTest.txt
@@ -183,10 +183,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`InputDistinct_1`
 SELECT `_uuid`, `userid`, `event_time`, `unique_id`, `hash_columns`(`userid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`_Input`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_Input_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`_Input`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
@@ -349,6 +349,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerExport`
 SELECT *
@@ -357,14 +358,17 @@ FROM `default_catalog`.`default_database`.`CustomerSubset`
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubset_2`
 SELECT `customerid`, `name`, `timestamp`, `hash_columns`(`customerid`, `name`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerSubset`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctStream_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *
@@ -373,10 +377,12 @@ FROM `default_catalog`.`default_database`.`JoinStream`
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_6`
 SELECT `id`, `name`, `hash_columns`(`id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`JoinStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_7`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
@@ -349,6 +349,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerExportInternal_ex1`
 SELECT *
@@ -357,14 +358,17 @@ FROM `default_catalog`.`default_database`.`CustomerSubset`
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubset_2`
 SELECT `customerid`, `name`, `timestamp`, `hash_columns`(`customerid`, `name`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerSubset`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctStream_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *
@@ -373,10 +377,12 @@ FROM `default_catalog`.`default_database`.`JoinStream`
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_6`
 SELECT `id`, `name`, `hash_columns`(`id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`JoinStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_7`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
@@ -345,6 +345,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerExport_ex1`
 SELECT *
@@ -353,14 +354,17 @@ FROM `default_catalog`.`default_database`.`CustomerSubset`
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubset_2`
 SELECT `customerid`, `name`, `timestamp`, `hash_columns`(`customerid`, `name`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerSubset`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctStream_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *
@@ -369,10 +373,12 @@ FROM `default_catalog`.`default_database`.`JoinStream`
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_6`
 SELECT `id`, `name`, `hash_columns`(`id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`JoinStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_7`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/filteredDistinctProcTimeTest.txt
@@ -373,26 +373,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomerWoutTs_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomerWoutTs`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctOrderFieldsWoutTs_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctOrderFieldsWoutTs`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctOrderWithTs_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderFields_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderFields`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_6`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
@@ -167,14 +167,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerHighCount_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerHighCount`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionCollapseTest.txt
@@ -167,17 +167,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerHighCount_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerHighCount`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
@@ -156,10 +156,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerVectorEmbed_2`
 SELECT `customerid`, `name`, `name_vector`, `hash_columns`(`customerid`, `name`, `name_vector`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerVectorEmbed`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterExpressionTest.txt
@@ -156,12 +156,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerVectorEmbed_2`
 SELECT `customerid`, `name`, `name_vector`, `hash_columns`(`customerid`, `name`, `name_vector`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerVectorEmbed`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
@@ -210,7 +210,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerMessage_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterMetadataTest.txt
@@ -210,6 +210,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerMessage_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
@@ -193,7 +193,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByNothing_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionParameterTest.txt
@@ -193,6 +193,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByNothing_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
@@ -115,10 +115,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FunctionCalls_1`
 SELECT `searchResult`, `format`, `hash_columns`(`searchResult`, `format`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`FunctionCalls`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/functionTest.txt
@@ -115,12 +115,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FunctionCalls_1`
 SELECT `searchResult`, `format`, `hash_columns`(`searchResult`, `format`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`FunctionCalls`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
@@ -287,17 +287,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`FinalCustomer_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`FinalCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/hidingTest.txt
@@ -287,14 +287,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`FinalCustomer_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`FinalCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
@@ -192,14 +192,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders1_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`SelectOrders1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders2_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`SelectOrders2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/identicalTableResolutionTest.txt
@@ -192,17 +192,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders1_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`SelectOrders1`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectOrders2_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`SelectOrders2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
@@ -119,7 +119,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Category_1`
 SELECT `categoryid`, `name`, `description`, `updateTime`, `hash_columns`(`categoryid`, `name`, `description`, `updateTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Category`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CategoryDistinct_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importFlinkSQLTest.txt
@@ -119,10 +119,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Category_1`
 SELECT `categoryid`, `name`, `description`, `updateTime`, `hash_columns`(`categoryid`, `name`, `description`, `updateTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Category`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CategoryDistinct_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Category`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptExternalTest.txt
@@ -241,10 +241,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CustomerAggregate1_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerAggregate1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerAggregate2_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerAggregate2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
@@ -232,10 +232,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importScriptInlineTest.txt
@@ -232,12 +232,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
@@ -341,17 +341,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Category_1`
 SELECT `categoryid`, `name`, `description`, `updateTime`, `hash_columns`(`categoryid`, `name`, `description`, `updateTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Category`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerOther_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerOther`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`myevents_4`
 SELECT *
@@ -360,7 +360,7 @@ FROM `default_catalog`.`default_database`.`MyEvents`
 INSERT INTO `default_catalog`.`default_database`.`Product_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/imports.txt
@@ -341,14 +341,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Category_1`
 SELECT `categoryid`, `name`, `description`, `updateTime`, `hash_columns`(`categoryid`, `name`, `description`, `updateTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Category`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerOther_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerOther`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`myevents_4`
 SELECT *
@@ -357,6 +360,7 @@ FROM `default_catalog`.`default_database`.`MyEvents`
 INSERT INTO `default_catalog`.`default_database`.`Product_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
@@ -90,7 +90,7 @@ FROM `default_catalog`.`default_database`.`CustomerInternal`
 INSERT INTO `default_catalog`.`default_database`.`CustomerInternal_2`
 SELECT `customer_id`, `full_name`, `timestamp`, `hash_columns`(`customer_id`, `full_name`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerInternal`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsIndividualInternal.txt
@@ -90,6 +90,7 @@ FROM `default_catalog`.`default_database`.`CustomerInternal`
 INSERT INTO `default_catalog`.`default_database`.`CustomerInternal_2`
 SELECT `customer_id`, `full_name`, `timestamp`, `hash_columns`(`customer_id`, `full_name`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerInternal`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
@@ -70,7 +70,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/importsWithNestedType.txt
@@ -70,6 +70,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -279,27 +279,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersIndexBtree_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersIndexBtree`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersIndexHash_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersIndexHash`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersNoHint_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersNoHint`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersNoIndex_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersNoIndex`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersTwoIndex_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersTwoIndex`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexHints.txt
@@ -279,22 +279,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersIndexBtree_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersIndexBtree`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersIndexHash_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersIndexHash`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersNoHint_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersNoHint`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersNoIndex_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersNoIndex`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyOrdersTwoIndex_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`MyOrdersTwoIndex`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
@@ -300,17 +300,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/indexSelectionTest.txt
@@ -300,14 +300,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -112,7 +112,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `customer_id_count`
 SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -112,6 +112,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `customer_id_count`
 SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -210,10 +210,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerCount_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerCount`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `CustomerCount`
 SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
@@ -223,6 +225,7 @@ GROUP BY `Customer`.`customerid`
 INSERT INTO `default_catalog`.`default_database`.`CustomerForApi_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerForApi`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -210,7 +210,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerCount_2`
 SELECT *
@@ -225,7 +225,7 @@ GROUP BY `Customer`.`customerid`
 INSERT INTO `default_catalog`.`default_database`.`CustomerForApi_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerForApi`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/joinTimestampPropagationTest.txt
@@ -194,10 +194,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
@@ -371,10 +371,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerStream_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInDatabaseTest.txt
@@ -376,7 +376,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`CustomerStream_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerStream`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
@@ -509,50 +509,62 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerStream_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ObjComplex_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`ObjComplex`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonArrayAggTable_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonArrayAggTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonArrayTable_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonArrayTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonConcatTable_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonConcatTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonExistsTable_7`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonExistsTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonExtractTable_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonExtractTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonObjectAggTable_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonObjectAggTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonQueryTable_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonQueryTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`jsonToStringTable_11`
 SELECT *
 FROM `default_catalog`.`default_database`.`jsonToStringTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`toJsonTable_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`toJsonTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/lateralJoinTableFunction.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/lateralJoinTableFunction.txt
@@ -119,10 +119,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerEmailCopies_2`
 SELECT `customerid`, `email`, `hash_columns`(`customerid`, `email`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerEmailCopies`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
@@ -232,12 +232,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_3`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationInsertTypeTest.txt
@@ -232,14 +232,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Sensors`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
@@ -190,7 +190,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CustomerData_1`
 SELECT `customerid`, `to_jsonb`(`payload`) AS `payload`, `hash_columns`(`customerid`, `payload`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerData`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`NestedCustomers_2`
 SELECT `customerid`, `to_jsonb`(`payload`) AS `payload`, `updatedTime`
@@ -200,7 +200,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/mutationNestedTypeTest.txt
@@ -190,14 +190,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CustomerData_1`
 SELECT `customerid`, `to_jsonb`(`payload`) AS `payload`, `hash_columns`(`customerid`, `payload`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomerData`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`NestedCustomers_2`
 SELECT `customerid`, `to_jsonb`(`payload`) AS `payload`, `updatedTime`
 FROM `default_catalog`.`default_database`.`NestedCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
@@ -117,10 +117,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_OrdersTotals_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`_OrdersTotals`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/nestedTableWithUnnest.txt
@@ -117,7 +117,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`_OrdersTotals_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
@@ -475,12 +475,12 @@ FROM `default_catalog`.`default_database`.`CustomerImport`
 INSERT INTO `default_catalog`.`default_database`.`CustomerImport_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerImport`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`LargeOrders_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`LargeOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`LargeOrders_4`
 SELECT *
@@ -489,12 +489,12 @@ FROM `default_catalog`.`default_database`.`LargeOrders`
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SimpleOrders_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`SimpleOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Unnestorders_7`
 SELECT *
@@ -503,7 +503,7 @@ FROM `default_catalog`.`default_database`.`UnnestOrders`
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_8`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/overview.txt
@@ -466,6 +466,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerImport`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -474,10 +475,12 @@ FROM `default_catalog`.`default_database`.`CustomerImport`
 INSERT INTO `default_catalog`.`default_database`.`CustomerImport_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerImport`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`LargeOrders_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`LargeOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`LargeOrders_4`
 SELECT *
@@ -486,10 +489,12 @@ FROM `default_catalog`.`default_database`.`LargeOrders`
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SimpleOrders_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`SimpleOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Unnestorders_7`
 SELECT *
@@ -498,6 +503,7 @@ FROM `default_catalog`.`default_database`.`UnnestOrders`
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_8`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -193,14 +193,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`OrderMetrics_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`OrderMetrics`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderUpdates_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`OrderUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`_OrdersStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/partitionTest.txt
@@ -193,12 +193,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`OrderMetrics_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`OrderMetrics`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderUpdates_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`OrderUpdates`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
@@ -115,12 +115,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`FilteredOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/passthroughTest.txt
@@ -115,10 +115,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`FilteredOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/postgresMapTranslationTest.txt
@@ -62,6 +62,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyTable_1`
 SELECT `num`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/procTimeTest.txt
@@ -197,14 +197,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerOrdersJoin_2`
 SELECT `customerid`, `email`, `name`, `lastUpdated`, `_ingest_time`, `id`, `customerid0`, `time`, `to_jsonb`(`entries`) AS `entries`, CAST(`_ingest_time0` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `_ingest_time0`
 FROM `default_catalog`.`default_database`.`CustomerOrdersJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
@@ -160,14 +160,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders1_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders2_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/queryByTest.txt
@@ -160,17 +160,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders1_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders1`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders2_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
@@ -176,12 +176,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipInvalidArgTest.txt
@@ -176,10 +176,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
@@ -140,10 +140,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationshipTest.txt
@@ -140,12 +140,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
@@ -124,10 +124,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Order_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Order`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Where_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `select`
 FROM `default_catalog`.`default_database`.`Where`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/reservedNamesTest.txt
@@ -124,12 +124,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Order_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Order`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Where_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `select`
 FROM `default_catalog`.`default_database`.`Where`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
@@ -110,10 +110,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductId_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`ProductId`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/selectDistinctTest.txt
@@ -110,7 +110,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductId_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/sqrlFunctionsTest.txt
@@ -76,10 +76,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTable2_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
@@ -1320,7 +1320,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Orders_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/staticDataTest.txt
@@ -1305,18 +1305,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Numbers_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Numbers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Numbers2_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Numbers2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`NumbersLarge_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`NumbersLarge`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
@@ -153,7 +153,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/streamAggregateTest.txt
@@ -143,14 +143,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg1_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderAgg1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderAgg2_2`
 SELECT `order_count`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderAgg2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
@@ -369,32 +369,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExcludedOrders_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExcludedOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`FilteredOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrdersByProduct_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`FilteredOrdersByProduct`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryInFilterTest.txt
@@ -369,26 +369,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExcludedOrders_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExcludedOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrders_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`FilteredOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`FilteredOrdersByProduct_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`FilteredOrdersByProduct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Product_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
@@ -317,18 +317,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerWithOrders_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerWithOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_SpecialOrders_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `isSpecialorder`
 FROM `default_catalog`.`default_database`.`_SpecialOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/subqueryTest.txt
@@ -317,22 +317,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerWithOrders_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerWithOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`_SpecialOrders_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `isSpecialorder`
 FROM `default_catalog`.`default_database`.`_SpecialOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
@@ -272,27 +272,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer1_2`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer1`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer2_3`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer3_4`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer3`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableIntervalJoinTest.txt
@@ -272,22 +272,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer1_2`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer2_3`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer2`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer3_4`
 SELECT `id`, `name`, `customerid`, `hash_columns`(`id`, `name`, `customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomer3`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_5`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
@@ -307,18 +307,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_SensorReading_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_Sensors_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`_Sensors`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableRowCounts.txt
@@ -307,17 +307,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineReading_1`
 SELECT `sensorid`, `temperature`, `event_time`, `machineid`, `hash_columns`(`sensorid`, `temperature`, `event_time`, `machineid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MachineTempByHour_2`
 SELECT `machineid`, `time_hour`, `avg_temperature`, `hash_columns`(`machineid`, `time_hour`, `avg_temperature`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`MachineTempByHour`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`_SensorReading_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`_Sensors_4`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
@@ -501,34 +501,42 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerConstant_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerConstant`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerLeft_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerLeft`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerLeftExcluded_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerLeftExcluded`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerRight_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerRight`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerRightExcluded_7`
 SELECT `lastUpdated`, `customerid`, `name`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrderCustomerRightExcluded`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_8`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
@@ -423,18 +423,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerLeftExcludedTimeBound_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerLeftExcludedTimeBound`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`VerifyStream_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`VerifyStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStreamJoinTest.txt
@@ -423,22 +423,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomerLeftExcludedTimeBound_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCustomerLeftExcludedTimeBound`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`VerifyStream_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`VerifyStream`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
@@ -323,26 +323,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerCumulate_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerCumulate`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerHop_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerHop`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSession_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerSession`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerTumble_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTumble`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`StreamJoin_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`StreamJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableValuedFunctionsTest.txt
@@ -323,32 +323,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerCumulate_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerCumulate`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerHop_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerHop`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSession_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerSession`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerTumble_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTumble`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`StreamJoin_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`StreamJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
@@ -254,18 +254,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, `email`, `name`, `lastUpdated`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/testExecutionTypeHint.txt
@@ -175,14 +175,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CustomerAgg1_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerAgg1`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerAgg3_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerAgg3`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionDifferentKeysAndOrder.txt
@@ -145,14 +145,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CombinedStream_1`
 SELECT `id_a`, `val`, `hash_columns`(`id_a`, `val`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CombinedStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`source_a_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`source_a`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`source_b_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`source_b`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
@@ -185,17 +185,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CombinedStream_1`
 SELECT `customerid`, `rowtime`, `hash_columns`(`customerid`, `rowtime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CombinedStream`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithTimestamp.txt
@@ -185,14 +185,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CombinedStream_1`
 SELECT `customerid`, `rowtime`, `hash_columns`(`customerid`, `rowtime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CombinedStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/unionWithoutTimestamp.txt
@@ -223,18 +223,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CombinedState_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`CombinedState`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CombinedStream_2`
 SELECT `customerid`, `hash_columns`(`customerid`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CombinedStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_4`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `_ingest_time`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
@@ -1647,12 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1684,7 +1684,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1694,7 +1694,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1709,7 +1709,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1718,12 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-limit-offset-combinations.txt
@@ -1647,10 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1659,14 +1661,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1679,26 +1684,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1707,10 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
@@ -1647,12 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1684,7 +1684,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1694,7 +1694,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1709,7 +1709,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1718,12 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-results.txt
@@ -1647,10 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1659,14 +1661,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1679,26 +1684,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1707,10 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
@@ -1647,12 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1684,7 +1684,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1694,7 +1694,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1709,7 +1709,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1718,12 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-paged-userdefined.txt
@@ -1647,10 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1659,14 +1661,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1679,26 +1684,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1707,10 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
@@ -1647,12 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1684,7 +1684,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1694,7 +1694,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1709,7 +1709,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1718,12 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest-parameters-order.txt
@@ -1647,10 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1659,14 +1661,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1679,26 +1684,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1707,10 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
@@ -1647,12 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1684,7 +1684,7 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
@@ -1694,7 +1694,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
@@ -1709,7 +1709,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1718,12 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/GraphQLValidationTest/comprehensiveTest.txt
@@ -1647,10 +1647,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AnotherCustomer_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AnotherCustomer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customer_3`
 SELECT *
@@ -1659,14 +1661,17 @@ FROM `default_catalog`.`default_database`.`Customer`
 INSERT INTO `default_catalog`.`default_database`.`CustomerByMultipleTime_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerByTime2_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerFilteredDistinct_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerFilteredDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerSubscription_7`
 SELECT *
@@ -1679,26 +1684,32 @@ FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
 INSERT INTO `default_catalog`.`default_database`.`CustomerTimeWindow_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerTimeWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExplicitDistinct_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`ExplicitDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ExternalOrders_11`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
 FROM `default_catalog`.`default_database`.`ExternalOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InvalidDistinct_12`
 SELECT *
 FROM `default_catalog`.`default_database`.`InvalidDistinct`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_13`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SelectCustomers_14`
 SELECT *
 FROM `default_catalog`.`default_database`.`SelectCustomers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyPrintSink_ex1`
 SELECT *
@@ -1707,10 +1718,12 @@ FROM `default_catalog`.`default_database`.`TemporalJoin`
 INSERT INTO `default_catalog`.`default_database`.`TemporalJoin_15`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`, `customerid0`, CAST(`timestamp` AS TIMESTAMP(3) WITH LOCAL TIME ZONE) AS `timestamp`, `name`
 FROM `default_catalog`.`default_database`.`TemporalJoin`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnnestOrders_16`
 SELECT `id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`, `hash_columns`(`id`, `customerid`, `time`, `productid`, `quantity`, `discount`, `newId`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`UnnestOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only-package-snowflake.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only-package-snowflake.txt
@@ -351,10 +351,12 @@ FROM `default_catalog`.`default_database`.`ApplicationStatus`
 INSERT INTO `default_catalog`.`default_database`.`_Applications_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`_Applications`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_LoanTypes_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_LoanTypes`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>iceberg-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/analytics-only-package.txt
@@ -351,10 +351,12 @@ FROM `default_catalog`.`default_database`.`ApplicationStatus`
 INSERT INTO `default_catalog`.`default_database`.`_Applications_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`_Applications`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_LoanTypes_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_LoanTypes`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>iceberg-duckdb-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
@@ -117,7 +117,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Res_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Res`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-legacy-ts-package.txt
@@ -117,6 +117,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Res_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Res`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
@@ -313,7 +313,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Schema_1`
 SELECT `uuidField`, `timestampMillisField`, `nullableTimestampMillisField`, `timestampMicrosField`, `nullableTimestampMicrosField`, `dateField`, `nullableDateField`, `timeMillisField`, `nullableTimeMillisField`, `timeMicrosField`, `nullableTimeMicrosField`, `to_jsonb`(`complexArrayField`) AS `complexArrayField`, `to_jsonb`(`nullableComplexArrayField`) AS `nullableComplexArrayField`, `to_jsonb`(`multiNestedRecord`) AS `multiNestedRecord`, `stringField`, `nullableStringField`, `intField`, `nullableIntField`, `longField`, `nullableLongField`, `floatField`, `nullableFloatField`, `doubleField`, `nullableDoubleField`, `booleanField`, `nullableBooleanField`, `enumField`, `nullableEnumField`, `to_jsonb`(`arrayField`) AS `arrayField`, `to_jsonb`(`nullableArrayField`) AS `nullableArrayField`, `to_jsonb`(`nestedRecord`) AS `nestedRecord`, `to_jsonb`(`nullableNestedRecord`) AS `nullableNestedRecord`, `decimalField`, `to_jsonb`(`mapField`) AS `mapField`, `to_jsonb`(`nullableMapField`) AS `nullableMapField`
 FROM `default_catalog`.`default_database`.`Schema`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package-no-snapshots.txt
@@ -313,6 +313,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Schema_1`
 SELECT `uuidField`, `timestampMillisField`, `nullableTimestampMillisField`, `timestampMicrosField`, `nullableTimestampMicrosField`, `dateField`, `nullableDateField`, `timeMillisField`, `nullableTimeMillisField`, `timeMicrosField`, `nullableTimeMicrosField`, `to_jsonb`(`complexArrayField`) AS `complexArrayField`, `to_jsonb`(`nullableComplexArrayField`) AS `nullableComplexArrayField`, `to_jsonb`(`multiNestedRecord`) AS `multiNestedRecord`, `stringField`, `nullableStringField`, `intField`, `nullableIntField`, `longField`, `nullableLongField`, `floatField`, `nullableFloatField`, `doubleField`, `nullableDoubleField`, `booleanField`, `nullableBooleanField`, `enumField`, `nullableEnumField`, `to_jsonb`(`arrayField`) AS `arrayField`, `to_jsonb`(`nullableArrayField`) AS `nullableArrayField`, `to_jsonb`(`nestedRecord`) AS `nestedRecord`, `to_jsonb`(`nullableNestedRecord`) AS `nullableNestedRecord`, `decimalField`, `to_jsonb`(`mapField`) AS `mapField`, `to_jsonb`(`nullableMapField`) AS `nullableMapField`
 FROM `default_catalog`.`default_database`.`Schema`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
@@ -313,7 +313,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Schema_1`
 SELECT `uuidField`, `timestampMillisField`, `nullableTimestampMillisField`, `timestampMicrosField`, `nullableTimestampMicrosField`, `dateField`, `nullableDateField`, `timeMillisField`, `nullableTimeMillisField`, `timeMicrosField`, `nullableTimeMicrosField`, `to_jsonb`(`complexArrayField`) AS `complexArrayField`, `to_jsonb`(`nullableComplexArrayField`) AS `nullableComplexArrayField`, `to_jsonb`(`multiNestedRecord`) AS `multiNestedRecord`, `stringField`, `nullableStringField`, `intField`, `nullableIntField`, `longField`, `nullableLongField`, `floatField`, `nullableFloatField`, `doubleField`, `nullableDoubleField`, `booleanField`, `nullableBooleanField`, `enumField`, `nullableEnumField`, `to_jsonb`(`arrayField`) AS `arrayField`, `to_jsonb`(`nullableArrayField`) AS `nullableArrayField`, `to_jsonb`(`nestedRecord`) AS `nestedRecord`, `to_jsonb`(`nullableNestedRecord`) AS `nullableNestedRecord`, `decimalField`, `to_jsonb`(`mapField`) AS `mapField`, `to_jsonb`(`nullableMapField`) AS `nullableMapField`
 FROM `default_catalog`.`default_database`.`Schema`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/avro-schema-package.txt
@@ -313,6 +313,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Schema_1`
 SELECT `uuidField`, `timestampMillisField`, `nullableTimestampMillisField`, `timestampMicrosField`, `nullableTimestampMicrosField`, `dateField`, `nullableDateField`, `timeMillisField`, `nullableTimeMillisField`, `timeMicrosField`, `nullableTimeMicrosField`, `to_jsonb`(`complexArrayField`) AS `complexArrayField`, `to_jsonb`(`nullableComplexArrayField`) AS `nullableComplexArrayField`, `to_jsonb`(`multiNestedRecord`) AS `multiNestedRecord`, `stringField`, `nullableStringField`, `intField`, `nullableIntField`, `longField`, `nullableLongField`, `floatField`, `nullableFloatField`, `doubleField`, `nullableDoubleField`, `booleanField`, `nullableBooleanField`, `enumField`, `nullableEnumField`, `to_jsonb`(`arrayField`) AS `arrayField`, `to_jsonb`(`nullableArrayField`) AS `nullableArrayField`, `to_jsonb`(`nestedRecord`) AS `nestedRecord`, `to_jsonb`(`nullableNestedRecord`) AS `nullableNestedRecord`, `decimalField`, `to_jsonb`(`mapField`) AS `mapField`, `to_jsonb`(`nullableMapField`) AS `nullableMapField`
 FROM `default_catalog`.`default_database`.`Schema`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-batch-package.txt
@@ -331,18 +331,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`ApplicationUpdates_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`ApplicationUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Applications_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Applications`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerUpdates_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customers_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customers`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -700,6 +700,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AddChatMessage_1`
 SELECT `_uuid`, `role`, `content`, `name`, `to_jsonb`(`context`) AS `context`, `event_time`
 FROM `default_catalog`.`default_database`.`AddChatMessage`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ApplicationAlert_2`
 SELECT *
@@ -708,38 +709,47 @@ FROM `default_catalog`.`default_database`.`ApplicationAlert`
 INSERT INTO `default_catalog`.`default_database`.`ApplicationStatus_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`ApplicationStatus`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`ApplicationUpdates_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`ApplicationUpdates`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Applications_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Applications`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ApplicationsStream_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`ApplicationsStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerChatMessage_7`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomerChatMessage`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customers_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersStream_9`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersStream`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`LoanTypes_10`
 SELECT *
 FROM `default_catalog`.`default_database`.`LoanTypes`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`LoanTypesStream_11`
 SELECT *
 FROM `default_catalog`.`default_database`.`LoanTypesStream`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
@@ -263,7 +263,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Click_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Click`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Recommendation_2`
 SELECT *
@@ -278,7 +278,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`VisitAfter_4`
 SELECT `beforeURL`, `afterURL`, `timestamp`, `hash_columns`(`beforeURL`, `afterURL`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`VisitAfter`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package-paginated.txt
@@ -263,18 +263,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Click_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Click`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Recommendation_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Recommendation`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Trending_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Trending`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`VisitAfter_4`
 SELECT `beforeURL`, `afterURL`, `timestamp`, `hash_columns`(`beforeURL`, `afterURL`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`VisitAfter`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
@@ -230,18 +230,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Click_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Click`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Recommendation_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Recommendation`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Trending_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Trending`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`VisitAfter_4`
 SELECT `beforeURL`, `afterURL`, `timestamp`, `hash_columns`(`beforeURL`, `afterURL`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`VisitAfter`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/clickstream-package.txt
@@ -230,7 +230,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Click_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Click`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Recommendation_2`
 SELECT *
@@ -245,7 +245,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`VisitAfter_4`
 SELECT `beforeURL`, `afterURL`, `timestamp`, `hash_columns`(`beforeURL`, `afterURL`, `timestamp`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`VisitAfter`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package-invalid.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package-invalid.txt
@@ -1,8 +1,0 @@
-[WARN] Table 'InputTable' field 'userid' type is not backwards compatible: 'VARCHAR(2147483647)' -> 'INTEGER'
-
-[WARN] Table 'InputTable' field 'event_time' metadata changed from 'null' to 'timestamp'
-
-[WARN] Table 'SinkTable' field 'total_tokens' type is not backwards compatible: 'VARCHAR(2147483647)' -> 'BIGINT'
-
-[FATAL] The mutation tables defined by the script are not backwards compatible with the provided database. See warnings above for incompatibilities.
-

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/complex-mutation-package.txt
@@ -188,6 +188,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`LatestTokens_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`LatestTokens`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SinkTable_ex1`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
@@ -562,18 +562,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`EventLikeCount_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`EventLikeCount`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Events_2`
 SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `to_jsonb`(`speakers`) AS `speakers`, `last_updated`, `id`, `full_text`, `startTime`, `embedding`, `startTimestamp`
 FROM `default_catalog`.`default_database`.`Events`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_UserInterests_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_UserInterests`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_UserLikes_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`_UserLikes`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/connectors-compile-package.txt
@@ -328,26 +328,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`iceberg_parquet_table_1`
 SELECT `user_id`, `name`, `hash_columns`(`user_id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`iceberg_parquet_table`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`kafka_avro_table_2`
 SELECT `user_id`, `name`, `hash_columns`(`user_id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`kafka_avro_table`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`kafka_debezium_table_3`
 SELECT `user_id`, `name`, `hash_columns`(`user_id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`kafka_debezium_table`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`kafka_safe_csv_table_4`
 SELECT `user_id`, `name`, `hash_columns`(`user_id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`kafka_safe_csv_table`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`kafka_safe_json_table_5`
 SELECT `user_id`, `name`, `hash_columns`(`user_id`, `name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`kafka_safe_json_table`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`upsert_kafka_confluent_avro_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`upsert_kafka_confluent_avro`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-redshift-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-redshift-compile-package.txt
@@ -189,6 +189,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`RedshiftAggregates_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`RedshiftAggregates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`RedshiftTypeMappings_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-spark-sql-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-spark-sql-compile-package.txt
@@ -189,6 +189,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SparkAggregates_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`SparkAggregates`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SparkTypeMappings_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/distinct-materialization-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/distinct-materialization-compile-package.txt
@@ -205,18 +205,22 @@ FROM `default_catalog`.`default_database`.`DeploymentState`
 INSERT INTO `default_catalog`.`default_database`.`DeploymentState_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`DeploymentState`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`DeploymentStateBase_3`
 SELECT `deploymentId`, `dataGroupId`, `eventTime`, `hash_columns`(`deploymentId`, `dataGroupId`, `eventTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`DeploymentStateBase`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Deployments_4`
 SELECT `deploymentId`, `projectId`, `eventTime`, `hash_columns`(`deploymentId`, `projectId`, `eventTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Deployments`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Projects_5`
 SELECT `projectId`, `dataGroupId`, `eventTime`, `hash_columns`(`projectId`, `dataGroupId`, `eventTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Projects`
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
@@ -283,7 +283,7 @@ FROM `default_catalog`.`default_database`.`_MyApplications2`
 INSERT INTO `default_catalog`.`default_database`.`_MyApplications2_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_MyApplications2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>iceberg-duckdb-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-disk-cache-package.txt
@@ -283,6 +283,7 @@ FROM `default_catalog`.`default_database`.`_MyApplications2`
 INSERT INTO `default_catalog`.`default_database`.`_MyApplications2_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_MyApplications2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>iceberg-duckdb-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
@@ -281,6 +281,7 @@ FROM `default_catalog`.`default_database`.`_MyApplications2`
 INSERT INTO `default_catalog`.`default_database`.`_MyApplications2_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_MyApplications2`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>iceberg-duckdb-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/duckdb-package.txt
@@ -281,7 +281,7 @@ FROM `default_catalog`.`default_database`.`_MyApplications2`
 INSERT INTO `default_catalog`.`default_database`.`_MyApplications2_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_MyApplications2`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>iceberg-duckdb-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/filtered-distinct-package.txt
@@ -170,10 +170,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`DistinctOrders_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`DistinctOrders`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/function-translation-postgres-package.txt
@@ -281,10 +281,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`_ArrayData_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`_ArrayData`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_InputData_2`
 SELECT `dummy`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`_InputData`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package-base.txt
@@ -153,10 +153,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyStringTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyStringTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTable_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-authorized-package.txt
@@ -262,10 +262,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyStringTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyStringTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTable_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`_Messages_3`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/jwt-unauthorized-package.txt
@@ -92,6 +92,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/load-functions-package.txt
@@ -73,6 +73,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FunctionApplied_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`FunctionApplied`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
@@ -114,6 +114,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`FooOut_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`FooOut`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
@@ -122,6 +122,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Product_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/nullable-api-arg-package.txt
@@ -122,7 +122,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Product_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Product`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/oauth-authorized-compile-package.txt
@@ -92,6 +92,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/passthrough-package.txt
@@ -206,10 +206,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Employees_1`
 SELECT *
 FROM `default_catalog`.`hr`.`Employees`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Reporting_2`
 SELECT *
 FROM `default_catalog`.`hr`.`Reporting`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-arrays-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-arrays-package.txt
@@ -143,18 +143,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`IntArray_1`
 SELECT `id`, `to_jsonb`(`int_array`) AS `int_array`
 FROM `default_catalog`.`default_database`.`IntArray`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`NestedArray_2`
 SELECT `id`, `to_jsonb`(`nested_array`) AS `nested_array`
 FROM `default_catalog`.`default_database`.`NestedArray`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`StringArray_3`
 SELECT `id`, `to_jsonb`(`string_array`) AS `string_array`
 FROM `default_catalog`.`default_database`.`StringArray`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`StringVals_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`StringVals`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-minimal-flink-package.txt
@@ -138,6 +138,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-no-vertx-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-no-vertx-package.txt
@@ -34,6 +34,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyView_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyView`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/relationship-filter-package.txt
@@ -260,26 +260,32 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Detail_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Detail`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Thing_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Thing`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Tombstone_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`Tombstone`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`cleanQuery_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`cleanQuery`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`joinQuery_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`joinQuery`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`subqueryQuery_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`subqueryQuery`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -267,22 +267,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Package_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Package`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Submission_2`
 SELECT `name`, `version`, `variant`, `latest`, `type`, `license`, `repository`, `homepage`, `documentation`, `readme`, `description`, `to_jsonb`(`keywords`) AS `keywords`, `uniqueId`, `file`, `hash`, `authorId`, `submissionTime`, `event_time`, `variant0`, `repoURL`, `hash_columns`(`name`, `version`, `variant`, `latest`, `type`, `license`, `repository`, `homepage`, `documentation`, `readme`, `description`, `keywords`, `uniqueId`, `file`, `hash`, `authorId`, `submissionTime`, `event_time`, `variant0`, `repoURL`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Submission`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SubmissionTopics_3`
 SELECT `pkgName`, `topicName`, `submissionTime`, `hash_columns`(`pkgName`, `topicName`, `submissionTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SubmissionTopics`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`TopicPackages_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`TopicPackages`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`TopicSearch_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`TopicSearch`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>postgres-schema.sql

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/repository-package.txt
@@ -272,12 +272,12 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Submission_2`
 SELECT `name`, `version`, `variant`, `latest`, `type`, `license`, `repository`, `homepage`, `documentation`, `readme`, `description`, `to_jsonb`(`keywords`) AS `keywords`, `uniqueId`, `file`, `hash`, `authorId`, `submissionTime`, `event_time`, `variant0`, `repoURL`, `hash_columns`(`name`, `version`, `variant`, `latest`, `type`, `license`, `repository`, `homepage`, `documentation`, `readme`, `description`, `keywords`, `uniqueId`, `file`, `hash`, `authorId`, `submissionTime`, `event_time`, `variant0`, `repoURL`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Submission`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SubmissionTopics_3`
 SELECT `pkgName`, `topicName`, `submissionTime`, `hash_columns`(`pkgName`, `topicName`, `submissionTime`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SubmissionTopics`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`TopicPackages_4`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
@@ -153,10 +153,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`OrderCount_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`OrderCount`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`items`) AS `items`, `_source_time`, `hash_columns`(`id`, `customerid`, `time`, `items`, `_source_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-avro-compile-package.txt
@@ -158,7 +158,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`Orders_2`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`items`) AS `items`, `_source_time`, `hash_columns`(`id`, `customerid`, `time`, `items`, `_source_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`Orders`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
@@ -718,34 +718,42 @@ FROM `default_catalog`.`default_database`.`CustomerPromotion`
 INSERT INTO `default_catalog`.`default_database`.`Customers_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersOrderStats_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersOrderStats`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersPastPurchases_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersPastPurchases`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersSpending_5`
 SELECT `customerid`, `week`, `spend`, `saved`, `hash_columns`(`customerid`, `week`, `spend`, `saved`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomersSpending`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_6`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`items`) AS `items`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrdersTotals_7`
 SELECT `id`, `time`, `customerid`, `price`, `saving`, `hash_columns`(`id`, `time`, `customerid`, `price`, `saving`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrdersTotals`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Products_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`Products`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductsByCountry_9`
 SELECT `productid`, `country`, `quantity`, `spend`, `weight`, `hash_columns`(`productid`, `country`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`ProductsByCountry`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
@@ -718,34 +718,42 @@ FROM `default_catalog`.`default_database`.`CustomerPromotion`
 INSERT INTO `default_catalog`.`default_database`.`Customers_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customers`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersOrderStats_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersOrderStats`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersPastPurchases_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`CustomersPastPurchases`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersSpending_5`
 SELECT `customerid`, `week`, `spend`, `saved`, `hash_columns`(`customerid`, `week`, `spend`, `saved`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`CustomersSpending`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_6`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`items`) AS `items`
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrdersTotals_7`
 SELECT `id`, `time`, `customerid`, `price`, `saving`, `hash_columns`(`id`, `time`, `customerid`, `price`, `saving`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`OrdersTotals`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Products_8`
 SELECT *
 FROM `default_catalog`.`default_database`.`Products`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductsByCountry_9`
 SELECT `productid`, `country`, `quantity`, `spend`, `weight`, `hash_columns`(`productid`, `country`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`ProductsByCountry`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -219,14 +219,17 @@ FROM `default_catalog`.`default_database`.`HighTempAlert`
 INSERT INTO `default_catalog`.`default_database`.`SensorAnalysis_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorAnalysis`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorMaxTempLastMin_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`_SensorMaxTempLastMinWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-doc-package.txt
@@ -229,7 +229,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
@@ -412,22 +412,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`HighTemp_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`HighTemp`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Machine_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`Machine`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SecReading_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`SecReading`
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorLastHour_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`_SensorMaxTempWindow`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Sensors`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -232,7 +232,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`HighTempAlert_1`
 SELECT `sensorid`, `temperature`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`HighTempAlert`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorMaxTemp_2`
 SELECT *
@@ -242,7 +242,7 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
 SELECT `sensorid`, `temperature`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingSubscription_4`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-mutation-package.txt
@@ -232,14 +232,17 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`HighTempAlert_1`
 SELECT `sensorid`, `temperature`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`HighTempAlert`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorMaxTemp_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorMaxTemp`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
 SELECT `sensorid`, `temperature`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReadingSubscription_4`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
@@ -355,22 +355,27 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineGroup_1`
 SELECT `groupId`, `groupName`, `created`, `to_jsonb`(`machines`) AS `machines`
 FROM `default_catalog`.`default_database`.`MachineGroup`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SecReading_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`SecReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorMaxTemp_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorMaxTemp`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Sensors`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-teaser-package.txt
@@ -355,7 +355,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MachineGroup_1`
 SELECT `groupId`, `groupName`, `created`, `to_jsonb`(`machines`) AS `machines`
 FROM `default_catalog`.`default_database`.`MachineGroup`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SecReading_2`
 SELECT *
@@ -370,12 +370,12 @@ ON CONFLICT DO DEDUPLICATE
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_5`
 SELECT *
 FROM `default_catalog`.`default_database`.`Sensors`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
@@ -132,6 +132,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customers_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customers`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/server-functions-package.txt
@@ -132,7 +132,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customers_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Customers`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/simple-with-bigint-support-package.txt
@@ -108,6 +108,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Orders_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Orders`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
@@ -149,12 +149,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Json_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Json`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnmodifiedJsonData_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`UnmodifiedJsonData`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-json-package.txt
@@ -149,10 +149,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Json_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`Json`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UnmodifiedJsonData_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`UnmodifiedJsonData`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-math-package.txt
@@ -117,6 +117,7 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MathFunctions_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MathFunctions`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-async-package.txt
@@ -111,10 +111,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`data_1`
 SELECT `val`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`data`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`results_2`
 SELECT `completions_result`, `extract_json_result_response`, `extract_json_result_with_schema_response`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`results`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-openai-package.txt
@@ -111,10 +111,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`data_1`
 SELECT `val`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`data`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`results_2`
 SELECT `completions_result`, `extract_json_result_response`, `extract_json_result_with_schema_response`, 1 AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`results`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/stdlib-vector-package.txt
@@ -144,10 +144,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`CategoryCentroids_1`
 SELECT `category_id`, `to_jsonb`(`center_vector`) AS `center_vector`
 FROM `default_catalog`.`default_database`.`CategoryCentroids`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`VectorData_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`VectorData`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -241,7 +241,7 @@ FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
 INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
 SELECT `sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
 SELECT *
@@ -250,7 +250,7 @@ FROM `default_catalog`.`default_database`.`SensorReading`
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
-ON CONFLICT DO DEDUPLICATE
+ON CONFLICT DO NOTHING
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_5`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/temporal-join-package.txt
@@ -241,6 +241,7 @@ FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
 INSERT INTO `default_catalog`.`default_database`.`EnrichedSensorReading_2`
 SELECT `sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`, `sensor_name`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`EnrichedSensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_3`
 SELECT *
@@ -249,6 +250,7 @@ FROM `default_catalog`.`default_database`.`SensorReading`
 INSERT INTO `default_catalog`.`default_database`.`SensorReading_4`
 SELECT `sensorid`, `temperature`, `placement`, `event_time`, `hash_columns`(`sensorid`, `temperature`, `placement`, `event_time`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`SensorReading`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_5`
 SELECT *
@@ -257,6 +259,7 @@ FROM `default_catalog`.`default_database`.`SensorUpdates`
 INSERT INTO `default_catalog`.`default_database`.`SensorUpdates_6`
 SELECT *
 FROM `default_catalog`.`default_database`.`SensorUpdates`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
@@ -132,10 +132,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`AppendStream_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`AppendStream`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`InputAgg_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`InputAgg`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/udf-package.txt
@@ -198,18 +198,22 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`MyAsyncTable_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyAsyncTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTable_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTable`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTableAnother_3`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTableAnother`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`MyTableDifferentCase_4`
 SELECT *
 FROM `default_catalog`.`default_database`.`MyTableDifferentCase`
+ON CONFLICT DO DEDUPLICATE
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/useractivity-package.txt
@@ -219,10 +219,12 @@ EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`TotalOrgTokens_1`
 SELECT *
 FROM `default_catalog`.`default_database`.`TotalOrgTokens`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`TotalUserTokens_2`
 SELECT *
 FROM `default_catalog`.`default_database`.`TotalUserTokens`
+ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `default_catalog`.`default_database`.`UsageAlert_3`
 SELECT *


### PR DESCRIPTION
## Summary

- Generate Flink 2.3 `ON CONFLICT` clauses only for upsert-capable sinks.
- Preserve append-only sinks, including `print`, by omitting conflict clauses.
- Carry optional `InsertConflictStrategy.ConflictBehavior` through relational and table analysis.
- Mark `TO_CHANGELOG` with explicit `DEDUPLICATE` behavior without changing its `TableType`.
- Centralize conflict behavior resolution in `FlinkConflictBehaviorUtil`.
- Use explicit behavior when present, otherwise resolve from table type and source watermarks.
- Move `SqlScriptPlannerUtil` to the planner utility package.

## Conflict Resolution Policy

- Append-only sinks: no `ON CONFLICT` clause.
- Explicit analyzed behavior: use Flink's `ERROR`, `NOTHING`, or `DEDUPLICATE` behavior.
- `STATE`, `VERSIONED_STATE`, and `STATIC` tables: `ON CONFLICT DO DEDUPLICATE`.
- `STREAM` tables with watermarked leaf sources: `ON CONFLICT DO NOTHING`.
- Other `STREAM` tables: `ON CONFLICT DO DEDUPLICATE`.
- Other table types without explicit behavior: no clause.