### PR TITLE
fix: Resolve LIKE source table across databases in mutation database check

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/RelDataTypeParser.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/RelDataTypeParser.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner;
+
+import static com.datasqrl.config.SqrlConstants.FLINK_DEFAULT_CATALOG;
+
+import com.datasqrl.engine.stream.flink.FlinkSqlNodes;
+import com.datasqrl.planner.parser.ParsePosUtil;
+import com.datasqrl.planner.parser.ParsedObject;
+import com.datasqrl.planner.parser.SQLStatement;
+import com.datasqrl.planner.parser.StatementParserException;
+import com.datasqrl.server.exec.FlinkExecFunction;
+import java.util.List;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.flink.sql.parser.ddl.table.SqlCreateTableLike;
+import org.apache.flink.sql.parser.ddl.table.SqlTableLike;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.ddl.CreateTableOperation;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class RelDataTypeParser {
+
+  private static final String DATATYPE_PARSING_PREFIX =
+      "CREATE TEMPORARY TABLE __sqrlinternal_types( ";
+
+  private final Sqrl2FlinkSQLTranslator translator;
+
+  /**
+   * Parses a table-column definition into resolved relational data types.
+   *
+   * <p>Wraps the definition in a temporary {@code CREATE TABLE} statement so Flink can resolve the
+   * types. Parser errors are translated to the source location of the supplied definition.
+   *
+   * @param dataTypeDefinition column definition and its source location
+   * @return the parsed fields, including metadata and computed-column information
+   */
+  public List<ParsedRelDataTypeResult> parseToRelDataType(ParsedObject<String> dataTypeDefinition) {
+    if (dataTypeDefinition.isEmpty()) {
+      return List.of();
+    }
+
+    var createTableStatement =
+        DATATYPE_PARSING_PREFIX + dataTypeDefinition.get() + " ) WITH ('connector' = 'filesystem')";
+
+    try {
+      var sqlNode = translator.parseSQL(createTableStatement);
+      var op = (CreateTableOperation) translator.getOperation(sqlNode);
+      var schema = op.getCatalogTable().getResolvedSchema();
+
+      return translator.parseSchema(schema, true);
+    } catch (Exception e) {
+      var location = dataTypeDefinition.getFileLocation();
+      var converted = ParsePosUtil.convertFlinkParserException(e);
+
+      if (converted.isPresent()) {
+        location =
+            location.add(
+                SQLStatement.removeFirstRowOffset(
+                    converted.get().location(), DATATYPE_PARSING_PREFIX.length()));
+      }
+
+      throw new StatementParserException(
+          location, e, converted.map(ParsePosUtil.MessageLocation::message).orElse(e.getMessage()));
+    }
+  }
+
+  /**
+   * Parses the schema of a serialized {@code CREATE TABLE} statement.
+   *
+   * <p>When the statement contains an unqualified {@code LIKE} source that is not in the current
+   * database, resolves the source from a database created during planning before parsing.
+   *
+   * <p>This cross-database fallback can resolve an unintended table and must only be used for
+   * well-specified cases, such as mutation database compatibility checks.
+   *
+   * @param createTableStatement CREATE TABLE statement whose schema is parsed
+   * @return the parsed fields, including metadata and computed-column information
+   */
+  public List<ParsedRelDataTypeResult> parseToRelDataType(String createTableStatement) {
+    var sqlNode = translator.parseSQL(createTableStatement);
+    sqlNode = resolveLikeSource(sqlNode);
+
+    var op = (CreateTableOperation) translator.getOperation(sqlNode);
+
+    return translator.parseSchema(op.getCatalogTable().getResolvedSchema(), true);
+  }
+
+  /**
+   * Qualifies an unqualified {@code LIKE} source by locating it in a database created during
+   * planning.
+   */
+  private SqlNode resolveLikeSource(SqlNode sqlNode) {
+    if (!(sqlNode instanceof SqlCreateTableLike likeTable)) {
+      return sqlNode;
+    }
+
+    var likeClause = likeTable.getTableLike();
+    var sourceTable = likeClause.getSourceTable();
+    if (tableExists(translator.qualifyIdentifier(sourceTable))) {
+      return sqlNode;
+    }
+
+    var sourceName = sourceTable.names.get(sourceTable.names.size() - 1);
+
+    return translator.getCreatedDatabases().stream()
+        .map(database -> ObjectIdentifier.of(FLINK_DEFAULT_CATALOG, database, sourceName))
+        .filter(this::tableExists)
+        .findFirst()
+        .map(id -> modifySqlTableLike(likeTable, likeClause, id))
+        .orElse(sqlNode);
+  }
+
+  private boolean tableExists(ObjectIdentifier id) {
+    return translator.getCatalogManager().getTable(id).isPresent();
+  }
+
+  private SqlNode modifySqlTableLike(
+      SqlCreateTableLike originalCreateTableLike, SqlTableLike likeClause, ObjectIdentifier id) {
+
+    var modifiedLikeClause =
+        new SqlTableLike(
+            likeClause.getParserPosition(), FlinkSqlNodes.identifier(id), likeClause.getOptions());
+
+    return FlinkSqlNodes.createTableLike(
+        originalCreateTableLike.getName().getSimple(), originalCreateTableLike, modifiedLikeClause);
+  }
+
+  public record ParsedRelDataTypeResult(
+      RelDataTypeField field, Optional<String> metadata, Optional<FlinkExecFunction> function) {}
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/SqlScriptPlanner.java
@@ -367,11 +367,11 @@ public class SqlScriptPlanner {
       var originalSql = sqrlDef.toSql(sqrlEnv, statementStack);
       // Relationships and Table functions require special handling
       if (sqrlDef instanceof SqrlTableFunctionStatement tblFnStmt) {
-        // TODO: should be resolved against the current catalog and database
         var identifier = scriptContext.toIdentifier(tblFnStmt.getPath().getFirst());
         final var arguments = new LinkedHashMap<Name, ParsedArgument>();
         if (!tblFnStmt.getSignature().isEmpty()) {
-          var parsedArgs = sqrlEnv.parse2RelDataType(tblFnStmt.getSignature());
+          var parsedArgs =
+              sqrlEnv.getRelDataTypeParser().parseToRelDataType(tblFnStmt.getSignature());
           parsedArgs.forEach(
               parsedField -> {
                 var field = parsedField.field();

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -35,6 +35,7 @@ import com.datasqrl.io.schema.SchemaConversionResult;
 import com.datasqrl.loaders.schema.SchemaLoader;
 import com.datasqrl.plan.util.PrimaryKeyMap;
 import com.datasqrl.planner.FlinkPhysicalPlan.Builder;
+import com.datasqrl.planner.RelDataTypeParser.ParsedRelDataTypeResult;
 import com.datasqrl.planner.analyzer.SQRLLogicalPlanAnalyzer;
 import com.datasqrl.planner.analyzer.SQRLLogicalPlanAnalyzer.ViewAnalysis;
 import com.datasqrl.planner.analyzer.TableAnalysis;
@@ -42,10 +43,7 @@ import com.datasqrl.planner.analyzer.TableOrFunctionAnalysis;
 import com.datasqrl.planner.dag.plan.MutationTable.MutationTableBuilder;
 import com.datasqrl.planner.hint.HintsAndDoc;
 import com.datasqrl.planner.parser.NoLocationStatementParserException;
-import com.datasqrl.planner.parser.ParsePosUtil;
-import com.datasqrl.planner.parser.ParsePosUtil.MessageLocation;
 import com.datasqrl.planner.parser.ParsedObject;
-import com.datasqrl.planner.parser.SQLStatement;
 import com.datasqrl.planner.parser.SqrlTableFunctionStatement.ParsedArgument;
 import com.datasqrl.planner.parser.StatementParserException;
 import com.datasqrl.planner.tables.FlinkConnectorConfigWrapper;
@@ -168,21 +166,19 @@ public class Sqrl2FlinkSQLTranslator {
 
   private static final String SCHEMA_SUFFIX = "__schema";
   private static final String TEMP_VIEW_SUFFIX = "__view";
-  private static final String DATATYPE_PARSING_PREFIX =
-      "CREATE TEMPORARY TABLE __sqrlinternal_types( ";
-
-  private final Set<String> createdDatabases = new LinkedHashSet<>();
 
   private final RuntimeExecutionMode executionMode;
   private final boolean compileFlinkPlan;
   private final StreamTableEnvironmentImpl tEnv;
   private final Supplier<FlinkPlannerImpl> validatorSupplier;
   private final SqrlFunctionCatalog sqrlFunctionCatalog;
-  private final CatalogManager catalogManager;
   private final FlinkPhysicalPlan.Builder planBuilder;
+  @Getter private final CatalogManager catalogManager;
   @Getter private final FlinkTypeFactory typeFactory;
   @Getter private final FlinkExecFunctionFactory execFnFactory;
+  @Getter private final RelDataTypeParser relDataTypeParser;
 
+  @Getter private final Set<String> createdDatabases = new LinkedHashSet<>();
   @Getter private final TableAnalysisLookup tableLookup = new TableAnalysisLookup();
 
   public Sqrl2FlinkSQLTranslator(
@@ -232,6 +228,7 @@ public class Sqrl2FlinkSQLTranslator {
     this.catalogManager = tEnv.getCatalogManager();
 
     execFnFactory = new FlinkExecFunctionFactory(tEnv.getConfig(), typeFactory);
+    relDataTypeParser = new RelDataTypeParser(this);
 
     // Register SQRL standard library functions
     ServiceLoader<AutoRegisterSystemFunction> standardLibraryFunctions =
@@ -591,7 +588,7 @@ public class Sqrl2FlinkSQLTranslator {
 
     var parameters = getFunctionParameters(arguments);
 
-    var parsedReturnType = parse2RelDataType(returnType);
+    var parsedReturnType = relDataTypeParser.parseToRelDataType(returnType);
     var returnDataType =
         CalciteUtil.getRelTypeBuilder(typeFactory)
             .addAll(parsedReturnType.stream().map(ParsedRelDataTypeResult::field).toList())
@@ -789,7 +786,7 @@ public class Sqrl2FlinkSQLTranslator {
         viewName, FlinkSqlNodes.selectAllFromTable(FlinkSqlNodes.identifier(id)));
   }
 
-  private ObjectIdentifier qualifyIdentifier(SqlIdentifier identifier) {
+  ObjectIdentifier qualifyIdentifier(SqlIdentifier identifier) {
     var names = identifier.names;
     var size = names.size();
 
@@ -1052,8 +1049,7 @@ public class Sqrl2FlinkSQLTranslator {
     return parseSchema(schema, false).stream().map(ParsedRelDataTypeResult::field).toList();
   }
 
-  private List<ParsedRelDataTypeResult> parseSchema(
-      ResolvedSchema schema, boolean createFunctions) {
+  List<ParsedRelDataTypeResult> parseSchema(ResolvedSchema schema, boolean createFunctions) {
     var fields = new ArrayList<ParsedRelDataTypeResult>();
 
     var typeBuilder = CalciteUtil.getRelTypeBuilder(typeFactory);
@@ -1113,76 +1109,6 @@ public class Sqrl2FlinkSQLTranslator {
     return fields;
   }
 
-  /**
-   * Uses a CREATE TABLE statement to parse the data types from a string
-   *
-   * @param dataTypeDefinition
-   * @return
-   */
-  public List<ParsedRelDataTypeResult> parse2RelDataType(ParsedObject<String> dataTypeDefinition) {
-    if (dataTypeDefinition.isEmpty()) {
-      return List.of();
-    }
-    var createTableStatement =
-        DATATYPE_PARSING_PREFIX + dataTypeDefinition.get() + " ) WITH ('connector' = 'filesystem')";
-    try {
-      var op = (CreateTableOperation) getOperation(parseSQL(createTableStatement));
-      var schema = op.getCatalogTable().getResolvedSchema();
-      return parseSchema(schema, true);
-    } catch (Exception e) {
-      var location = dataTypeDefinition.getFileLocation();
-      var converted = ParsePosUtil.convertFlinkParserException(e);
-      if (converted.isPresent()) {
-        location =
-            location.add(
-                SQLStatement.removeFirstRowOffset(
-                    converted.get().location(), DATATYPE_PARSING_PREFIX.length()));
-      }
-      throw new StatementParserException(
-          location, e, converted.map(MessageLocation::message).orElse(e.getMessage()));
-    }
-  }
-
-  public List<ParsedRelDataTypeResult> parse2RelDataType(String createTableStatement) {
-    var op = (CreateTableOperation) getOperation(resolveLikeSource(parseSQL(createTableStatement)));
-    var schema = op.getCatalogTable().getResolvedSchema();
-    return parseSchema(schema, true);
-  }
-
-  /**
-   * CREATE TABLE statements are serialized with the source table of their LIKE clause unqualified,
-   * but a script imported under an alias is planned in its own database. Re-parsing such a
-   * statement (e.g. for the mutation database compatibility check) resolves the LIKE source against
-   * the current database where it does not exist, so we look the source table up in the databases
-   * created during planning and qualify the reference.
-   */
-  private SqlNode resolveLikeSource(SqlNode sqlNode) {
-    if (!(sqlNode instanceof SqlCreateTableLike likeTable)) {
-      return sqlNode;
-    }
-    var likeClause = likeTable.getTableLike();
-    var sourceTable = likeClause.getSourceTable();
-    if (catalogManager.getTable(qualifyIdentifier(sourceTable)).isPresent()) {
-      return sqlNode;
-    }
-
-    var sourceName = sourceTable.names.get(sourceTable.names.size() - 1);
-    return createdDatabases.stream()
-        .map(database -> ObjectIdentifier.of(FLINK_DEFAULT_CATALOG, database, sourceName))
-        .filter(identifier -> catalogManager.getTable(identifier).isPresent())
-        .findFirst()
-        .<SqlNode>map(
-            identifier ->
-                FlinkSqlNodes.createTableLike(
-                    likeTable.getName().getSimple(),
-                    likeTable,
-                    new SqlTableLike(
-                        likeClause.getParserPosition(),
-                        FlinkSqlNodes.identifier(identifier),
-                        likeClause.getOptions())))
-        .orElse(sqlNode);
-  }
-
   @SneakyThrows
   public Operation executeSQL(String sqlStatement) {
     return executeSqlNode(parseSQL(sqlStatement));
@@ -1195,7 +1121,7 @@ public class Sqrl2FlinkSQLTranslator {
     return operation;
   }
 
-  private Operation getOperation(SqlNode sqlNode) {
+  Operation getOperation(SqlNode sqlNode) {
     return SqlNodeToOperationConversion.convert(validatorSupplier.get(), catalogManager, sqlNode)
         .orElseThrow(() -> new TableException("Unsupported query: " + sqlNode));
   }
@@ -1229,7 +1155,4 @@ public class Sqrl2FlinkSQLTranslator {
               + " Supported engines: \"kafka\", \"iceberg\".");
     }
   }
-
-  public record ParsedRelDataTypeResult(
-      RelDataTypeField field, Optional<String> metadata, Optional<FlinkExecFunction> function) {}
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -67,6 +67,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -170,7 +171,7 @@ public class Sqrl2FlinkSQLTranslator {
   private static final String DATATYPE_PARSING_PREFIX =
       "CREATE TEMPORARY TABLE __sqrlinternal_types( ";
 
-  private final Set<String> createdDatabases = new HashSet<>();
+  private final Set<String> createdDatabases = new LinkedHashSet<>();
 
   private final RuntimeExecutionMode executionMode;
   private final boolean compileFlinkPlan;
@@ -1143,9 +1144,43 @@ public class Sqrl2FlinkSQLTranslator {
   }
 
   public List<ParsedRelDataTypeResult> parse2RelDataType(String createTableStatement) {
-    var op = (CreateTableOperation) getOperation(parseSQL(createTableStatement));
+    var op = (CreateTableOperation) getOperation(resolveLikeSource(parseSQL(createTableStatement)));
     var schema = op.getCatalogTable().getResolvedSchema();
     return parseSchema(schema, true);
+  }
+
+  /**
+   * CREATE TABLE statements are serialized with the source table of their LIKE clause unqualified,
+   * but a script imported under an alias is planned in its own database. Re-parsing such a
+   * statement (e.g. for the mutation database compatibility check) resolves the LIKE source against
+   * the current database where it does not exist, so we look the source table up in the databases
+   * created during planning and qualify the reference.
+   */
+  private SqlNode resolveLikeSource(SqlNode sqlNode) {
+    if (!(sqlNode instanceof SqlCreateTableLike likeTable)) {
+      return sqlNode;
+    }
+    var likeClause = likeTable.getTableLike();
+    var sourceTable = likeClause.getSourceTable();
+    if (catalogManager.getTable(qualifyIdentifier(sourceTable)).isPresent()) {
+      return sqlNode;
+    }
+
+    var sourceName = sourceTable.names.get(sourceTable.names.size() - 1);
+    return createdDatabases.stream()
+        .map(database -> ObjectIdentifier.of(FLINK_DEFAULT_CATALOG, database, sourceName))
+        .filter(identifier -> catalogManager.getTable(identifier).isPresent())
+        .findFirst()
+        .<SqlNode>map(
+            identifier ->
+                FlinkSqlNodes.createTableLike(
+                    likeTable.getName().getSimple(),
+                    likeTable,
+                    new SqlTableLike(
+                        likeClause.getParserPosition(),
+                        FlinkSqlNodes.identifier(identifier),
+                        likeClause.getOptions())))
+        .orElse(sqlNode);
   }
 
   @SneakyThrows

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/plan/MutationDatabase.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/plan/MutationDatabase.java
@@ -22,7 +22,6 @@ import com.datasqrl.deployment.model.MutationDatabaseModel.Table;
 import com.datasqrl.deployment.model.MutationDatabaseModel.TableDefinition;
 import com.datasqrl.error.ErrorCollector;
 import com.datasqrl.planner.Sqrl2FlinkSQLTranslator;
-import com.datasqrl.planner.Sqrl2FlinkSQLTranslator.ParsedRelDataTypeResult;
 import com.datasqrl.server.exec.FlinkExecFunction;
 import java.util.Collection;
 import java.util.List;
@@ -115,9 +114,9 @@ public final class MutationDatabase {
         compatible = false;
       }
 
-      List<ParsedRelDataTypeResult> newSchema = env.parse2RelDataType(table.createTableSql());
-      List<ParsedRelDataTypeResult> oldSchema =
-          env.parse2RelDataType(compareTable.createTableSql());
+      var parser = env.getRelDataTypeParser();
+      var newSchema = parser.parseToRelDataType(table.createTableSql());
+      var oldSchema = parser.parseToRelDataType(compareTable.createTableSql());
 
       var oldFieldsByName =
           oldSchema.stream()

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package-incompatible.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package-incompatible.txt
@@ -1,0 +1,4 @@
+[WARN] Table 'Foo_raw' field 'label' type is not backwards compatible: 'INTEGER' -> 'VARCHAR(2147483647)'
+
+[FATAL] The mutation tables defined by the script are not backwards compatible with the provided database. See warnings above for incompatibilities.
+

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/mutation-like-import-compile-package.txt
@@ -1,0 +1,209 @@
+>>>inferred_schema.graphqls
+"An RFC-3339 compliant Full Date Scalar"
+scalar Date
+
+"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats"
+scalar DateTime
+
+type FooOut {
+  id: Int!
+  label: String
+}
+
+"A JSON scalar"
+scalar JSON
+
+"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`."
+scalar LocalTime
+
+"A 64-bit signed integer"
+scalar Long
+
+type Query {
+  FooOut(limit: Int = 10, offset: Int = 0): [FooOut!]
+}
+
+enum _McpMethodType {
+  NONE
+  TOOL
+  RESOURCE
+}
+
+enum _RestMethodType {
+  NONE
+  GET
+  POST
+}
+
+directive @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION
+
+>>>pipeline_explain.txt
+=== FooOut
+ID:          default_catalog.default_database.FooOut
+Type:        state
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: INTEGER NOT NULL
+ - label: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Inputs:
+ - default_catalog.src.Foo_raw
+
+=== Foo_raw
+ID:          default_catalog.src.Foo_raw
+Type:        state
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - ts: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL
+ - id: INTEGER NOT NULL
+ - label: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+Inputs:
+ - default_catalog.src.Foo_raw__base
+
+>>>flink-sql-no-functions.sql
+CREATE DATABASE IF NOT EXISTS `src`;
+USE `src`;
+CREATE TABLE `Foo_schema` (
+  `ts` TIMESTAMP_LTZ(3) NOT NULL,
+  `id` INTEGER NOT NULL,
+  `label` STRING
+);
+CREATE TABLE `Foo_raw` (
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'upsert-kafka-safe',
+  'key.format' = 'flexible-json',
+  'properties.auto.offset.reset' = 'earliest',
+  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
+  'properties.compression.type' = 'zstd',
+  'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'topic' = 'Foo_raw',
+  'value.fields-include' = 'ALL',
+  'value.format' = 'flexible-json'
+)
+LIKE `Foo_schema`;
+USE CATALOG `default_catalog`;
+CREATE DATABASE IF NOT EXISTS `default_database`;
+USE `default_database`;
+CREATE VIEW `FooOut`
+AS
+SELECT `id`, `label`
+FROM `src`.`Foo_raw`;
+CREATE TABLE `FooOut_1` (
+  `id` INTEGER NOT NULL,
+  `label` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'table-name' = 'FooOut',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`FooOut_1`
+SELECT *
+FROM `default_catalog`.`default_database`.`FooOut`
+;
+END
+>>>kafka.json
+{
+  "topics" : [
+    {
+      "topicName" : "Foo_raw",
+      "tableName" : "Foo_raw",
+      "format" : "flexible-json",
+      "numPartitions" : 1,
+      "replicationFactor" : 3,
+      "type" : "MUTATION",
+      "messageKeys" : [
+        "id"
+      ],
+      "messageSchema" : "",
+      "config" : {
+        "cleanup.policy" : "compact"
+      }
+    }
+  ],
+  "testRunnerTopics" : [ ]
+}
+>>>postgres-schema.sql
+CREATE TABLE IF NOT EXISTS "FooOut" ("id" INTEGER NOT NULL, "label" TEXT, PRIMARY KEY ("id"))
+>>>vertx.json
+{
+  "models" : {
+    "v1" : {
+      "queries" : [
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "FooOut",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"FooOut\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        }
+      ],
+      "mutations" : [ ],
+      "subscriptions" : [ ],
+      "operations" : [
+        {
+          "function" : {
+            "name" : "GetFooOut",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "format" : "JSON",
+          "apiQuery" : {
+            "query" : "query FooOut($limit: Int = 10, $offset: Int = 0) {\nFooOut(limit: $limit, offset: $offset) {\nid\nlabel\n}\n\n}",
+            "queryName" : "FooOut",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/FooOut{?offset,limit}"
+        }
+      ],
+      "schema" : {
+        "type" : "string",
+        "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype FooOut {\n  id: Int!\n  label: String\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  FooOut(limit: Int = 10, offset: Int = 0): [FooOut!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+      }
+    }
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/database/incompatible_database.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/database/incompatible_database.json
@@ -1,0 +1,32 @@
+{
+  "tables": [
+    {
+      "canonicalName": "Foo_raw",
+      "engine": "kafka",
+      "createTableSql": "CREATE TABLE `Foo_raw` (\n  `ts` TIMESTAMP_LTZ(3) NOT NULL,\n  `id` INT NOT NULL,\n  `label` INT,\n  PRIMARY KEY (`id`) NOT ENFORCED\n)\nWITH (\n  'connector' = 'upsert-kafka-safe',\n  'key.format' = 'flexible-json',\n  'properties.auto.offset.reset' = 'earliest',\n  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',\n  'properties.compression.type' = 'zstd',\n  'properties.group.id' = '${KAFKA_GROUP_ID}',\n  'topic' = 'Foo_raw',\n  'value.fields-include' = 'ALL',\n  'value.format' = 'flexible-json'\n)",
+      "definition": {
+        "columns": [
+          {
+            "name": "ts",
+            "spec": "TIMESTAMP_LTZ(3) NOT NULL"
+          },
+          {
+            "name": "id",
+            "spec": "INT NOT NULL"
+          },
+          {
+            "name": "label",
+            "spec": "INT"
+          }
+        ],
+        "primaryKey": [
+          "id"
+        ],
+        "partitionKey": []
+      },
+      "configOptions": {
+        "cleanup.policy": "compact"
+      }
+    }
+  ]
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/database/mutation_database.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/database/mutation_database.json
@@ -1,0 +1,15 @@
+{
+  "tables" : [ {
+    "canonicalName" : "Foo_raw",
+    "engine" : "kafka",
+    "createTableSql" : "CREATE TABLE `Foo_raw` (\n  PRIMARY KEY (`id`) NOT ENFORCED\n)\nWITH (\n  'connector' = 'upsert-kafka-safe',\n  'key.format' = 'flexible-json',\n  'properties.auto.offset.reset' = 'earliest',\n  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',\n  'properties.compression.type' = 'zstd',\n  'properties.group.id' = '${KAFKA_GROUP_ID}',\n  'topic' = 'Foo_raw',\n  'value.fields-include' = 'ALL',\n  'value.format' = 'flexible-json'\n)\nLIKE `Foo_schema`",
+    "definition" : {
+      "columns" : [ ],
+      "primaryKey" : [ "id" ],
+      "partitionKey" : [ ]
+    },
+    "configOptions" : {
+      "cleanup.policy" : "compact"
+    }
+  } ]
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/mutation-like-import.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/mutation-like-import.sqrl
@@ -1,0 +1,3 @@
+IMPORT sources AS src;
+
+FooOut := SELECT id, label FROM src.Foo_raw;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/package-incompatible.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/package-incompatible.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "kafka", "postgres", "vertx"],
+  "script": {
+    "main": "mutation-like-import.sqrl",
+    "database": "database/incompatible_database.json"
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "kafka", "postgres", "vertx"],
+  "script": {
+    "main": "mutation-like-import.sqrl",
+    "database": "database/mutation_database.json"
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/sources.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/mutation-like-import-compile/sources.sqrl
@@ -1,0 +1,10 @@
+CREATE TABLE Foo_schema (
+    ts TIMESTAMP_LTZ(3) NOT NULL,
+    id INT NOT NULL,
+    label STRING
+);
+
+/*+engine(kafka) */
+CREATE TABLE Foo_raw (
+    PRIMARY KEY (id) NOT ENFORCED
+) LIKE Foo_schema;


### PR DESCRIPTION
Fixes #2291

## Problem

With `script.database` configured, compilation fails for any kafka mutation table defined with a `LIKE` clause that is reached through an aliased import (`IMPORT <module> AS <alias>`):

```
Source table '`default_catalog`.`default_database`.`Foo_schema`' of the LIKE clause not found in the catalog
    at com.datasqrl.planner.Sqrl2FlinkSQLTranslator.parse2RelDataType
    at com.datasqrl.planner.dag.plan.MutationDatabase.isBackwardsCompatible
```

The first deploy succeeds; every redeploy against the emitted `pipeline_mutation_database.json` fails.

## Root cause

An aliased *script* import plans that module in its own Flink database (`SqlScriptPlanner.addImport` → `setDatabase("src", …)`), so `Foo_schema` is registered as `default_catalog.src.Foo_schema`. But `MutationDatabase.from` serializes the mutation table's DDL with the `LIKE` source **unqualified**, and `MutationDatabase.isBackwardsCompatible` re-parses it later, when the current database is back to `default_database` — so the lookup fails. A plain `IMPORT sources.*` uses an inline script context, stays in the default database, and happens to resolve.

## Fix

`parse2RelDataType(String)` now runs the parsed statement through `resolveLikeSource`: when the `LIKE` source does not resolve against the current database, it is looked up in the databases created during planning and the reference is rewritten to a fully-qualified identifier. `createdDatabases` became a `LinkedHashSet` so that search is deterministic.

This fixes the **resolution** side rather than emitting qualified or expanded DDL, because the compatibility check parses the file written by a *previous* deploy — a generation-only fix would leave every already-emitted `pipeline_mutation_database.json` broken. It also keeps the 81 existing `LIKE`-bearing snapshots untouched.

## Tests

New compile-only use case `usecases/mutation-like-import-compile/` reproducing the issue (aliased script import + `LIKE`-defined kafka mutation table + `script.database`), with two package files:

- `package.json` — compiles clean.
- `package-incompatible.json` — snapshots the incompatibility warning (`field 'label' type is not backwards compatible: 'INTEGER' -> 'VARCHAR(2147483647)'`), so the check cannot silently regress into a no-op and we prove the `LIKE` resolves to the *right* table.

Both cases fail without the fix and pass with it. Full `mvn test` across the reactor is green, with no other snapshot churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ursWMkvguqDybED1cjngY
