### PR TITLE
fix: Analyze process table function inputs

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -447,7 +447,13 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
       }
     }
     // Generic table function call
-    return setProcessResult(RelNodeAnalysis.builder().relNode(functionScan).build());
+    var inputs = getInputAnalyses(functionScan);
+    return setProcessResult(
+        RelNodeAnalysis.builder()
+            .relNode(
+                updateRelnode(
+                    functionScan, inputs.stream().map(RelNodeAnalysis::getRelNode).toList()))
+            .build());
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -92,7 +92,9 @@ import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.functions.sql.SqlWindowTableFunction;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 
@@ -445,15 +447,19 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
                 .hasNowFilter(false)
                 .build());
       }
+    } else if (call.getOperator() instanceof BridgingSqlFunction function
+        && function.getDefinition().getKind() == FunctionKind.PROCESS_TABLE) {
+      // PTFs carry TABLE arguments as relational inputs that form DAG dependencies.
+      var inputs = getInputAnalyses(functionScan);
+      return setProcessResult(
+          RelNodeAnalysis.builder()
+              .relNode(
+                  updateRelnode(
+                      functionScan, inputs.stream().map(RelNodeAnalysis::getRelNode).toList()))
+              .build());
     }
     // Generic table function call
-    var inputs = getInputAnalyses(functionScan);
-    return setProcessResult(
-        RelNodeAnalysis.builder()
-            .relNode(
-                updateRelnode(
-                    functionScan, inputs.stream().map(RelNodeAnalysis::getRelNode).toList()))
-            .build());
+    return setProcessResult(RelNodeAnalysis.builder().relNode(functionScan).build());
   }
 
   @Override

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/to-changelog-package.txt
@@ -1,9 +1,4 @@
 >>>inferred_schema.graphqls
-type AppendStream {
-  k: String!
-  v_sum: Int!
-}
-
 "An RFC-3339 compliant Full Date Scalar"
 scalar Date
 
@@ -25,7 +20,7 @@ scalar LocalTime
 scalar Long
 
 type Query {
-  AppendStream(limit: Int = 10, offset: Int = 0): [AppendStream!]
+  AppendStream(limit: Int = 10, offset: Int = 0): [InputAgg!]
   InputAgg(limit: Int = 10, offset: Int = 0): [InputAgg!]
 }
 
@@ -50,11 +45,13 @@ Type:        relation
 Stage:       flink
 Primary key: k, v_sum
 Timestamp:   -
-Row count:   ~3
+Row count:   ~1e8
 ---
 Schema:
  - k: CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL
  - v_sum: INTEGER NOT NULL
+Inputs:
+ - default_catalog.default_database.InputAgg
 
 === InputAgg
 ID:          default_catalog.default_database.InputAgg
@@ -263,7 +260,7 @@ CREATE TABLE IF NOT EXISTS "InputAgg" ("k" TEXT NOT NULL, "v_sum" INTEGER NOT NU
       ],
       "schema" : {
         "type" : "string",
-        "schema" : "type AppendStream {\n  k: String!\n  v_sum: Int!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype InputAgg {\n  k: String!\n  v_sum: Int!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  AppendStream(limit: Int = 10, offset: Int = 0): [AppendStream!]\n  InputAgg(limit: Int = 10, offset: Int = 0): [InputAgg!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+        "schema" : "\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\ntype InputAgg {\n  k: String!\n  v_sum: Int!\n}\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\ntype Query {\n  AppendStream(limit: Int = 10, offset: Int = 0): [InputAgg!]\n  InputAgg(limit: Int = 10, offset: Int = 0): [InputAgg!]\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
       }
     }
   }


### PR DESCRIPTION
Fixes #2056

Process table function scans could skip analysis of their relational inputs, leaving referenced source tables out of the logical plan analysis and causing missing DAG subtrees.

Analyze each input and rebuild the table function scan with the analyzed nodes so its source dependencies are preserved.
So my Addition is simple : `getInputAnalyses(functionScan)` now visits every relational input, allowing existing table-scan analysis to collect its sources. The scan is then rebuilt with the analyzed inputs so those dependencies remain in the logical plan and DAG.