### PR TITLE
fix: Restrict custom build folders to `build/` subdirectories

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/AbstractCompileCmd.java
@@ -91,11 +91,9 @@ public abstract class AbstractCompileCmd extends BasePackageConfCmd {
 
     try (var springCtx = new AnnotationConfigApplicationContext()) {
       springCtx.registerBean(ErrorCollector.class, () -> errors);
-      if (projectRoot.isPresent()) {
-        // We only set this if project root is explicitly given
-        springCtx.registerBean("projectRoot", Path.class, this::getProjectRoot);
-      }
       springCtx.registerBean("workspaceDir", Path.class, () -> cli.workspaceDir);
+      springCtx.registerBean("projectRoot", Path.class, this::getProjectRoot);
+      springCtx.registerBean("buildBaseDir", Path.class, this::getBuildBaseDir);
       springCtx.registerBean("buildDir", Path.class, this::getBuildDir);
       springCtx.registerBean("targetDir", Path.class, this::getTargetDir);
       springCtx.registerBean(PackageJson.class, () -> sqrlConfig);

--- a/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/cli/BaseOsProcessManagerCmd.java
@@ -37,15 +37,21 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
   @Option(
       names = {"-b", "--build"},
       description =
-          "Build folder for any output generated during build. Must be a relative path within the project root."
-              + " Resolved relative to the specified or inferred project root. Default: \"<project-root>/build\".\n")
+          "Subfolder of \"<project-root>/build\" for build output."
+              + " The value must be a relative path that remains within that build folder."
+              + " For example, \"--build development\" writes to \"<project-root>/build/development\"."
+              + " If omitted, output is written directly to \"<project-root>/build\"."
+              + " This setting determines the default target folder when \"--target\" is omitted.\n")
   protected Optional<Path> buildFolder = Optional.empty();
 
   @Option(
       names = {"-t", "--target"},
       description =
-          "Target folder for deployment artifacts and plans. Must be a relative path within the project root."
-              + " Resolved relative to the specified or inferred project root. Default: \"<project-root>/build/deploy\".\n")
+          "Folder for deployment artifacts and plans. The value must be a relative path that remains within \"<project-root>\"."
+              + " Unlike \"--build\", an explicit value is resolved directly from the project root:"
+              + " \"--target artifacts\" writes to \"<project-root>/artifacts\", independent of \"--build\"."
+              + " If omitted, the target is \"<build-folder>/deploy\"."
+              + " For example, \"--build development\" defaults the target to \"<project-root>/build/development/deploy\".\n")
   protected Optional<Path> targetFolder = Optional.empty();
 
   @Override
@@ -75,8 +81,12 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
 
   protected Path getBuildDir() {
     return buildFolder
-        .map(path -> resolveGivenCliDir(path, "Build"))
-        .orElseGet(() -> getProjectRoot().resolve(SqrlConstants.BUILD_DIR_NAME));
+        .map(path -> resolveGivenCliDir(path, "Build", getBuildBaseDir(), "build folder"))
+        .orElseGet(this::getBuildBaseDir);
+  }
+
+  protected Path getBuildBaseDir() {
+    return getProjectRoot().resolve(SqrlConstants.BUILD_DIR_NAME);
   }
 
   protected Path getTargetDir() {
@@ -124,11 +134,14 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
   }
 
   private Path resolveGivenCliDir(Path dir, String dirType) {
+    return resolveGivenCliDir(dir, dirType, getProjectRoot(), "project root");
+  }
+
+  private Path resolveGivenCliDir(Path dir, String dirType, Path root, String rootDescription) {
     if (!cli.internalTestExec && dir.isAbsolute()) {
       throw new IllegalArgumentException(dirType + " folder must be a relative path, got: " + dir);
     }
 
-    var root = getProjectRoot();
     var directory = root.resolve(dir);
     if (!cli.internalTestExec && !directory.normalize().startsWith(root.normalize())) {
       throw new IllegalArgumentException(
@@ -137,7 +150,9 @@ public abstract class BaseOsProcessManagerCmd extends BaseCmd {
               + dir
               + "' resolves to '"
               + directory.normalize()
-              + "', which is outside project root '"
+              + "', which is outside "
+              + rootDescription
+              + " '"
               + root.normalize()
               + "'");
     }

--- a/sqrl-cli/src/main/java/com/datasqrl/packager/FilePreprocessingPipeline.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/packager/FilePreprocessingPipeline.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -48,11 +49,20 @@ import org.springframework.stereotype.Component;
  * preprocessing than just copying files.
  */
 @Component
-@RequiredArgsConstructor
 public class FilePreprocessingPipeline {
 
   private final WorkspacePaths workspacePaths;
+  private final Path buildBaseDir;
   private final Set<Preprocessor> preprocessors;
+
+  public FilePreprocessingPipeline(
+      WorkspacePaths workspacePaths,
+      @Qualifier("buildBaseDir") Path buildBaseDir,
+      Set<Preprocessor> preprocessors) {
+    this.workspacePaths = workspacePaths;
+    this.buildBaseDir = buildBaseDir;
+    this.preprocessors = preprocessors;
+  }
 
   public void run(Path sourceDir, ErrorCollector errors) throws IOException {
     run(sourceDir, NamePath.ROOT, errors);
@@ -65,7 +75,7 @@ public class FilePreprocessingPipeline {
         sourceDir,
         EnumSet.of(FileVisitOption.FOLLOW_LINKS),
         Integer.MAX_VALUE,
-        new PathVisitor(sourceDir, buildDir, errors));
+        new PathVisitor(sourceDir, buildBaseDir, buildDir, errors));
     preprocessors.forEach(Preprocessor::complete);
   }
 
@@ -87,12 +97,13 @@ public class FilePreprocessingPipeline {
     private final Deque<Context> ctxDeque = new ArrayDeque<>();
 
     private final Path sourceDir;
+    private final Path buildBaseDir;
     private final Path buildDir;
     private final ErrorCollector errors;
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-      if (dir.startsWith(buildDir)) {
+      if (dir.startsWith(buildBaseDir)) {
         return FileVisitResult.SKIP_SUBTREE;
       }
 

--- a/sqrl-cli/src/main/java/com/datasqrl/packager/Packager.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/packager/Packager.java
@@ -65,7 +65,7 @@ public class Packager {
       cleanDir(workspacePaths.workspaceDir().resolve(SqrlConstants.DEFAULT_ICEBERG_WAREHOUSE_DIR));
       createBuildDir(workspacePaths.buildDir());
 
-      var basePath = workspacePaths.projectRoot().orElse(workspacePaths.buildDir().getParent());
+      var basePath = workspacePaths.projectRoot();
       // Preprocess included project(s) first if there are any
       var includes = config.getScriptConfig().getIncludeConfigs();
       for (var include : includes) {

--- a/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/util/SqrlInjector.java
@@ -20,7 +20,6 @@ import com.datasqrl.config.WorkspacePaths;
 import com.datasqrl.loaders.resolver.FileResourceResolver;
 import com.datasqrl.loaders.resolver.ResourceResolver;
 import java.nio.file.Path;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -35,7 +34,7 @@ public class SqrlInjector {
       @Qualifier("workspaceDir") Path workspaceDir,
       @Qualifier("buildDir") Path buildDir,
       @Qualifier("targetDir") Path targetDir,
-      @Qualifier("projectRoot") Optional<Path> projectRoot) {
+      @Qualifier("projectRoot") Path projectRoot) {
 
     return new WorkspacePaths(workspaceDir, buildDir, targetDir, projectRoot);
   }

--- a/sqrl-cli/src/test/java/com/datasqrl/cli/CompileCmdTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/cli/CompileCmdTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,6 +104,46 @@ class CompileCmdTest {
   }
 
   @Test
+  void givenInferredProjectRoot_whenCompiling_thenRegistersProjectRootForPreprocessing()
+      throws Exception {
+    var projectRoot = tempDir.resolve("project");
+    var packageJsonPath = projectRoot.resolve("package.json");
+    Files.createDirectory(projectRoot);
+    Files.writeString(packageJsonPath, "{}");
+
+    var compileCmd = new CompileCmd();
+    compileCmd.cli = new DatasqrlCli(tempDir, StatusHook.NONE, true);
+    compileCmd.packageFiles = List.of(Path.of("project", "package.json"));
+
+    when(sqrlConfig.getTestConfig()).thenReturn(testConfig);
+    when(testConfig.getTestDir(projectRoot)).thenReturn(Optional.empty());
+    when(compilationProcess.executeCompilation(Optional.empty()))
+        .thenReturn(Pair.of(PhysicalPlan.builder().build(), new TestPlan()));
+
+    try (var configLoader = mockStatic(ConfigLoaderUtils.class);
+        var springContext =
+            mockConstruction(
+                AnnotationConfigApplicationContext.class,
+                (mock, context) -> {
+                  when(mock.getBean(ExecutionEnginesHolder.class)).thenReturn(engineHolder);
+                  when(mock.getBean(Packager.class)).thenReturn(packager);
+                  when(mock.getBean(CompilationProcess.class)).thenReturn(compilationProcess);
+                })) {
+      configLoader
+          .when(
+              () ->
+                  ConfigLoaderUtils.loadUnresolvedConfig(
+                      any(ErrorCollector.class), eq(List.of(packageJsonPath))))
+          .thenReturn(sqrlConfig);
+
+      compileCmd.compile(ErrorCollector.root());
+
+      verify(springContext.constructed().get(0))
+          .registerBean(eq("projectRoot"), eq(Path.class), any(Supplier.class));
+    }
+  }
+
+  @Test
   void givenInferredProjectRoot_whenFormattingPackageFiles_thenRemovesInferredRoot()
       throws IOException {
     var projectDir = tempDir.resolve(Path.of("apps", "orders"));
@@ -142,7 +183,7 @@ class CompileCmdTest {
 
   @Test
   void
-      givenCustomBuildFolderAndProjectRoot_whenGettingBuildAndDefaultTargetDirs_thenResolvesBothFromProjectRoot()
+      givenCustomBuildFolderAndProjectRoot_whenGettingBuildAndDefaultTargetDirs_thenResolvesBothFromDefaultBuildFolder()
           throws IOException {
     var projectRoot = tempDir.resolve("project");
     Files.createDirectory(projectRoot);
@@ -152,9 +193,9 @@ class CompileCmdTest {
     compileCmd.projectRoot = Optional.of(Path.of("project"));
     compileCmd.buildFolder = Optional.of(Path.of("output"));
 
-    assertThat(compileCmd.getBuildDir()).isEqualTo(projectRoot.resolve("output"));
+    assertThat(compileCmd.getBuildDir()).isEqualTo(projectRoot.resolve("build/output"));
     assertThat(compileCmd.getTargetDir())
-        .isEqualTo(projectRoot.resolve("output").resolve("deploy"));
+        .isEqualTo(projectRoot.resolve("build/output").resolve("deploy"));
   }
 
   @Test
@@ -170,7 +211,8 @@ class CompileCmdTest {
   }
 
   @Test
-  void givenBuildFolderOutsideProjectRoot_whenGettingBuildDir_thenThrows() throws IOException {
+  void givenBuildFolderOutsideDefaultBuildFolder_whenGettingBuildDir_thenThrows()
+      throws IOException {
     var projectRoot = tempDir.resolve("banking");
     Files.createDirectory(projectRoot);
 
@@ -183,9 +225,9 @@ class CompileCmdTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Build folder '../build-banking' resolves to '"
-                + tempDir.resolve("build-banking")
-                + "', which is outside project root '"
-                + projectRoot
+                + projectRoot.resolve("build-banking")
+                + "', which is outside build folder '"
+                + projectRoot.resolve("build")
                 + "'");
   }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/config/WorkspacePaths.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/WorkspacePaths.java
@@ -16,10 +16,8 @@
 package com.datasqrl.config;
 
 import java.nio.file.Path;
-import java.util.Optional;
 
-public record WorkspacePaths(
-    Path workspaceDir, Path buildDir, Path targetDir, Optional<Path> projectRoot) {
+public record WorkspacePaths(Path workspaceDir, Path buildDir, Path targetDir, Path projectRoot) {
 
   public Path getUdfPath() {
     return targetDir.resolve(SqrlConstants.FLINK_ASSETS_DIR).resolve(SqrlConstants.LIB_DIR);

--- a/sqrl-planner/src/test/java/com/datasqrl/MockSqrlInjector.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/MockSqrlInjector.java
@@ -21,7 +21,6 @@ import com.datasqrl.loaders.resolver.FileResourceResolver;
 import com.datasqrl.loaders.resolver.ResourceResolver;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -49,7 +48,7 @@ public class MockSqrlInjector {
         workspaceDir,
         workspaceDir.resolve("build"),
         workspaceDir.resolve("build").resolve("deploy"),
-        Optional.of(workspaceDir));
+        workspaceDir);
   }
 
   @Bean

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/discovery/FilePreprocessingPipelineIT.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/discovery/FilePreprocessingPipelineIT.java
@@ -34,7 +34,6 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
@@ -58,7 +57,7 @@ class FilePreprocessingPipelineIT {
   void setup() {
     outputDir = snapshotExtension.getOutputDir();
     errorCollector = ErrorCollector.root();
-    workspacePaths = new WorkspacePaths(outputDir, outputDir, outputDir, Optional.of(outputDir));
+    workspacePaths = new WorkspacePaths(outputDir, outputDir, outputDir, outputDir);
   }
 
   @Test
@@ -66,7 +65,8 @@ class FilePreprocessingPipelineIT {
       throws Exception {
     // Arrange
     var preprocessingPipeline =
-        new FilePreprocessingPipeline(workspacePaths, Set.of(new CopyStaticDataPreprocessor()));
+        new FilePreprocessingPipeline(
+            workspacePaths, outputDir, Set.of(new CopyStaticDataPreprocessor()));
 
     // Act
     preprocessingPipeline.run(FILES_DIR, errorCollector);
@@ -102,7 +102,7 @@ class FilePreprocessingPipelineIT {
   void given_jarFile_when_jarPreprocessorRuns_then_processesJarCorrectly() throws Exception {
     // Arrange
     var preprocessingPipeline =
-        new FilePreprocessingPipeline(workspacePaths, Set.of(new JarPreprocessor()));
+        new FilePreprocessingPipeline(workspacePaths, outputDir, Set.of(new JarPreprocessor()));
 
     // Act
     preprocessingPipeline.run(FILES_DIR, errorCollector);
@@ -134,7 +134,8 @@ class FilePreprocessingPipelineIT {
                 new CopyStaticDataPreprocessor(),
                 new JarPreprocessor(),
                 new SqrlPreprocessor(new PackageJsonImpl(), ErrorCollector.root())));
-    var preprocessingPipeline = new FilePreprocessingPipeline(workspacePaths, preprocessors);
+    var preprocessingPipeline =
+        new FilePreprocessingPipeline(workspacePaths, outputDir, preprocessors);
 
     // Act
     preprocessingPipeline.run(FILES_DIR, errorCollector);


### PR DESCRIPTION
## Key Changes

- Restrict custom `--build` paths to subdirectories of `<project-root>/build`
- Reject custom build paths that escape the base build directory
- Resolve `--build development` to `<project-root>/build/development`
- Preserve `--target` as a project-root-relative path when explicitly supplied
- Expand `--build` and `--target` CLI help with optionality, resolution rules, defaults, boundaries, and examples
- Introduce an explicit `buildBaseDir` dependency for file preprocessing
- Skip all directories under `<project-root>/build` during preprocessing, including output from other build profiles
- Fix preprocessing for custom `--build` folders by always providing the resolved project root, ensuring the main SQRL script is copied rather than skipping `<project-root>/build`
- Add regression coverage for custom build resolution and sibling build-directory exclusion