### PR TITLE
feat: Make `build` folder configurable

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
@@ -35,9 +35,16 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
   protected Optional<Path> projectRoot = Optional.empty();
 
   @Option(
+      names = {"-b", "--build"},
+      description =
+          "Build folder for any output generated during build. Must be a relative path within the project root."
+              + " Resolved relative to the specified or inferred project root. Default: \"<project-root>/build\".\n")
+  protected Optional<Path> buildFolder = Optional.empty();
+
+  @Option(
       names = {"-t", "--target"},
       description =
-          "Target folder for deployment artifacts and plans. Must be a relative path."
+          "Target folder for deployment artifacts and plans. Must be a relative path within the project root."
               + " Resolved relative to the specified or inferred project root. Default: \"<project-root>/build/deploy\".\n")
   protected Optional<Path> targetFolder = Optional.empty();
 
@@ -67,20 +74,15 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
   }
 
   protected Path getBuildDir() {
-    return getProjectRoot().resolve(SqrlConstants.BUILD_DIR_NAME);
+    return buildFolder
+        .map(path -> resolveGivenCliDir(path, "Build"))
+        .orElseGet(() -> getProjectRoot().resolve(SqrlConstants.BUILD_DIR_NAME));
   }
 
   protected Path getTargetDir() {
-    if (targetFolder.isEmpty()) {
-      return getBuildDir().resolve(SqrlConstants.DEPLOY_DIR_NAME);
-    }
-
-    var target = targetFolder.get();
-    if (!cli.internalTestExec && target.isAbsolute()) {
-      throw new IllegalArgumentException("Target folder must be a relative path");
-    }
-
-    return getProjectRoot().resolve(target);
+    return targetFolder
+        .map(path -> resolveGivenCliDir(path, "Target"))
+        .orElseGet(() -> getBuildDir().resolve(SqrlConstants.DEPLOY_DIR_NAME));
   }
 
   protected OsProcessManager getOsProcessManager() {
@@ -119,5 +121,27 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
     }
 
     return fullProjectRoot;
+  }
+
+  private Path resolveGivenCliDir(Path dir, String dirType) {
+    if (!cli.internalTestExec && dir.isAbsolute()) {
+      throw new IllegalArgumentException(dirType + " folder must be a relative path, got: " + dir);
+    }
+
+    var root = getProjectRoot();
+    var directory = root.resolve(dir);
+    if (!cli.internalTestExec && !directory.normalize().startsWith(root.normalize())) {
+      throw new IllegalArgumentException(
+          dirType
+              + " folder '"
+              + dir
+              + "' resolves to '"
+              + directory.normalize()
+              + "', which is outside project root '"
+              + root.normalize()
+              + "'");
+    }
+
+    return directory;
   }
 }

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/CompileCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/CompileCmdTest.java
@@ -16,6 +16,7 @@
 package com.datasqrl.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockConstruction;
@@ -129,5 +130,82 @@ class CompileCmdTest {
 
     assertThat(compileCmd.formatGivenPackageFiles())
         .containsExactly(projectDir.resolve("package.json"));
+  }
+
+  @Test
+  void givenNoBuildFolder_whenGettingBuildDir_thenUsesDefaultFolder() {
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, true);
+
+    assertThat(compileCmd.getBuildDir()).isEqualTo(tempDir.resolve("build"));
+  }
+
+  @Test
+  void
+      givenCustomBuildFolderAndProjectRoot_whenGettingBuildAndDefaultTargetDirs_thenResolvesBothFromProjectRoot()
+          throws IOException {
+    var projectRoot = tempDir.resolve("project");
+    Files.createDirectory(projectRoot);
+
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, true);
+    compileCmd.projectRoot = Optional.of(Path.of("project"));
+    compileCmd.buildFolder = Optional.of(Path.of("output"));
+
+    assertThat(compileCmd.getBuildDir()).isEqualTo(projectRoot.resolve("output"));
+    assertThat(compileCmd.getTargetDir())
+        .isEqualTo(projectRoot.resolve("output").resolve("deploy"));
+  }
+
+  @Test
+  void givenAbsoluteBuildFolderOutsideTestExecution_whenGettingBuildDir_thenThrows() {
+    var buildFolder = tempDir.resolve("output");
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+    compileCmd.buildFolder = Optional.of(buildFolder);
+
+    assertThatThrownBy(compileCmd::getBuildDir)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Build folder must be a relative path, got: " + buildFolder);
+  }
+
+  @Test
+  void givenBuildFolderOutsideProjectRoot_whenGettingBuildDir_thenThrows() throws IOException {
+    var projectRoot = tempDir.resolve("banking");
+    Files.createDirectory(projectRoot);
+
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+    compileCmd.projectRoot = Optional.of(Path.of("banking"));
+    compileCmd.buildFolder = Optional.of(Path.of("..", "build-banking"));
+
+    assertThatThrownBy(compileCmd::getBuildDir)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Build folder '../build-banking' resolves to '"
+                + tempDir.resolve("build-banking")
+                + "', which is outside project root '"
+                + projectRoot
+                + "'");
+  }
+
+  @Test
+  void givenTargetFolderOutsideProjectRoot_whenGettingTargetDir_thenThrows() throws IOException {
+    var projectRoot = tempDir.resolve("banking");
+    Files.createDirectory(projectRoot);
+
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, false);
+    compileCmd.projectRoot = Optional.of(Path.of("banking"));
+    compileCmd.targetFolder = Optional.of(Path.of("..", "deploy-banking"));
+
+    assertThatThrownBy(compileCmd::getTargetDir)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Target folder '../deploy-banking' resolves to '"
+                + tempDir.resolve("deploy-banking")
+                + "', which is outside project root '"
+                + projectRoot
+                + "'");
   }
 }


### PR DESCRIPTION
## Summary

Add configurable build and target output directories through `--build` / `-b`, just like we have `--target` / `-t` already.

Both directories must be relative paths that resolve within the specified or inferred project root. This prevents compilation artifacts from escaping the project directory mounted into the Docker container.

## Behavior

- `--build` defaults to `<project-root>/build`
- `--target` defaults to `<build-dir>/deploy`
- Explicit build and target directories are resolved relative to the project root.
- Absolute paths are rejected.
- Relative paths that escape the project root, such as `../build-banking`, are rejected.

## Examples

When the use-case directory is mounted as the Docker workspace:
```sh
docker run -it --rm -p 8888:8888 -p 8081:8081 \
  -v $PWD:/workspace \
  datasqrl/cmd:local compile banking/package.json -b build-banking
```
The project root is inferred as banking, so the build output is written to:
```
/workspace/banking/build-banking
```
On the host, this corresponds to:
```
sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/banking/build-banking
```
---
A custom target directory is also resolved from the project root:
```sh
docker run -it --rm -p 8888:8888 -p 8081:8081 \
  -v $PWD:/workspace \
  datasqrl/cmd:local compile banking/package.json \
  --build build-banking \
  --target deployment-banking
```
This writes deployment artifacts to:
```
/workspace/banking/deployment-banking
```
---
Paths that escape the inferred project root are rejected:
```sh
docker run -it --rm -p 8888:8888 -p 8081:8081 \
  -v $PWD:/workspace \
  datasqrl/cmd:local compile banking/package.json -t ../deployment-banking
```
Will result in an error like:
```
Target folder '../deployment-banking' resolves to '/workspace/deployment-banking', which is outside project root '/workspace/banking'
```