### PR TITLE
chore: Document pg_partman_bgw.interval override

### DIFF
--- a/documentation/docs/configuration-engine/cloud-deployment.md
+++ b/documentation/docs/configuration-engine/cloud-deployment.md
@@ -349,3 +349,5 @@ Typically used in a catch-up profile that trades durability for ingest throughpu
 }
 ```
 
+For deployments with [partitioned tables](postgres.md#partitioning), `pg_partman_bgw.interval` (seconds between pg_partman background-worker maintenance runs, default `3600`) can also be overridden here. The `pg_partman_bgw.dbname` and `pg_partman_bgw.role` settings are managed by the platform and cannot be overridden.
+


### PR DESCRIPTION
## What was done
- Documented in the cloud-deployment `parameters` section that `pg_partman_bgw.interval` (pg_partman background-worker maintenance interval, default 3600s) can be overridden via `engines.postgres.deployment.parameters`, and that `pg_partman_bgw.dbname` / `pg_partman_bgw.role` are platform-managed and not overridable

## Why it was done
- Docs counterpart of DataSQRL/cloud-compilation#1217, which makes the interval user-configurable through the existing parameters pass-through