### PR TITLE
fix: Preserve distinct state for materialized stream consumers

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/dag/DAGPlanner.java
@@ -267,10 +267,18 @@ public class DAGPlanner {
                   var exportEngine = (ExportEngine) exportStage.engine();
                   TableAnalysis originalNodeTable = node.getTableAnalysis(),
                       sinkNodeTable = originalNodeTable;
+                  var hasStreamConsumer =
+                      dag.getOutputs(node).stream()
+                          .anyMatch(
+                              output ->
+                                  output != downstream
+                                      && (output instanceof ExportNode
+                                          || output.getChosenStage().equals(streamStage)));
                   if (exportEngine.supports(EngineFeature.MATERIALIZE_ON_KEY)
-                      && node.getTableAnalysis().isMostRecentDistinct()) {
+                      && node.getTableAnalysis().isMostRecentDistinct()
+                      && !hasStreamConsumer) {
                     // If we are sinking to a datastore and the node is a most recent distinct, we
-                    // can remove that node
+                    // can remove that node when it has no other stream consumers
                     // since materializing into the table on primary key has the same effect and is
                     // more efficient
                     errors.checkFatal(

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/aggregateWithMaxTimestamp.txt
@@ -302,7 +302,7 @@ FROM `default_catalog`.`default_database`.`Orders`
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrdersState_6`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
-FROM `default_catalog`.`default_database`.`Orders`
+FROM `default_catalog`.`default_database`.`OrdersState`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportTest.txt
@@ -364,7 +364,7 @@ FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
-FROM `default_catalog`.`default_database`.`Customer`
+FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualInternal.txt
@@ -364,7 +364,7 @@ FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
-FROM `default_catalog`.`default_database`.`Customer`
+FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/exportToIndividualTable.txt
@@ -360,7 +360,7 @@ FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_4`
 SELECT *
-FROM `default_catalog`.`default_database`.`Customer`
+FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`JoinStream_5`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/jsonInStreamTest.txt
@@ -508,7 +508,7 @@ WITH (
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
-FROM `default_catalog`.`default_database`.`CustomerStream`
+FROM `default_catalog`.`default_database`.`Customer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerStream_2`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/tableStateJoinTest.txt
@@ -500,7 +500,7 @@ WITH (
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `default_catalog`.`default_database`.`Customer_1`
 SELECT *
-FROM `default_catalog`.`default_database`.`_Customer`
+FROM `default_catalog`.`default_database`.`Customer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`OrderCustomer_2`
 SELECT *
@@ -528,7 +528,7 @@ FROM `default_catalog`.`default_database`.`OrderCustomerRightExcluded`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_8`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
-FROM `default_catalog`.`default_database`.`_Orders`
+FROM `default_catalog`.`default_database`.`Orders`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/temporalJoinTest.txt
@@ -257,7 +257,7 @@ FROM `default_catalog`.`default_database`.`Customer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`DistinctCustomer_2`
 SELECT *
-FROM `default_catalog`.`default_database`.`Customer`
+FROM `default_catalog`.`default_database`.`DistinctCustomer`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Orders_3`
 SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/banking-package.txt
@@ -715,7 +715,7 @@ FROM `default_catalog`.`default_database`.`ApplicationUpdates`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Applications_5`
 SELECT *
-FROM `default_catalog`.`default_database`.`ApplicationsStream`
+FROM `default_catalog`.`default_database`.`Applications`
 ;
 INSERT INTO `default_catalog`.`default_database`.`ApplicationsStream_6`
 SELECT *
@@ -735,7 +735,7 @@ FROM `default_catalog`.`default_database`.`CustomersStream`
 ;
 INSERT INTO `default_catalog`.`default_database`.`LoanTypes_10`
 SELECT *
-FROM `default_catalog`.`default_database`.`LoanTypesStream`
+FROM `default_catalog`.`default_database`.`LoanTypes`
 ;
 INSERT INTO `default_catalog`.`default_database`.`LoanTypesStream_11`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/conference-package.txt
@@ -565,7 +565,7 @@ FROM `default_catalog`.`default_database`.`EventLikeCount`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Events_2`
 SELECT `url`, `date`, `time`, `title`, `abstract`, `location`, `to_jsonb`(`speakers`) AS `speakers`, `last_updated`, `id`, `full_text`, `startTime`, `embedding`, `startTimestamp`
-FROM `default_catalog`.`default_database`.`_ProcessedEventStream`
+FROM `default_catalog`.`default_database`.`Events`
 ;
 INSERT INTO `default_catalog`.`default_database`.`_UserInterests_3`
 SELECT *
@@ -573,7 +573,7 @@ FROM `default_catalog`.`default_database`.`_UserInterests`
 ;
 INSERT INTO `default_catalog`.`default_database`.`_UserLikes_4`
 SELECT *
-FROM `default_catalog`.`default_database`.`_Likes`
+FROM `default_catalog`.`default_database`.`_UserLikes`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/distinct-materialization-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/distinct-materialization-compile-package.txt
@@ -1,0 +1,254 @@
+>>>pipeline_explain.txt
+=== DeploymentState
+ID:          default_catalog.default_database.DeploymentState
+Type:        state
+Stage:       flink
+Primary key: deploymentId
+Timestamp:   eventTime
+Row count:   ~2e7
+---
+Schema:
+ - deploymentId: BIGINT NOT NULL
+ - dataGroupId: BIGINT NOT NULL
+ - eventTime: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.DeploymentStateBase
+Annotations:
+ - mostRecentDistinct: true
+
+=== DeploymentStateBase
+ID:          default_catalog.default_database.DeploymentStateBase
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   eventTime
+Row count:   ~1e8
+---
+Schema:
+ - deploymentId: BIGINT NOT NULL
+ - dataGroupId: BIGINT NOT NULL
+ - eventTime: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Deployments
+ - default_catalog.default_database.Projects
+
+=== DeploymentStateById
+ID:          default_catalog.default_database.DeploymentStateById
+Type:        query
+Stage:       postgres
+---
+Inputs:
+ - default_catalog.default_database.DeploymentState
+Annotations:
+ - parameters: deploymentId
+ - base-table: DeploymentState
+
+=== Deployments
+ID:          default_catalog.default_database.Deployments
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   eventTime
+Row count:   ~1e8
+---
+Schema:
+ - deploymentId: BIGINT NOT NULL
+ - projectId: BIGINT NOT NULL
+ - eventTime: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Deployments__base
+
+=== Projects
+ID:          default_catalog.default_database.Projects
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   eventTime
+Row count:   ~1e8
+---
+Schema:
+ - projectId: BIGINT NOT NULL
+ - dataGroupId: BIGINT NOT NULL
+ - eventTime: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Projects__base
+
+=== DeploymentState
+ID:          logger.DeploymentState
+Type:        export
+Stage:       flink
+---
+Inputs:
+ - default_catalog.default_database.DeploymentState
+
+>>>flink-sql-no-functions.sql
+CREATE TABLE `Deployments` (
+  `deploymentId` BIGINT NOT NULL,
+  `projectId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
+  WATERMARK FOR `eventTime` AS `eventTime` - INTERVAL '0.0' SECOND
+)
+WITH (
+  'connector' = 'kafka-safe',
+  'format' = 'flexible-json',
+  'properties.auto.offset.reset' = 'earliest',
+  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
+  'properties.compression.type' = 'zstd',
+  'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'topic' = 'Deployments'
+);
+CREATE TABLE `Projects` (
+  `projectId` BIGINT NOT NULL,
+  `dataGroupId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp',
+  WATERMARK FOR `eventTime` AS `eventTime` - INTERVAL '0.0' SECOND
+)
+WITH (
+  'connector' = 'kafka-safe',
+  'format' = 'flexible-json',
+  'properties.auto.offset.reset' = 'earliest',
+  'properties.bootstrap.servers' = '${KAFKA_BOOTSTRAP_SERVERS}',
+  'properties.compression.type' = 'zstd',
+  'properties.group.id' = '${KAFKA_GROUP_ID}',
+  'topic' = 'Projects'
+);
+CREATE VIEW `DeploymentStateBase`
+AS
+SELECT `d`.`deploymentId`, `p`.`dataGroupId`, `d`.`eventTime`
+FROM `Deployments` AS `d`
+ INNER JOIN `Projects` AS `p` ON `d`.`projectId` = `p`.`projectId`;
+CREATE VIEW `DeploymentState`
+AS
+SELECT `deploymentId`, `dataGroupId`, `eventTime`
+FROM (SELECT `deploymentId`, `dataGroupId`, `eventTime`, ROW_NUMBER() OVER (PARTITION BY `deploymentId` ORDER BY `eventTime` DESC NULLS LAST) AS `__sqrlinternal_rownum`
+  FROM `default_catalog`.`default_database`.`DeploymentStateBase`) AS `t`
+WHERE `__sqrlinternal_rownum` = 1;
+CREATE TABLE `DeploymentState_1` (
+  `deploymentId` BIGINT NOT NULL,
+  `dataGroupId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`deploymentId`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'print',
+  'print-identifier' = 'DeploymentState'
+);
+CREATE TABLE `DeploymentState_2` (
+  `deploymentId` BIGINT NOT NULL,
+  `dataGroupId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`deploymentId`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'TIMESTAMP',
+  'sink.on-conflict.timestamp-column' = 'eventTime',
+  'table-name' = 'DeploymentState',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `DeploymentStateBase_3` (
+  `deploymentId` BIGINT NOT NULL,
+  `dataGroupId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'DeploymentStateBase',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Deployments_4` (
+  `deploymentId` BIGINT NOT NULL,
+  `projectId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Deployments',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Projects_5` (
+  `projectId` BIGINT NOT NULL,
+  `dataGroupId` BIGINT NOT NULL,
+  `eventTime` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Projects',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`DeploymentState_1`
+SELECT *
+FROM `default_catalog`.`default_database`.`DeploymentState`
+;
+INSERT INTO `default_catalog`.`default_database`.`DeploymentState_2`
+SELECT *
+FROM `default_catalog`.`default_database`.`DeploymentState`
+;
+INSERT INTO `default_catalog`.`default_database`.`DeploymentStateBase_3`
+SELECT `deploymentId`, `dataGroupId`, `eventTime`, `hash_columns`(`deploymentId`, `dataGroupId`, `eventTime`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`DeploymentStateBase`
+;
+INSERT INTO `default_catalog`.`default_database`.`Deployments_4`
+SELECT `deploymentId`, `projectId`, `eventTime`, `hash_columns`(`deploymentId`, `projectId`, `eventTime`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`Deployments`
+;
+INSERT INTO `default_catalog`.`default_database`.`Projects_5`
+SELECT `projectId`, `dataGroupId`, `eventTime`, `hash_columns`(`projectId`, `dataGroupId`, `eventTime`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`Projects`
+;
+END
+>>>kafka.json
+{
+  "topics" : [
+    {
+      "topicName" : "Deployments",
+      "tableName" : "Deployments",
+      "format" : "flexible-json",
+      "numPartitions" : 1,
+      "replicationFactor" : 3,
+      "type" : "MUTATION",
+      "messageKeys" : [ ],
+      "messageSchema" : "",
+      "config" : { }
+    },
+    {
+      "topicName" : "Projects",
+      "tableName" : "Projects",
+      "format" : "flexible-json",
+      "numPartitions" : 1,
+      "replicationFactor" : 3,
+      "type" : "MUTATION",
+      "messageKeys" : [ ],
+      "messageSchema" : "",
+      "config" : { }
+    }
+  ],
+  "testRunnerTopics" : [ ]
+}
+>>>postgres-schema.sql
+CREATE TABLE IF NOT EXISTS "DeploymentState" ("deploymentId" BIGINT NOT NULL, "dataGroupId" BIGINT NOT NULL, "eventTime" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY ("deploymentId"));
+CREATE TABLE IF NOT EXISTS "DeploymentStateBase" ("deploymentId" BIGINT NOT NULL, "dataGroupId" BIGINT NOT NULL, "eventTime" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "Deployments" ("deploymentId" BIGINT NOT NULL, "projectId" BIGINT NOT NULL, "eventTime" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"));
+CREATE TABLE IF NOT EXISTS "Projects" ("projectId" BIGINT NOT NULL, "dataGroupId" BIGINT NOT NULL, "eventTime" TIMESTAMP WITH TIME ZONE NOT NULL, "__pk_hash" TEXT, PRIMARY KEY ("__pk_hash"))

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package-s3.txt
@@ -717,7 +717,7 @@ FROM `default_catalog`.`default_database`.`CustomerPromotion`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customers_2`
 SELECT *
-FROM `default_catalog`.`default_database`.`_CustomersStream`
+FROM `default_catalog`.`default_database`.`Customers`
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersOrderStats_3`
 SELECT *
@@ -741,7 +741,7 @@ FROM `default_catalog`.`default_database`.`OrdersTotals`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Products_8`
 SELECT *
-FROM `default_catalog`.`default_database`.`_ProductsStream`
+FROM `default_catalog`.`default_database`.`Products`
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductsByCountry_9`
 SELECT `productid`, `country`, `quantity`, `spend`, `weight`, `hash_columns`(`productid`, `country`) AS `__pk_hash`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/seedshop-tutorial-package.txt
@@ -717,7 +717,7 @@ FROM `default_catalog`.`default_database`.`CustomerPromotion`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Customers_2`
 SELECT *
-FROM `default_catalog`.`default_database`.`_CustomersStream`
+FROM `default_catalog`.`default_database`.`Customers`
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomersOrderStats_3`
 SELECT *
@@ -741,7 +741,7 @@ FROM `default_catalog`.`default_database`.`OrdersTotals`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Products_8`
 SELECT *
-FROM `default_catalog`.`default_database`.`_ProductsStream`
+FROM `default_catalog`.`default_database`.`Products`
 ;
 INSERT INTO `default_catalog`.`default_database`.`ProductsByCountry_9`
 SELECT `productid`, `country`, `quantity`, `spend`, `weight`, `hash_columns`(`productid`, `country`) AS `__pk_hash`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/sensors-full-compile-package.txt
@@ -427,7 +427,7 @@ FROM `default_catalog`.`default_database`.`_SensorMaxTempWindow`
 ;
 INSERT INTO `default_catalog`.`default_database`.`Sensors_5`
 SELECT *
-FROM `default_catalog`.`sources`.`Sensors`
+FROM `default_catalog`.`default_database`.`Sensors`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/distinct-materialization-compile/distinct-materialization.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/distinct-materialization-compile/distinct-materialization.sqrl
@@ -1,0 +1,27 @@
+/*+engine(kafka) */
+CREATE TABLE Deployments (
+  deploymentId BIGINT NOT NULL,
+  projectId BIGINT NOT NULL,
+  eventTime TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp'
+);
+
+/*+engine(kafka) */
+CREATE TABLE Projects (
+  projectId BIGINT NOT NULL,
+  dataGroupId BIGINT NOT NULL,
+  eventTime TIMESTAMP_LTZ(3) NOT NULL METADATA FROM 'timestamp'
+);
+
+DeploymentStateBase :=
+    SELECT d.deploymentId, p.dataGroupId, d.eventTime
+    FROM Deployments d JOIN Projects p ON d.projectId = p.projectId;
+
+/*+primary_key(deploymentId) */
+DeploymentState := DISTINCT DeploymentStateBase ON deploymentId ORDER BY eventTime DESC;
+
+-- Keeps the ranked state table in the Flink pipeline.
+EXPORT DeploymentState TO logger.DeploymentState;
+
+-- Forces the same state table to be materialized to Postgres.
+DeploymentStateById(deploymentId BIGINT NOT NULL) :=
+    SELECT * FROM DeploymentState WHERE deploymentId = :deploymentId;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/distinct-materialization-compile/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/distinct-materialization-compile/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "enabled-engines": ["postgres", "kafka", "flink"],
+  "script": {
+    "main": "distinct-materialization.sqrl"
+  },
+  "test-runner": {
+    "delay-sec": -1
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2296 by preserving a `DISTINCT ... ON` state table when it is consumed by both a Flink pipeline and a datastore materialization.

Previously, the planner could bypass the rank for the datastore sink and persist the unranked input stream instead.

## Changes

- Prevent the planner from skipping the `DISTINCT ... ON` rank when a state table has another Flink or export consumer.
- Add a `distinct-materialization-compile` regression fixture.
- Update affected compilation snapshots to materialize the distinct state table instead of its source stream.