### PR TITLE
fix: Preserve hinted view identity during collapse

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -97,9 +97,11 @@ import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOrderBy;
+import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
@@ -336,22 +338,43 @@ public class Sqrl2FlinkSQLTranslator {
       relationship) inference fails because the row types no longer match. */
       relNode = relRoot.project();
     }
+
     var analyzer =
         new SQRLLogicalPlanAnalyzer(
             relNode,
             tableLookup,
             viewName,
+            getReferencedViews(getQueryFromView(viewDef)),
             relBuilder,
-            flinkPlanner
-                .getOrCreateSqlValidator()
-                .getCatalogReader()
-                .unwrap(CalciteCatalogReader.class),
+            flinkPlanner,
             errors);
 
     var viewAnalysis = analyzer.analyze(hintsAndDoc);
     viewAnalysis.tableAnalysis().topLevelSort(topLevelSort);
 
     return viewAnalysis;
+  }
+
+  private Set<ObjectIdentifier> getReferencedViews(SqlNode query) {
+    query = removeSort(query);
+    if (!(query instanceof SqlSelect select)) {
+      return Set.of();
+    }
+    return getReferencedView(select.getFrom()).map(Set::of).orElseGet(Set::of);
+  }
+
+  private Optional<ObjectIdentifier> getReferencedView(SqlNode source) {
+    if (source instanceof org.apache.calcite.sql.SqlBasicCall call
+        && call.getKind() == SqlKind.AS) {
+      source = call.operand(0);
+    }
+    if (source instanceof SqlIdentifier identifier) {
+      var view = tableLookup.lookupView(qualifyIdentifier(identifier));
+      if (view != null) {
+        return Optional.of(view.getObjectIdentifier());
+      }
+    }
+    return Optional.empty();
   }
 
   public RelRoot toRelRoot(SqlNode query, @Nullable FlinkPlannerImpl flinkPlanner) {
@@ -505,6 +528,7 @@ public class Sqrl2FlinkSQLTranslator {
   /** Analyzes a query executed directly by an INSERT statement. */
   public TableAnalysis analyzeInsertQuery(
       SqlNode query, ObjectIdentifier identifier, HintsAndDoc hintsAndDoc, ErrorCollector errors) {
+
     var flinkPlanner = validatorSupplier.get();
     var relRoot = toRelRoot(query, flinkPlanner);
     var analyzer =
@@ -512,12 +536,11 @@ public class Sqrl2FlinkSQLTranslator {
             relRoot.project(),
             tableLookup,
             identifier.getObjectName(),
+            getReferencedViews(query),
             getRelBuilder(flinkPlanner),
-            flinkPlanner
-                .getOrCreateSqlValidator()
-                .getCatalogReader()
-                .unwrap(CalciteCatalogReader.class),
+            flinkPlanner,
             errors);
+
     return analyzer
         .analyze(hintsAndDoc)
         .tableAnalysis()

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/TableAnalysisLookup.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/TableAnalysisLookup.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Value;
@@ -91,19 +92,36 @@ public class TableAnalysisLookup {
   }
 
   public Optional<TableAnalysis> lookupView(RelNode originalRelnode) {
+    return lookupView(originalRelnode, Set.of());
+  }
+
+  public Optional<TableAnalysis> lookupView(
+      RelNode originalRelnode, Set<ObjectIdentifier> referencedViews) {
+
     var hashCode = originalRelnode.getRowType().hashCode();
-    if (viewMap.containsKey(hashCode)) {
-      var normalizeRelnode = normalizeRelnode(originalRelnode);
-      List<TableAnalysis> allMatches =
-          viewMap.get(hashCode).stream().filter(tbl -> matches(tbl, normalizeRelnode)).toList();
-      // return last one in case there are multiple matches
-      if (allMatches.isEmpty()) {
-        return Optional.empty();
-      }
-      return Optional.of(allMatches.get(allMatches.size() - 1));
-    } else {
+    if (!viewMap.containsKey(hashCode)) {
       return Optional.empty();
     }
+
+    var normalizeRelnode = normalizeRelnode(originalRelnode);
+    var allMatches =
+        viewMap.get(hashCode).stream().filter(tbl -> matches(tbl, normalizeRelnode)).toList();
+
+    if (allMatches.isEmpty()) {
+      return Optional.empty();
+    }
+
+    var referencedMatches =
+        allMatches.stream()
+            .filter(tableAnalysis -> referencedViews.contains(tableAnalysis.getObjectIdentifier()))
+            .toList();
+
+    if (referencedMatches.size() == 1) {
+      return Optional.of(referencedMatches.get(0));
+    }
+
+    // return last one in case there are multiple matches
+    return Optional.of(allMatches.get(allMatches.size() - 1));
   }
 
   private static boolean matches(TableAnalysis tbl, RelNode otherRelNode) {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -93,7 +93,9 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.validate.SqlUserDefinedTableFunction;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.flink.table.api.InsertConflictStrategy.ConflictBehavior;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.functions.sql.SqlWindowTableFunction;
@@ -114,13 +116,14 @@ import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 @Slf4j
 public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
 
-  final RelNode originalRelnode;
-  final SqrlRexUtil rexUtil;
-  final TableAnalysisLookup tableLookup;
-  final String viewName;
-  final FlinkRelBuilder relBuilder;
-  final CalciteCatalogReader catalog;
-  final ErrorCollector errors;
+  @NonNull final RelNode originalRelnode;
+  @NonNull final SqrlRexUtil rexUtil;
+  @NonNull final TableAnalysisLookup tableLookup;
+  @NonNull final String viewName;
+  @NonNull final Set<ObjectIdentifier> referencedViews;
+  @NonNull final FlinkRelBuilder relBuilder;
+  @NonNull final CalciteCatalogReader catalog;
+  @NonNull final ErrorCollector errors;
 
   /** The sources for this relational tree */
   private final List<TableOrFunctionAnalysis> sourceTables = new ArrayList<>();
@@ -146,18 +149,24 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
   protected RelNodeAnalysis intermediateAnalysis = null;
 
   public SQRLLogicalPlanAnalyzer(
-      @NonNull RelNode relNode,
-      @NonNull TableAnalysisLookup tableLookup,
-      @NonNull String viewName,
-      @NonNull FlinkRelBuilder relBuilder,
-      @NonNull CalciteCatalogReader catalog,
-      @NonNull ErrorCollector errors) {
+      RelNode relNode,
+      TableAnalysisLookup tableLookup,
+      String viewName,
+      Set<ObjectIdentifier> referencedViews,
+      FlinkRelBuilder relBuilder,
+      FlinkPlannerImpl flinkPlanner,
+      ErrorCollector errors) {
     this.originalRelnode = relNode;
     this.rexUtil = new SqrlRexUtil(relNode.getCluster().getRexBuilder());
     this.tableLookup = tableLookup;
     this.viewName = viewName;
+    this.referencedViews = referencedViews == null ? Set.of() : referencedViews;
     this.relBuilder = relBuilder;
-    this.catalog = catalog;
+    this.catalog =
+        flinkPlanner
+            .getOrCreateSqlValidator()
+            .getCatalogReader()
+            .unwrap(CalciteCatalogReader.class);
     this.errors = errors;
   }
 
@@ -297,7 +306,7 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
    * @return
    */
   protected RelNodeAnalysis analyzeRelNode(RelNode input) {
-    var tableAnalysis = tableLookup.lookupView(input);
+    var tableAnalysis = tableLookup.lookupView(input, referencedViews);
     if (tableAnalysis.isPresent()) {
       return fromSource(tableAnalysis.get(), input);
     } else {

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/TableAnalysisLookupTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/TableAnalysisLookupTest.java
@@ -17,7 +17,9 @@ package com.datasqrl.planner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datasqrl.planner.analyzer.TableAnalysis;
 import java.util.List;
+import java.util.Set;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
@@ -26,6 +28,7 @@ import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.junit.jupiter.api.Test;
 
 class TableAnalysisLookupTest {
@@ -78,5 +81,30 @@ class TableAnalysisLookupTest {
     assertThat(((Hintable) normalized).getHints())
         .containsExactly(RelHint.builder("STATE_TTL").build());
     assertThat(normalized.deepEquals(lookup.normalizeRelnode(unhintedProject))).isFalse();
+  }
+
+  @Test
+  void givenIdenticalViews_whenLookupViewWithReferencedView_thenSelectsReferencedView() {
+    var typeFactory = new JavaTypeFactoryImpl();
+    var cluster = RelOptCluster.create(new VolcanoPlanner(), new RexBuilder(typeFactory));
+    var relNode = LogicalValues.createOneRow(cluster);
+    var lookup = new TableAnalysisLookup();
+    var explicitIndexes = view(lookup, "ExplicitIndexes", relNode);
+    var noIndexes = view(lookup, "NoIndexes", relNode);
+    lookup.registerTable(explicitIndexes);
+    lookup.registerTable(noIndexes);
+
+    assertThat(lookup.lookupView(relNode, Set.of(explicitIndexes.getObjectIdentifier())))
+        .get()
+        .isEqualTo(explicitIndexes);
+  }
+
+  private static TableAnalysis view(
+      TableAnalysisLookup lookup, String name, LogicalValues relNode) {
+    return TableAnalysis.builder()
+        .objectIdentifier(ObjectIdentifier.of("catalog", "database", name))
+        .originalRelnode(lookup.normalizeRelnode(relNode))
+        .collapsedRelnode(relNode)
+        .build();
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/HintedIndexSelectionTest.java
+++ b/sqrl-testing/sqrl-testing-integration/src/test/java/com/datasqrl/HintedIndexSelectionTest.java
@@ -18,6 +18,7 @@ package com.datasqrl;
 import static com.datasqrl.SnapshotTestSupport.getResourcesDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,7 +31,8 @@ public class HintedIndexSelectionTest {
   final CliCompileTestExtension snapshotExtension = new CliCompileTestExtension();
 
   @Test
-  void givenHintedTablesExceedIndexLimits_whenCompiled_thenDoesNotEmitWarningsForHintedTables() {
+  void givenHintedTablesExceedIndexLimits_whenCompiled_thenRetainsHintedTableDependencies()
+      throws Exception {
     var packageFile = USECASE_DIR.resolve("pg-index-selection-compile").resolve("package.json");
     var hook =
         snapshotExtension.execute(
@@ -38,5 +40,18 @@ public class HintedIndexSelectionTest {
 
     assertThat(hook.isFailed()).as(hook.getMessages()).isFalse();
     assertThat(hook.getMessages()).doesNotContain("table `ExplicitIndexes`", "table `NoIndexes`");
+    var plan = Files.readString(snapshotExtension.getBuildDir().resolve("pipeline_explain.txt"));
+    assertEndpointInput(plan, "ExplicitByCarrierId", "ExplicitIndexes");
+    assertEndpointInput(plan, "NoIndexByCarrierId", "NoIndexes");
+    assertEndpointInput(plan, "ExplicitIndexesSink", "ExplicitIndexes");
+  }
+
+  private static void assertEndpointInput(String plan, String endpoint, String input) {
+    var start = plan.indexOf("=== " + endpoint);
+    var end = plan.indexOf("===", start + 3);
+    assertThat(start).isGreaterThanOrEqualTo(0);
+    assertThat(end).isGreaterThan(start);
+    assertThat(plan.substring(start, end))
+        .contains("Inputs:\n - default_catalog.default_database." + input);
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-index-selection-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-index-selection-compile-package.txt
@@ -707,7 +707,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: campaignId
  - base-table: ExplicitByCampaignId
@@ -718,7 +718,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: carrierId
  - base-table: ExplicitByCarrierId
@@ -729,7 +729,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: category
  - base-table: ExplicitByCategory
@@ -740,7 +740,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: channel
  - base-table: ExplicitByChannel
@@ -751,7 +751,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: country
  - base-table: ExplicitByCountry
@@ -762,7 +762,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: currency
  - base-table: ExplicitByCurrency
@@ -773,7 +773,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: customerId
  - base-table: ExplicitByCustomerId
@@ -784,7 +784,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: deviceType
  - base-table: ExplicitByDeviceType
@@ -795,7 +795,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: discountCode
  - base-table: ExplicitByDiscountCode
@@ -806,7 +806,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: fulfillmentStatus
  - base-table: ExplicitByFulfillmentStatus
@@ -817,7 +817,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: orderId
  - base-table: ExplicitByOrderId
@@ -828,7 +828,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: paymentMethod
  - base-table: ExplicitByPaymentMethod
@@ -839,7 +839,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: productId
  - base-table: ExplicitByProductId
@@ -850,7 +850,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: returnReason
  - base-table: ExplicitByReturnReason
@@ -861,7 +861,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: riskLevel
  - base-table: ExplicitByRiskLevel
@@ -872,7 +872,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: salesRepId
  - base-table: ExplicitBySalesRepId
@@ -883,7 +883,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: shippingMethod
  - base-table: ExplicitByShippingMethod
@@ -894,7 +894,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: status
  - base-table: ExplicitByStatus
@@ -905,7 +905,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: storeId
  - base-table: ExplicitByStoreId
@@ -916,7 +916,7 @@ Type:        query
 Stage:       postgres
 ---
 Inputs:
- - default_catalog.default_database.NoIndexes
+ - default_catalog.default_database.ExplicitIndexes
 Annotations:
  - parameters: warehouseId
  - base-table: ExplicitByWarehouseId
@@ -955,6 +955,30 @@ Schema:
  - createdAt: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
 Inputs:
  - default_catalog.default_database.Orders
+
+=== ExplicitIndexesSink
+ID:          default_catalog.default_database.ExplicitIndexesSink
+Type:        export
+Stage:       flink
+Connector:   print
+---
+Inputs:
+ - default_catalog.default_database.ExplicitIndexesSink_in1
+
+=== ExplicitIndexesSink_in1
+ID:          default_catalog.default_database.ExplicitIndexesSink_in1
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   createdAt
+Row count:   ~1e8
+---
+Schema:
+ - orderId: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - customerId: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - createdAt: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.ExplicitIndexes
 
 === NoIndexByCampaignId
 ID:          default_catalog.default_database.NoIndexByCampaignId
@@ -1288,6 +1312,15 @@ CREATE VIEW `NoIndexes`
 AS
 SELECT *
 FROM `Orders`;
+CREATE TABLE `ExplicitIndexesSink` (
+  `orderId` STRING NOT NULL,
+  `customerId` STRING NOT NULL,
+  `createdAt` TIMESTAMP_LTZ(3) NOT NULL,
+  WATERMARK FOR `createdAt` AS `createdAt`
+)
+WITH (
+  'connector' = 'print'
+);
 CREATE TABLE `ExplicitIndexes_1` (
   `orderId` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
   `customerId` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
@@ -1401,6 +1434,10 @@ INSERT INTO `default_catalog`.`default_database`.`ExplicitIndexes_1`
 SELECT `orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`, `hash_columns`(`orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`) AS `__pk_hash`
 FROM `default_catalog`.`default_database`.`ExplicitIndexes`
 ON CONFLICT DO NOTHING
+;
+INSERT INTO `ExplicitIndexesSink`
+SELECT `ExplicitIndexes`.`orderId`, `ExplicitIndexes`.`customerId`, `ExplicitIndexes`.`createdAt`
+FROM `default_catalog`.`default_database`.`ExplicitIndexes` AS `ExplicitIndexes`
 ;
 INSERT INTO `default_catalog`.`default_database`.`NoIndexes_2`
 SELECT `orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`, `hash_columns`(`orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`) AS `__pk_hash`
@@ -2233,7 +2270,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"campaignId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"campaignId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2268,7 +2305,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"carrierId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"carrierId\" = $1\nORDER BY \"orderId\" NULLS FIRST",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2303,7 +2340,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"category\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"category\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2338,7 +2375,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"channel\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"channel\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2373,7 +2410,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"country\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"country\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2408,7 +2445,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"currency\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"currency\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2443,7 +2480,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"customerId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"customerId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2478,7 +2515,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"deviceType\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"deviceType\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2513,7 +2550,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"discountCode\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"discountCode\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2548,7 +2585,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"fulfillmentStatus\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"fulfillmentStatus\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2583,7 +2620,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"orderId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"orderId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2618,7 +2655,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"paymentMethod\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"paymentMethod\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2653,7 +2690,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"productId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"productId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2688,7 +2725,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"returnReason\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"returnReason\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2723,7 +2760,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"riskLevel\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"riskLevel\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2758,7 +2795,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"salesRepId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"salesRepId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2793,7 +2830,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"shippingMethod\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"shippingMethod\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2828,7 +2865,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"status\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"status\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2863,7 +2900,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"storeId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"storeId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2898,7 +2935,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"warehouseId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"ExplicitIndexes\") AS \"t\"\nWHERE \"warehouseId\" = $1",
               "parameters" : [
                 {
                   "type" : "arg",
@@ -2968,7 +3005,7 @@ CREATE INDEX IF NOT EXISTS "Orders_hash_c7" ON "Orders" USING hash ("country")
             ],
             "query" : {
               "type" : "SqlQuery",
-              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"carrierId\" = $1",
+              "sql" : "SELECT \"orderId\", \"amount\", \"createdAt\"\nFROM (SELECT \"orderId\", \"customerId\", \"storeId\", \"productId\", \"category\", \"status\", \"paymentMethod\", \"country\", \"currency\", \"channel\", \"discountCode\", \"shippingMethod\", \"warehouseId\", \"carrierId\", \"campaignId\", \"deviceType\", \"riskLevel\", \"fulfillmentStatus\", \"returnReason\", \"salesRepId\", \"amount\", \"epoch_timestamp\", \"createdAt\"\n  FROM \"NoIndexes\") AS \"t\"\nWHERE \"carrierId\" = $1\nORDER BY \"orderId\" NULLS FIRST",
               "parameters" : [
                 {
                   "type" : "arg",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/pg-index-selection-compile/indexSelection.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/pg-index-selection-compile/indexSelection.sqrl
@@ -60,6 +60,15 @@ ExplicitIndexes := SELECT * FROM Orders;
 /*+index */
 NoIndexes := SELECT * FROM Orders;
 
+CREATE TABLE ExplicitIndexesSink (
+  orderId STRING NOT NULL,
+  customerId STRING NOT NULL,
+  createdAt TIMESTAMP_LTZ(3) NOT NULL,
+  WATERMARK FOR createdAt AS createdAt
+) WITH ('connector' = 'print');
+
+INSERT INTO ExplicitIndexesSink SELECT orderId, customerId, createdAt FROM ExplicitIndexes;
+
 ExplicitByOrderId(orderId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE orderId = :orderId;
 ExplicitByCustomerId(customerId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE customerId = :customerId;
 ExplicitByStoreId(storeId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE storeId = :storeId;
@@ -73,7 +82,7 @@ ExplicitByChannel(channel STRING NOT NULL) := SELECT orderId, amount, createdAt 
 ExplicitByDiscountCode(discountCode STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE discountCode = :discountCode;
 ExplicitByShippingMethod(shippingMethod STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE shippingMethod = :shippingMethod;
 ExplicitByWarehouseId(warehouseId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE warehouseId = :warehouseId;
-ExplicitByCarrierId(carrierId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE carrierId = :carrierId;
+ExplicitByCarrierId(carrierId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE carrierId = :carrierId ORDER BY orderId;
 ExplicitByCampaignId(campaignId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE campaignId = :campaignId;
 ExplicitByDeviceType(deviceType STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE deviceType = :deviceType;
 ExplicitByRiskLevel(riskLevel STRING NOT NULL) := SELECT orderId, amount, createdAt FROM ExplicitIndexes WHERE riskLevel = :riskLevel;
@@ -94,7 +103,7 @@ NoIndexByChannel(channel STRING NOT NULL) := SELECT orderId, amount, createdAt F
 NoIndexByDiscountCode(discountCode STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE discountCode = :discountCode;
 NoIndexByShippingMethod(shippingMethod STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE shippingMethod = :shippingMethod;
 NoIndexByWarehouseId(warehouseId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE warehouseId = :warehouseId;
-NoIndexByCarrierId(carrierId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE carrierId = :carrierId;
+NoIndexByCarrierId(carrierId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE carrierId = :carrierId ORDER BY orderId;
 NoIndexByCampaignId(campaignId STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE campaignId = :campaignId;
 NoIndexByDeviceType(deviceType STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE deviceType = :deviceType;
 NoIndexByRiskLevel(riskLevel STRING NOT NULL) := SELECT orderId, amount, createdAt FROM NoIndexes WHERE riskLevel = :riskLevel;


### PR DESCRIPTION
## Key changes
- Preserve the direct source-view identifier before Flink expands a view.
- Use that identifier to resolve otherwise ambiguous structural view matches.
- Keep existing view-collapse behavior for non-view and multi-source queries.
- Add unit and integration coverage for identical views with different index hints.