### PR TITLE
feat: Validate enabled engine names

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConfig.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConfig.java
@@ -271,9 +271,11 @@ public class SqrlConfig {
   public <T> Value<List<T>> asList(String key, Class<T> clazz) {
     var n = node();
     List<T> list = List.of();
-    if (n != null && n.has(key) && n.get(key).isArray()) {
+    if (n != null && n.has(key)) {
+      var value = n.get(key);
+      errors.checkFatal(value.isArray(), "Expected an array for key [%s]", getFullKey(key));
       list = new ArrayList<>();
-      for (JsonNode element : n.get(key)) {
+      for (var element : value) {
         list.add(MAPPER.convertValue(element, clazz));
       }
     }

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -15,16 +15,23 @@
     },
     "enabled-engines": {
       "description": "List of engines to enable for the data pipeline. The compiler builds deployment artifacts for the enabled engines during the build.",
-      "oneOf": [
-        {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "duckdb",
+          "flink",
+          "iceberg",
+          "kafka",
+          "postgres",
+          "print",
+          "redshift",
+          "snowflake",
+          "sparksql",
+          "vertx"
+        ]
+      },
+      "minItems": 1
     },
     "compiler": {
       "type": "object",
@@ -352,7 +359,8 @@
           },
           "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "connectors": {
       "type": "object",

--- a/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/PackageJsonSchemaTest.java
@@ -60,6 +60,8 @@ class PackageJsonSchemaTest {
   @ValueSource(
       strings = {
         "emptyEnabledEngines.json",
+        "invalidEnabledEngine.json",
+        "invalidEnabledEnginesType.json",
         "invalidVersionFormat.json",
         "emptyEnginesFlinkConnectors.json",
         "emptyTestRunner.json",

--- a/sqrl-planner/src/test/java/com/datasqrl/config/SqrlConfigTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/config/SqrlConfigTest.java
@@ -137,6 +137,15 @@ public class SqrlConfigTest {
   }
 
   @Test
+  void givenNonArrayValue_whenGetList_thenThrowsException() {
+    config.setProperty("list-value", "not-a-list");
+
+    assertThatThrownBy(() -> config.asList("list-value", String.class))
+        .isInstanceOf(CollectedException.class)
+        .hasMessageContaining("Expected an array for key [list-value]");
+  }
+
+  @Test
   void givenNestedProperties_whenGetSubConfig_thenReturnsNestedNalues() {
     var parentConfig = config.getSubConfig("parent");
     var childConfig = parentConfig.getSubConfig("child");

--- a/sqrl-planner/src/test/java/com/datasqrl/util/ConfigLoaderUtilsTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/util/ConfigLoaderUtilsTest.java
@@ -149,7 +149,7 @@ class ConfigLoaderUtilsTest {
     assertThat(underTest).isNotNull();
     assertThat(underTest.getVersion()).isEqualTo(1);
 
-    assertThat(underTest.getEnabledEngines()).contains("test");
+    assertThat(underTest.getEnabledEngines()).containsExactly("iceberg");
 
     assertThat(underTest.getTestConfig()).isNotNull();
     assertThat(underTest.getEngines().getEngineConfig("flink")).isPresent();

--- a/sqrl-planner/src/test/resources/config/package/invalidEnabledEngine.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidEnabledEngine.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "enabled-engines": ["not-an-engine"]
+}

--- a/sqrl-planner/src/test/resources/config/package/invalidEnabledEnginesType.json
+++ b/sqrl-planner/src/test/resources/config/package/invalidEnabledEnginesType.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "enabled-engines": "flink"
+}

--- a/sqrl-planner/src/test/resources/config/test-package.json
+++ b/sqrl-planner/src/test/resources/config/test-package.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "enabled-engines": ["test"],
+  "enabled-engines": ["iceberg"],
   "package": {
     "name": "datasqrl.test"
   }


### PR DESCRIPTION
## Summary
- Restrict `enabled-engines` to a non-empty array of supported engine names.
- Reject unknown engine names and scalar engine configuration values in schema tests.
- Reject scalar values for all `SqrlConfig.asList` calls instead of silently treating them as empty lists.
- Add schema and configuration regression coverage for invalid engine names and non-array list values.
- Update the config-loader fixture to use valid iceberg engine configuration.

## Testing
```
mvn test -pl sqrl-planner -am -Dtest=PackageJsonSchemaTest,ConfigLoaderUtilsTest,SqrlConfigTest -Dsurefire.failIfNoSpecifiedTests=false
```

Fixes #2337 