### PR TITLE
feat: Support a bare relation alias as a row value in a SELECT list

### DIFF
--- a/documentation/docs/sqrl-language.md
+++ b/documentation/docs/sqrl-language.md
@@ -40,6 +40,19 @@ Be aware that `CREATE CATALOG` statements are only supported in separate scripts
 To learn more about how `IMPORT` works, see [IMPORT Statement](#import-statement).
 :::
 
+### Relation Alias as a Row Value
+
+A relation alias may be used by itself in a `SELECT` list to produce a `ROW` value that holds all
+columns of that relation:
+
+```sql
+OrderWithCustomer := SELECT o.id, c AS customer
+                     FROM Orders o JOIN Customer c ON o.customerid = c.customerid;
+```
+
+The `customer` field is a nested structure with the column names and types of `Customer`, which the
+API exposes as a nested object. A column of the same name takes precedence over the relation alias.
+
 ## Type System
 In SQRL, every table and function has a type based on how the table represents data.
 The type determines the semantic validity of queries against tables and how data is processed by different engines.

--- a/documentation/docs/sqrl-language.md
+++ b/documentation/docs/sqrl-language.md
@@ -40,19 +40,6 @@ Be aware that `CREATE CATALOG` statements are only supported in separate scripts
 To learn more about how `IMPORT` works, see [IMPORT Statement](#import-statement).
 :::
 
-### Relation Alias as a Row Value
-
-A relation alias may be used by itself in a `SELECT` list to produce a `ROW` value that holds all
-columns of that relation:
-
-```sql
-OrderWithCustomer := SELECT o.id, c AS customer
-                     FROM Orders o JOIN Customer c ON o.customerid = c.customerid;
-```
-
-The `customer` field is a nested structure with the column names and types of `Customer`, which the
-API exposes as a nested object. A column of the same name takes precedence over the relation alias.
-
 ## Type System
 In SQRL, every table and function has a type based on how the table represents data.
 The type determines the semantic validity of queries against tables and how data is processed by different engines.
@@ -231,8 +218,20 @@ TableName.new_col := expression;
 
 Must appear **immediately after** the table definition it extends, and may reference previously added columns of the same table. Cannot be applied after `CREATE TABLE` statements.
 
+### Relation Alias As ROW
 
-### Passthrough definitions
+A relation alias may be used by itself in a `SELECT` list to produce a `ROW` value that holds all
+columns of that relation:
+
+```sql
+OrderWithCustomer := SELECT o.id, c AS customer
+                     FROM Orders o JOIN Customer c ON o.customerid = c.customerid;
+```
+
+The `customer` field is a nested structure with the column names and types of `Customer`, which the
+API exposes as a nested object. A column of the same name takes precedence over the relation alias.
+
+### Passthrough Definitions
 
 Passthrough definitions allow you to bypass SQRL's analysis and translation, passing SQL queries directly to the underlying database engine.
 This serves as a "backdoor" for SQL constructs that SQRL does not yet support natively.

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/expand/RelationAliasExpander.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/expand/RelationAliasExpander.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.planner;
+package com.datasqrl.calcite.expand;
 
 import com.datasqrl.calcite.schema.sql.SqlDataTypeSpecBuilder;
-import com.datasqrl.engine.stream.flink.FlinkCalciteParser;
-import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
+import com.datasqrl.engine.stream.flink.FlinkSqlNodePlanner;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.rel.type.RelDataType;
@@ -41,8 +38,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-import org.apache.flink.table.api.internal.TableEnvironmentImpl;
-import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 
 /**
  * Expands a bare relation alias in a SELECT list into a ROW value over the columns of that
@@ -59,14 +54,13 @@ import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
  * left untouched, so that the regular validation reports the error.
  */
 @Slf4j
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-class RelationAliasExpander {
+@RequiredArgsConstructor
+public final class RelationAliasExpander {
 
-  private final TableEnvironmentImpl tEnv;
-  private final Supplier<FlinkPlannerImpl> plannerSupplier;
+  private final FlinkSqlNodePlanner sqlNodePlanner;
 
   /** Rewrites the given statement in place and returns it. */
-  SqlNode expand(SqlNode statement) {
+  public SqlNode expand(SqlNode statement) {
     statement.accept(new SelectListVisitor());
     return statement;
   }
@@ -92,10 +86,12 @@ class RelationAliasExpander {
         visibleWithLists.pop();
         return null;
       }
+
       super.visit(call);
       if (call instanceof SqlSelect select) {
         expandSelect(select, visibleWithLists);
       }
+
       return null;
     }
   }
@@ -115,19 +111,22 @@ class RelationAliasExpander {
     if (queryType == null) {
       return;
     }
-    var columns = Set.copyOf(queryType.getFieldNames());
 
+    var columns = Set.copyOf(queryType.getFieldNames());
     for (var i = 0; i < selectList.size(); i++) {
       var item = selectList.get(i);
       var alias = bareName(item);
-      if (!relationAliases.contains(alias) || columns.contains(alias)) {
+      if (alias == null || !relationAliases.contains(alias) || columns.contains(alias)) {
         continue;
       }
+
       var star = new SqlIdentifier(alias, SqlParserPos.ZERO).plusStar();
       var rowType = resolveType(star, select, visibleWithLists);
+
       if (rowType != null) {
-        selectList.set(
-            i, SqlValidatorUtil.addAlias(rowValue(alias, rowType), SqlValidatorUtil.alias(item)));
+        var expandedNode =
+            SqlValidatorUtil.addAlias(rowValue(alias, rowType), SqlValidatorUtil.alias(item));
+        selectList.set(i, expandedNode);
       }
     }
   }
@@ -139,6 +138,7 @@ class RelationAliasExpander {
    */
   private @Nullable RelDataType resolveType(
       SqlIdentifier item, SqlSelect select, Deque<SqlNodeList> visibleWithLists) {
+
     var probe = (SqlSelect) select.clone(SqlParserPos.ZERO);
     probe.setSelectList(new SqlNodeList(List.of(item), SqlParserPos.ZERO));
     probe.setWhere(null);
@@ -156,13 +156,10 @@ class RelationAliasExpander {
       }
     }
 
-    var query = RelToFlinkSql.convertToString(statement);
     try {
-      var planner = plannerSupplier.get();
-      var validated = planner.validate(FlinkCalciteParser.parseSql(query, tEnv));
-      return planner.getOrCreateSqlValidator().getValidatedNodeType(validated);
+      return sqlNodePlanner.getValidatedNodeType(statement);
     } catch (Exception e) {
-      log.debug("Could not resolve the row type of [{}]", query, e);
+      log.debug("Could not resolve the row type of [{}]", statement, e);
       return null;
     }
   }
@@ -172,6 +169,7 @@ class RelationAliasExpander {
         rowType.getFieldNames().stream()
             .map(field -> (SqlNode) new SqlIdentifier(List.of(alias, field), SqlParserPos.ZERO))
             .toList();
+
     return SqlStdOperatorTable.CAST.createCall(
         SqlParserPos.ZERO,
         SqlStdOperatorTable.ROW.createCall(SqlParserPos.ZERO, fields),
@@ -184,19 +182,24 @@ class RelationAliasExpander {
       collectAliases(join.getRight(), aliases);
       return;
     }
+
     var alias = SqlValidatorUtil.alias(from);
     if (alias != null) {
       aliases.add(alias);
     }
   }
 
-  private static @Nullable String bareName(SqlNode selectItem) {
-    SqlNode node =
-        selectItem.getKind() == SqlKind.AS ? ((SqlCall) selectItem).operand(0) : selectItem;
-    return node instanceof SqlIdentifier identifier
-            && identifier.names.size() == 1
-            && !identifier.isStar()
-        ? identifier.getSimple()
-        : null;
+  private static String bareName(SqlNode selectItem) {
+    SqlNode node = selectItem;
+    if (selectItem.getKind() == SqlKind.AS && selectItem instanceof SqlCall selectCall) {
+      node = selectCall.operand(0);
+    }
+
+    String name = null;
+    if (node instanceof SqlIdentifier id && id.names.size() == 1 && !id.isStar()) {
+      name = id.getSimple();
+    }
+
+    return name;
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodePlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodePlanner.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.stream.flink;
+
+import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
+
+/** Encapsulates access to Flink's SQL planning facilities. */
+@RequiredArgsConstructor
+public final class FlinkSqlNodePlanner {
+
+  private final TableEnvironmentImpl tableEnvironment;
+  private final Supplier<FlinkPlannerImpl> plannerSupplier;
+
+  public RelDataType getValidatedNodeType(SqlNode statement) {
+    var sql = RelToFlinkSql.convertToString(statement);
+    var planner = plannerSupplier.get();
+    var validated = planner.validate(FlinkCalciteParser.parseSql(sql, tableEnvironment));
+    return planner.getOrCreateSqlValidator().getValidatedNodeType(validated);
+  }
+
+  public RelRoot toRelRoot(SqlNode query, @Nullable FlinkPlannerImpl flinkPlanner) {
+    var planner = getPlanner(flinkPlanner);
+    var validatedQuery = planner.getOrCreateSqlValidator().validate(query);
+    return planner.rel(validatedQuery);
+  }
+
+  public FlinkRelBuilder getRelBuilder(@Nullable FlinkPlannerImpl flinkPlanner) {
+    var planner = getPlanner(flinkPlanner);
+    var config =
+        planner.config().getSqlToRelConverterConfig().withAddJsonTypeOperatorEnabled(false);
+    // A null schema prevents the builder's scan method from expanding views.
+    return (FlinkRelBuilder)
+        config
+            .getRelBuilderFactory()
+            .create(planner.cluster(), null)
+            .transform(config.getRelBuilderConfigTransform());
+  }
+
+  public CalciteCatalogReader getCalciteCatalog(@Nullable FlinkPlannerImpl flinkPlanner) {
+    return getPlanner(flinkPlanner)
+        .getOrCreateSqlValidator()
+        .getCatalogReader()
+        .unwrap(CalciteCatalogReader.class);
+  }
+
+  private FlinkPlannerImpl getPlanner(@Nullable FlinkPlannerImpl planner) {
+    return planner == null ? plannerSupplier.get() : planner;
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/RelationAliasExpander.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/RelationAliasExpander.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner;
+
+import com.datasqrl.calcite.schema.sql.SqlDataTypeSpecBuilder;
+import com.datasqrl.engine.stream.flink.FlinkCalciteParser;
+import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+
+/**
+ * Expands a bare relation alias in a SELECT list into a ROW value over the columns of that
+ * relation, which neither Calcite nor Flink support natively.
+ *
+ * <p>For example, {@code SELECT p AS project FROM Projects p} is rewritten to {@code SELECT
+ * CAST(ROW(p.id, p.name) AS ROW(id BIGINT, name VARCHAR)) AS project FROM Projects p} so that a
+ * table's entire row can be nested under a single field without re-listing its columns.
+ *
+ * <p>The columns an alias contributes are resolved by validating a probe query built from the FROM
+ * clause alone, wrapped back into the {@code WITH} bindings visible at that point so that CTEs stay
+ * in scope. A column of the same name takes precedence over the relation alias. A FROM clause that
+ * does not validate on its own - a correlated or LATERAL join referencing the enclosing query - is
+ * left untouched, so that the regular validation reports the error.
+ */
+@Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class RelationAliasExpander {
+
+  private final TableEnvironmentImpl tEnv;
+  private final Supplier<FlinkPlannerImpl> plannerSupplier;
+
+  /** Rewrites the given statement in place and returns it. */
+  SqlNode expand(SqlNode statement) {
+    statement.accept(new SelectListVisitor());
+    return statement;
+  }
+
+  /**
+   * Tracks the CTE bindings visible at each SELECT so probes can be built in their scope. A CTE
+   * definition only sees the bindings declared before it, the body sees all of them.
+   */
+  private class SelectListVisitor extends SqlBasicVisitor<Void> {
+
+    private final Deque<SqlNodeList> visibleWithLists = new ArrayDeque<>();
+
+    @Override
+    public Void visit(SqlCall call) {
+      if (call instanceof SqlWith with) {
+        var visible = new SqlNodeList(SqlParserPos.ZERO);
+        visibleWithLists.push(visible);
+        for (SqlNode item : with.withList) {
+          item.accept(this);
+          visible.add(item);
+        }
+        with.body.accept(this);
+        visibleWithLists.pop();
+        return null;
+      }
+      super.visit(call);
+      if (call instanceof SqlSelect select) {
+        expandSelect(select, visibleWithLists);
+      }
+      return null;
+    }
+  }
+
+  private void expandSelect(SqlSelect select, Deque<SqlNodeList> visibleWithLists) {
+    if (select.getFrom() == null) {
+      return;
+    }
+    var relationAliases = new HashSet<String>();
+    collectAliases(select.getFrom(), relationAliases);
+    var selectList = select.getSelectList();
+    if (selectList.stream().noneMatch(item -> relationAliases.contains(bareName(item)))) {
+      return;
+    }
+
+    var queryType = resolveType(SqlIdentifier.star(SqlParserPos.ZERO), select, visibleWithLists);
+    if (queryType == null) {
+      return;
+    }
+    var columns = Set.copyOf(queryType.getFieldNames());
+
+    for (var i = 0; i < selectList.size(); i++) {
+      var item = selectList.get(i);
+      var alias = bareName(item);
+      if (!relationAliases.contains(alias) || columns.contains(alias)) {
+        continue;
+      }
+      var star = new SqlIdentifier(alias, SqlParserPos.ZERO).plusStar();
+      var rowType = resolveType(star, select, visibleWithLists);
+      if (rowType != null) {
+        selectList.set(
+            i, SqlValidatorUtil.addAlias(rowValue(alias, rowType), SqlValidatorUtil.alias(item)));
+      }
+    }
+  }
+
+  /**
+   * Validates a copy of the query that selects only the given item and keeps only the FROM clause,
+   * and returns the row type it produces. The probe is re-parsed from its serialized form because
+   * validation modifies the {@link SqlNode} tree it is given.
+   */
+  private @Nullable RelDataType resolveType(
+      SqlIdentifier item, SqlSelect select, Deque<SqlNodeList> visibleWithLists) {
+    var probe = (SqlSelect) select.clone(SqlParserPos.ZERO);
+    probe.setSelectList(new SqlNodeList(List.of(item), SqlParserPos.ZERO));
+    probe.setWhere(null);
+    probe.setGroupBy(null);
+    probe.setHaving(null);
+    probe.setQualify(null);
+    probe.setOrderBy(null);
+    probe.setOffset(null);
+    probe.setFetch(null);
+
+    SqlNode statement = probe;
+    for (SqlNodeList withList : visibleWithLists) {
+      if (!withList.isEmpty()) {
+        statement = new SqlWith(SqlParserPos.ZERO, withList, statement);
+      }
+    }
+
+    var query = RelToFlinkSql.convertToString(statement);
+    try {
+      var planner = plannerSupplier.get();
+      var validated = planner.validate(FlinkCalciteParser.parseSql(query, tEnv));
+      return planner.getOrCreateSqlValidator().getValidatedNodeType(validated);
+    } catch (Exception e) {
+      log.debug("Could not resolve the row type of [{}]", query, e);
+      return null;
+    }
+  }
+
+  private static SqlNode rowValue(String alias, RelDataType rowType) {
+    var fields =
+        rowType.getFieldNames().stream()
+            .map(field -> (SqlNode) new SqlIdentifier(List.of(alias, field), SqlParserPos.ZERO))
+            .toList();
+    return SqlStdOperatorTable.CAST.createCall(
+        SqlParserPos.ZERO,
+        SqlStdOperatorTable.ROW.createCall(SqlParserPos.ZERO, fields),
+        SqlDataTypeSpecBuilder.convertTypeToSpec(rowType));
+  }
+
+  private static void collectAliases(SqlNode from, Set<String> aliases) {
+    if (from instanceof SqlJoin join) {
+      collectAliases(join.getLeft(), aliases);
+      collectAliases(join.getRight(), aliases);
+      return;
+    }
+    var alias = SqlValidatorUtil.alias(from);
+    if (alias != null) {
+      aliases.add(alias);
+    }
+  }
+
+  private static @Nullable String bareName(SqlNode selectItem) {
+    SqlNode node =
+        selectItem.getKind() == SqlKind.AS ? ((SqlCall) selectItem).operand(0) : selectItem;
+    return node instanceof SqlIdentifier identifier
+            && identifier.names.size() == 1
+            && !identifier.isStar()
+        ? identifier.getSimple()
+        : null;
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -178,6 +178,7 @@ public class Sqrl2FlinkSQLTranslator {
   @Getter private final FlinkExecFunctionFactory execFnFactory;
   @Getter private final RelDataTypeParser relDataTypeParser;
   private final FlinkInsertConflictPlanner insertConflictPlanner;
+  private final RelationAliasExpander relationAliasExpander;
 
   @Getter private final Set<String> createdDatabases = new LinkedHashSet<>();
   @Getter private final TableAnalysisLookup tableLookup = new TableAnalysisLookup();
@@ -219,6 +220,7 @@ public class Sqrl2FlinkSQLTranslator {
 
     // Extract a number of classes we need access to for planning
     this.validatorSupplier = ((PlannerBase) tEnv.getPlanner())::createFlinkPlanner;
+    this.relationAliasExpander = new RelationAliasExpander(tEnv, validatorSupplier);
     var planner = this.validatorSupplier.get();
     typeFactory = (FlinkTypeFactory) planner.getOrCreateSqlValidator().getTypeFactory();
     // Initialize function catalog (custom)
@@ -247,8 +249,12 @@ public class Sqrl2FlinkSQLTranslator {
     return new SqrlRexUtil(typeFactory);
   }
 
+  /**
+   * Parses a SQL statement, expanding any bare relation alias in a SELECT list into a ROW value
+   * over the columns of that relation, see {@link RelationAliasExpander}.
+   */
   public SqlNode parseSQL(String sqlStatement) {
-    return FlinkCalciteParser.parseSql(sqlStatement, tEnv);
+    return relationAliasExpander.expand(FlinkCalciteParser.parseSql(sqlStatement, tEnv));
   }
 
   /**

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -19,10 +19,12 @@ import static com.datasqrl.config.SqrlConstants.FLINK_DEFAULT_CATALOG;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datasqrl.calcite.SqrlRexUtil;
+import com.datasqrl.calcite.expand.RelationAliasExpander;
 import com.datasqrl.config.PackageJson.CompilerConfig;
 import com.datasqrl.config.SqrlConstants;
 import com.datasqrl.config.WorkspacePaths;
 import com.datasqrl.engine.stream.flink.FlinkCalciteParser;
+import com.datasqrl.engine.stream.flink.FlinkSqlNodePlanner;
 import com.datasqrl.engine.stream.flink.FlinkSqlNodes;
 import com.datasqrl.engine.stream.flink.FlinkStreamEngine;
 import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
@@ -78,9 +80,7 @@ import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.SneakyThrows;
-import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableFunctionScan;
@@ -137,7 +137,6 @@ import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
-import org.apache.flink.table.planner.operations.SqlNodeConvertContext;
 import org.apache.flink.table.planner.operations.SqlNodeToOperationConversion;
 import org.apache.flink.table.planner.utils.RowLevelModificationContextUtils;
 import org.apache.flink.table.types.CollectionDataType;
@@ -178,6 +177,7 @@ public class Sqrl2FlinkSQLTranslator {
   @Getter private final FlinkExecFunctionFactory execFnFactory;
   @Getter private final RelDataTypeParser relDataTypeParser;
   private final FlinkInsertConflictPlanner insertConflictPlanner;
+  private final FlinkSqlNodePlanner flinkSqlNodePlanner;
   private final RelationAliasExpander relationAliasExpander;
 
   @Getter private final Set<String> createdDatabases = new LinkedHashSet<>();
@@ -220,7 +220,8 @@ public class Sqrl2FlinkSQLTranslator {
 
     // Extract a number of classes we need access to for planning
     this.validatorSupplier = ((PlannerBase) tEnv.getPlanner())::createFlinkPlanner;
-    this.relationAliasExpander = new RelationAliasExpander(tEnv, validatorSupplier);
+    this.flinkSqlNodePlanner = new FlinkSqlNodePlanner(tEnv, validatorSupplier);
+    this.relationAliasExpander = new RelationAliasExpander(flinkSqlNodePlanner);
     var planner = this.validatorSupplier.get();
     typeFactory = (FlinkTypeFactory) planner.getOrCreateSqlValidator().getTypeFactory();
     // Initialize function catalog (custom)
@@ -249,12 +250,11 @@ public class Sqrl2FlinkSQLTranslator {
     return new SqrlRexUtil(typeFactory);
   }
 
-  /**
-   * Parses a SQL statement, expanding any bare relation alias in a SELECT list into a ROW value
-   * over the columns of that relation, see {@link RelationAliasExpander}.
-   */
+  /** Parses a SQL statement and expands bare relation aliases in SELECT lists. */
   public SqlNode parseSQL(String sqlStatement) {
-    return relationAliasExpander.expand(FlinkCalciteParser.parseSql(sqlStatement, tEnv));
+    var sqlNode = FlinkCalciteParser.parseSql(sqlStatement, tEnv);
+
+    return relationAliasExpander.expand(sqlNode);
   }
 
   /**
@@ -318,8 +318,8 @@ public class Sqrl2FlinkSQLTranslator {
     } else {
       throw new UnsupportedOperationException("Unexpected SQLnode: " + validated);
     }
-    var relRoot = toRelRoot(query, flinkPlanner);
-    var relBuilder = getRelBuilder(flinkPlanner);
+    var relRoot = flinkSqlNodePlanner.toRelRoot(query, flinkPlanner);
+    var relBuilder = flinkSqlNodePlanner.getRelBuilder(flinkPlanner);
     var relNode = relRoot.rel;
     Optional<Sort> topLevelSort = Optional.empty();
     if (removeTopLevelSort) {
@@ -383,38 +383,6 @@ public class Sqrl2FlinkSQLTranslator {
     return Optional.empty();
   }
 
-  public RelRoot toRelRoot(SqlNode query, @Nullable FlinkPlannerImpl flinkPlanner) {
-    if (flinkPlanner == null) {
-      flinkPlanner = this.validatorSupplier.get();
-    }
-    var context = new SqlNodeConvertContext(flinkPlanner, catalogManager);
-    var validatedQuery = context.getSqlValidator().validate(query);
-    return context.toRelRoot(validatedQuery);
-  }
-
-  public FlinkRelBuilder getRelBuilder(@Nullable FlinkPlannerImpl flinkPlanner) {
-    if (flinkPlanner == null) {
-      flinkPlanner = this.validatorSupplier.get();
-    }
-    var config =
-        flinkPlanner.config().getSqlToRelConverterConfig().withAddJsonTypeOperatorEnabled(false);
-    // We are using a null schema because using the scan method on FlinkRelBuilder tries to expand
-    // views.
-    // Need to construct LogicalTableScan manually.
-    return (FlinkRelBuilder)
-        config
-            .getRelBuilderFactory()
-            .create(flinkPlanner.cluster(), null)
-            .transform(config.getRelBuilderConfigTransform());
-  }
-
-  private CalciteCatalogReader getCalciteCatalog(@Nullable FlinkPlannerImpl flinkPlanner) {
-    return flinkPlanner
-        .getOrCreateSqlValidator()
-        .getCatalogReader()
-        .unwrap(CalciteCatalogReader.class);
-  }
-
   public List<String> setDatabase(String databaseName, boolean withCatalog) {
     var allStmts = new ArrayList<String>();
     if (withCatalog) {
@@ -438,8 +406,8 @@ public class Sqrl2FlinkSQLTranslator {
 
   public FlinkRelBuilder getTableScan(ObjectIdentifier identifier) {
     var flinkPlanner = this.validatorSupplier.get();
-    var relBuilder = getRelBuilder(flinkPlanner);
-    var catalog = getCalciteCatalog(flinkPlanner);
+    var relBuilder = flinkSqlNodePlanner.getRelBuilder(flinkPlanner);
+    var catalog = flinkSqlNodePlanner.getCalciteCatalog(flinkPlanner);
     relBuilder.push(
         LogicalTableScan.create(
             flinkPlanner.cluster(), catalog.getTableForMember(identifier.toList()), List.of()));
@@ -536,14 +504,14 @@ public class Sqrl2FlinkSQLTranslator {
       SqlNode query, ObjectIdentifier identifier, HintsAndDoc hintsAndDoc, ErrorCollector errors) {
 
     var flinkPlanner = validatorSupplier.get();
-    var relRoot = toRelRoot(query, flinkPlanner);
+    var relRoot = flinkSqlNodePlanner.toRelRoot(query, flinkPlanner);
     var analyzer =
         new SQRLLogicalPlanAnalyzer(
             relRoot.project(),
             tableLookup,
             identifier.getObjectName(),
             getReferencedViews(query),
-            getRelBuilder(flinkPlanner),
+            flinkSqlNodePlanner.getRelBuilder(flinkPlanner),
             flinkPlanner,
             errors);
 
@@ -624,7 +592,7 @@ public class Sqrl2FlinkSQLTranslator {
             .addAll(parsedReturnType.stream().map(ParsedRelDataTypeResult::field).toList())
             .build();
     // use values relnode from return type
-    var values = getRelBuilder(null).values(returnDataType).build();
+    var values = flinkSqlNodePlanner.getRelBuilder(null).values(returnDataType).build();
     var tableAnalysis =
         TableAnalysis.builder()
             .objectIdentifier(identifier)

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/relationAliasRowTest.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/relationAliasRowTest.sqrl
@@ -1,0 +1,43 @@
+IMPORT ecommerceTs.customer;
+IMPORT ecommerceTs.orders;
+
+CREATE TABLE Shadowed (
+  `c` BIGINT NOT NULL,
+  `label` STRING NOT NULL
+) WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+);
+
+/** The whole customer row nested under a named field */
+CustomerRow := SELECT c.customerid, c AS customer FROM Customer c;
+
+/** A bare alias derives its column name from the alias itself */
+CustomerBare := SELECT customerid, c FROM Customer c;
+
+/** Both sides of a join can be nested, including array columns */
+OrderWithCustomer := SELECT o.id, o AS `order`, c AS customer
+                     FROM Orders o JOIN Customer c ON o.customerid = c.customerid;
+
+/** A column of the same name takes precedence over the relation alias */
+ShadowedAlias := SELECT c, label FROM Shadowed c;
+
+/** CTEs stay in scope while the alias is resolved */
+CteCustomerRow := WITH Recent AS (SELECT * FROM Customer WHERE customerid > 0)
+                  SELECT r.customerid, r AS customer FROM Recent r;
+
+/** Relation aliases are expanded in subqueries too */
+NestedCustomerRow := SELECT x.customer FROM (SELECT c AS customer FROM Customer c) x;
+
+/** The nested row is available to table functions as well */
+CustomerRowById(id BIGINT NOT NULL) := SELECT c AS customer FROM Customer c WHERE c.customerid = :id;
+
+/** Aliases inside a CTE definition see the preceding CTEs, but not their own binding */
+CteDefinitionRow := WITH Recent AS (SELECT * FROM Customer WHERE customerid > 0),
+                         Wrapped AS (SELECT r.customerid, r AS customer FROM Recent r)
+                    SELECT * FROM Wrapped;
+
+/** A quoted reserved word works as a relation alias */
+ReservedAliasRow := SELECT `order`.customerid, `order` AS whole FROM Customer `order`;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationAliasRowTest.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/relationAliasRowTest.txt
@@ -1,0 +1,2142 @@
+>>>pipeline_explain.txt
+=== CteCustomerRow
+ID:          default_catalog.default_database.CteCustomerRow
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~5e7
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - customer: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], customer=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[$4])
+    LogicalFilter(condition=[>($0, 0)])
+      LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `CteCustomerRow` AS  WITH Recent AS (SELECT * FROM Customer WHERE customerid > 0)
+                  SELECT r.customerid, r AS customer FROM Recent r;
+
+=== CteDefinitionRow
+ID:          default_catalog.default_database.CteDefinitionRow
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - customer: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.CteCustomerRow
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], customer=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, CteCustomerRow]])
+SQL:
+CREATE VIEW `CteDefinitionRow` AS  WITH Recent AS (SELECT * FROM Customer WHERE customerid > 0),
+                         Wrapped AS (SELECT r.customerid, r AS customer FROM Recent r)
+                    SELECT * FROM Wrapped;
+
+=== Customer
+ID:          default_catalog.default_database.Customer
+Type:        stream
+Stage:       flink
+Primary key: customerid, lastUpdated
+Timestamp:   timestamp
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - email: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - name: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+ - lastUpdated: BIGINT NOT NULL
+ - timestamp: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer__base
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[-($4, 1:INTERVAL SECOND)])
+  LogicalProject(customerid=[$0], email=[$1], name=[$2], lastUpdated=[$3], timestamp=[COALESCE(TO_TIMESTAMP_LTZ($3, 0), 1970-01-01 08:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE TABLE `Customer` (
+  `customerid` BIGINT NOT NULL,
+  `email` STRING NOT NULL,
+  `name` STRING NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), CAST(TIMESTAMP '1970-01-01 00:00:00.000' AS TIMESTAMP(3) WITH LOCAL TIME ZONE)),
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
+  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+)
+=== CustomerBare
+ID:          default_catalog.default_database.CustomerBare
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - c: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], c=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `CustomerBare` AS  SELECT customerid, c FROM Customer c;
+
+=== CustomerRow
+ID:          default_catalog.default_database.CustomerRow
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - customer: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], customer=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `CustomerRow` AS  SELECT c.customerid, c AS customer FROM Customer c;
+
+=== CustomerRowById
+ID:          default_catalog.default_database.CustomerRowById
+Type:        query
+Stage:       postgres
+---
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+ - parameters: id
+ - base-table: CustomerRowById
+Plan:
+LogicalProject(customer=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalFilter(condition=[=($0, ?0)])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `CustomerRowById` AS  SELECT c AS customer FROM Customer c WHERE c.customerid = ?  ;
+
+=== NestedCustomerRow
+ID:          default_catalog.default_database.NestedCustomerRow
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customer: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customer=[$0])
+  LogicalProject(customer=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `NestedCustomerRow` AS  SELECT x.customer FROM (SELECT c AS customer FROM Customer c) x;
+
+=== OrderWithCustomer
+ID:          default_catalog.default_database.OrderWithCustomer
+Type:        stream
+Stage:       postgres
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - order: RecordType:peek_no_expand(BIGINT NOT NULL id, BIGINT NOT NULL customerid, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL time, RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL entries) NOT NULL
+ - customer: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+ - default_catalog.default_database.Orders
+Plan:
+LogicalProject(id=[$0], order=[CAST(ROW($0, $1, $2, $3)):RecordType:peek_no_expand(BIGINT NOT NULL id, BIGINT NOT NULL customerid, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL time, RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL entries) NOT NULL], customer=[CAST(ROW($4, $5, $6, $7, $8)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+    LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+    LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `OrderWithCustomer` AS  SELECT o.id, o AS `order`, c AS customer
+                     FROM Orders o JOIN Customer c ON o.customerid = c.customerid;
+
+=== Orders
+ID:          default_catalog.default_database.Orders
+Type:        stream
+Stage:       flink
+Primary key: id, time
+Timestamp:   time
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - customerid: BIGINT NOT NULL
+ - time: TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
+ - entries: RecordType:peek_no_expand(BIGINT NOT NULL productid, BIGINT NOT NULL quantity, DOUBLE NOT NULL unit_price, DOUBLE discount) NOT NULL ARRAY NOT NULL
+Inputs:
+ - default_catalog.default_database.Orders__base
+Annotations:
+ - features: DENORMALIZE (feature)
+ - stream-root: Orders
+Plan:
+LogicalWatermarkAssigner(rowtime=[time], watermark=[-($2, 1:INTERVAL SECOND)])
+  LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+SQL:
+CREATE TABLE `Orders` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP_LTZ(3) NOT NULL,
+  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL,
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
+  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+)
+=== ReservedAliasRow
+ID:          default_catalog.default_database.ReservedAliasRow
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - customerid: BIGINT NOT NULL
+ - whole: RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL
+Inputs:
+ - default_catalog.default_database.Customer
+Annotations:
+ - stream-root: Customer
+Plan:
+LogicalProject(customerid=[$0], whole=[CAST(ROW($0, $1, $2, $3, $4)):RecordType:peek_no_expand(BIGINT NOT NULL customerid, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL email, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL name, BIGINT NOT NULL lastUpdated, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL timestamp) NOT NULL])
+  LogicalTableScan(table=[[default_catalog, default_database, Customer]])
+SQL:
+CREATE VIEW `ReservedAliasRow` AS  SELECT `order`.customerid, `order` AS whole FROM Customer `order`;
+
+=== Shadowed
+ID:          default_catalog.default_database.Shadowed
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - c: BIGINT NOT NULL
+ - label: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+Inputs:
+ - default_catalog.default_database.Shadowed__base
+Plan:
+LogicalTableScan(table=[[default_catalog, default_database, Shadowed]])
+SQL:
+CREATE TABLE `Shadowed` (
+  `c` BIGINT NOT NULL,
+  `label` STRING NOT NULL
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+)
+=== ShadowedAlias
+ID:          default_catalog.default_database.ShadowedAlias
+Type:        stream
+Stage:       flink
+Primary key: -
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - c: BIGINT NOT NULL
+ - label: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL
+Inputs:
+ - default_catalog.default_database.Shadowed
+Plan:
+LogicalProject(c=[$0], label=[$1])
+  LogicalTableScan(table=[[default_catalog, default_database, Shadowed]])
+SQL:
+CREATE VIEW `ShadowedAlias` AS  SELECT c, label FROM Shadowed c;
+
+>>>flink-sql-no-functions.sql
+CREATE TABLE `Customer` (
+  `customerid` BIGINT NOT NULL,
+  `email` STRING NOT NULL,
+  `name` STRING NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` AS COALESCE(`TO_TIMESTAMP_LTZ`(`lastUpdated`, 0), TIMESTAMP '1970-01-01 00:00:00.000'),
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED,
+  WATERMARK FOR `timestamp` AS `timestamp` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE TABLE `Orders` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP_LTZ(3) NOT NULL,
+  `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL,
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED,
+  WATERMARK FOR `time` AS `time` - INTERVAL '0.001' SECOND
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE TABLE `Shadowed` (
+  `c` BIGINT NOT NULL,
+  `label` STRING NOT NULL
+)
+WITH (
+  'connector' = 'filesystem',
+  'format' = 'flexible-json',
+  'path' = 'file:/mock',
+  'source.monitor-interval' = '10 sec'
+);
+CREATE VIEW `CustomerRow`
+AS
+SELECT `c`.`customerid`, CAST(ROW(`c`.`customerid`, `c`.`email`, `c`.`name`, `c`.`lastUpdated`, `c`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `customer`
+FROM `Customer` AS `c`;
+CREATE VIEW `CustomerBare`
+AS
+SELECT `customerid`, CAST(ROW(`c`.`customerid`, `c`.`email`, `c`.`name`, `c`.`lastUpdated`, `c`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `c`
+FROM `Customer` AS `c`;
+CREATE VIEW `OrderWithCustomer`
+AS
+SELECT `o`.`id`, CAST(ROW(`o`.`id`, `o`.`customerid`, `o`.`time`, `o`.`entries`) AS ROW(`id` BIGINT NOT NULL, `customerid` BIGINT NOT NULL, `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL, `entries` ROW(`productid` BIGINT NOT NULL, `quantity` BIGINT NOT NULL, `unit_price` DOUBLE NOT NULL, `discount` DOUBLE) NOT NULL ARRAY NOT NULL)) AS `order`, CAST(ROW(`c`.`customerid`, `c`.`email`, `c`.`name`, `c`.`lastUpdated`, `c`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `customer`
+FROM `Orders` AS `o`
+ INNER JOIN `Customer` AS `c` ON `o`.`customerid` = `c`.`customerid`;
+CREATE VIEW `ShadowedAlias`
+AS
+SELECT `c`, `label`
+FROM `Shadowed` AS `c`;
+CREATE VIEW `CteCustomerRow`
+AS
+WITH `Recent` AS (SELECT *
+  FROM `Customer`
+  WHERE `customerid` > 0) SELECT `r`.`customerid`, CAST(ROW(`r`.`customerid`, `r`.`email`, `r`.`name`, `r`.`lastUpdated`, `r`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `customer`
+  FROM `Recent` AS `r`;
+CREATE VIEW `NestedCustomerRow`
+AS
+SELECT `x`.`customer`
+FROM (SELECT CAST(ROW(`c`.`customerid`, `c`.`email`, `c`.`name`, `c`.`lastUpdated`, `c`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `customer`
+  FROM `Customer` AS `c`) AS `x`;
+CREATE VIEW `CteDefinitionRow`
+AS
+WITH `Recent` AS (SELECT *
+  FROM `Customer`
+  WHERE `customerid` > 0), `Wrapped` AS (SELECT `r`.`customerid`, CAST(ROW(`r`.`customerid`, `r`.`email`, `r`.`name`, `r`.`lastUpdated`, `r`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `customer`
+  FROM `Recent` AS `r`) SELECT *
+  FROM `Wrapped`;
+CREATE VIEW `ReservedAliasRow`
+AS
+SELECT `order`.`customerid`, CAST(ROW(`order`.`customerid`, `order`.`email`, `order`.`name`, `order`.`lastUpdated`, `order`.`timestamp`) AS ROW(`customerid` BIGINT NOT NULL, `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL, `lastUpdated` BIGINT NOT NULL, `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL)) AS `whole`
+FROM `Customer` AS `order`;
+CREATE TABLE `CteCustomerRow_1` (
+  `customerid` BIGINT NOT NULL,
+  `customer` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'CteCustomerRow_1',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `CteDefinitionRow_2` (
+  `customerid` BIGINT NOT NULL,
+  `customer` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'CteDefinitionRow_2',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Customer_3` (
+  `customerid` BIGINT NOT NULL,
+  `email` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `name` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `lastUpdated` BIGINT NOT NULL,
+  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  PRIMARY KEY (`customerid`, `lastUpdated`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Customer_3',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `CustomerBare_4` (
+  `customerid` BIGINT NOT NULL,
+  `c` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'CustomerBare_4',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `CustomerRow_5` (
+  `customerid` BIGINT NOT NULL,
+  `customer` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'CustomerRow_5',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `NestedCustomerRow_6` (
+  `customer` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'NestedCustomerRow_6',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Orders_7` (
+  `id` BIGINT NOT NULL,
+  `customerid` BIGINT NOT NULL,
+  `time` TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL,
+  `entries` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  PRIMARY KEY (`id`, `time`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Orders_7',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `ReservedAliasRow_8` (
+  `customerid` BIGINT NOT NULL,
+  `whole` RAW('com.datasqrl.flinkrunner.stdlib.json.FlinkJsonType', 'AERjb20uZGF0YXNxcmwuZmxpbmtydW5uZXIuc3RkbGliLmpzb24uRmxpbmtKc29uVHlwZVNlcmlhbGl6ZXJTbmFwc2hvdAAAAAM='),
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'ReservedAliasRow_8',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `Shadowed_9` (
+  `c` BIGINT NOT NULL,
+  `label` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'Shadowed_9',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+CREATE TABLE `ShadowedAlias_10` (
+  `c` BIGINT NOT NULL,
+  `label` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` NOT NULL,
+  `__pk_hash` CHAR(32) CHARACTER SET `UTF-16LE`,
+  PRIMARY KEY (`__pk_hash`) NOT ENFORCED
+)
+WITH (
+  'connector' = 'jdbc-sqrl',
+  'driver' = 'org.postgresql.Driver',
+  'password' = '${POSTGRES_PASSWORD}',
+  'sink.on-conflict.action' = 'IGNORE',
+  'table-name' = 'ShadowedAlias_10',
+  'url' = 'jdbc:postgresql://${POSTGRES_AUTHORITY}',
+  'username' = '${POSTGRES_USERNAME}'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`CteCustomerRow_1`
+SELECT `customerid`, `to_jsonb`(`customer`) AS `customer`, `hash_columns`(`customerid`, `customer`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`CteCustomerRow`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`CteDefinitionRow_2`
+SELECT `customerid`, `to_jsonb`(`customer`) AS `customer`, `hash_columns`(`customerid`, `customer`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`CteDefinitionRow`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`Customer_3`
+SELECT *
+FROM `default_catalog`.`default_database`.`Customer`
+;
+INSERT INTO `default_catalog`.`default_database`.`CustomerBare_4`
+SELECT `customerid`, `to_jsonb`(`c`) AS `c`, `hash_columns`(`customerid`, `c`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`CustomerBare`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`CustomerRow_5`
+SELECT `customerid`, `to_jsonb`(`customer`) AS `customer`, `hash_columns`(`customerid`, `customer`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`CustomerRow`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`NestedCustomerRow_6`
+SELECT `to_jsonb`(`customer`) AS `customer`, `hash_columns`(`customer`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`NestedCustomerRow`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`Orders_7`
+SELECT `id`, `customerid`, `time`, `to_jsonb`(`entries`) AS `entries`
+FROM `default_catalog`.`default_database`.`Orders`
+;
+INSERT INTO `default_catalog`.`default_database`.`ReservedAliasRow_8`
+SELECT `customerid`, `to_jsonb`(`whole`) AS `whole`, `hash_columns`(`customerid`, `whole`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`ReservedAliasRow`
+ON CONFLICT DO NOTHING
+;
+INSERT INTO `default_catalog`.`default_database`.`Shadowed_9`
+SELECT `c`, `label`, `hash_columns`(`c`, `label`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`Shadowed`
+ON CONFLICT DO DEDUPLICATE
+;
+INSERT INTO `default_catalog`.`default_database`.`ShadowedAlias_10`
+SELECT `c`, `label`, `hash_columns`(`c`, `label`) AS `__pk_hash`
+FROM `default_catalog`.`default_database`.`ShadowedAlias`
+ON CONFLICT DO DEDUPLICATE
+;
+END
+>>>kafka.json
+{
+  "topics" : [ ],
+  "testRunnerTopics" : [ ]
+}
+>>>postgres.json
+{
+  "statements" : [
+    {
+      "name" : "CteCustomerRow_1",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CteCustomerRow_1\" (\"customerid\" BIGINT NOT NULL, \"customer\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "CTEs stay in scope while the alias is resolved",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CteDefinitionRow_2",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CteDefinitionRow_2\" (\"customerid\" BIGINT NOT NULL, \"customer\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "Aliases inside a CTE definition see the preceding CTEs, but not their own binding",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "Customer_3",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"Customer_3\" (\"customerid\" BIGINT NOT NULL, \"email\" TEXT NOT NULL, \"name\" TEXT NOT NULL, \"lastUpdated\" BIGINT NOT NULL, \"timestamp\" TIMESTAMP WITH TIME ZONE NOT NULL, PRIMARY KEY (\"customerid\",\"lastUpdated\"))",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ],
+      "primaryKey" : [
+        "customerid",
+        "lastUpdated"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CustomerBare_4",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CustomerBare_4\" (\"customerid\" BIGINT NOT NULL, \"c\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "A bare alias derives its column name from the alias itself",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "c",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CustomerRow_5",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"CustomerRow_5\" (\"customerid\" BIGINT NOT NULL, \"customer\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "The whole customer row nested under a named field",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "NestedCustomerRow_6",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"NestedCustomerRow_6\" (\"customer\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "Relation aliases are expanded in subqueries too",
+      "fields" : [
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "Orders_7",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"Orders_7\" (\"id\" BIGINT NOT NULL, \"customerid\" BIGINT NOT NULL, \"time\" TIMESTAMP WITH TIME ZONE NOT NULL, \"entries\" JSONB, PRIMARY KEY (\"id\",\"time\"))",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "id",
+        "time"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "ReservedAliasRow_8",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"ReservedAliasRow_8\" (\"customerid\" BIGINT NOT NULL, \"whole\" JSONB, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "A quoted reserved word works as a relation alias",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "whole",
+          "type" : "JSONB",
+          "nullable" : true
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "Shadowed_9",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"Shadowed_9\" (\"c\" BIGINT NOT NULL, \"label\" TEXT NOT NULL, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "fields" : [
+        {
+          "name" : "c",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "label",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "ShadowedAlias_10",
+      "type" : "TABLE",
+      "sql" : "CREATE TABLE IF NOT EXISTS \"ShadowedAlias_10\" (\"c\" BIGINT NOT NULL, \"label\" TEXT NOT NULL, \"__pk_hash\" TEXT, PRIMARY KEY (\"__pk_hash\"))",
+      "description" : "A column of the same name takes precedence over the relation alias",
+      "fields" : [
+        {
+          "name" : "c",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "label",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "__pk_hash",
+          "type" : "TEXT",
+          "nullable" : true
+        }
+      ],
+      "primaryKey" : [
+        "__pk_hash"
+      ],
+      "partitionKey" : [ ],
+      "partitionType" : "NONE",
+      "numPartitions" : 0,
+      "ttl" : 0.0
+    },
+    {
+      "name" : "CteCustomerRow",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CteCustomerRow\"(\"customerid\", \"customer\") AS SELECT \"customerid\", \"customer\"\nFROM \"CteCustomerRow_1\"",
+      "description" : "CTEs stay in scope while the alias is resolved",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "CteDefinitionRow",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CteDefinitionRow\"(\"customerid\", \"customer\") AS SELECT \"customerid\", \"customer\"\nFROM \"CteDefinitionRow_2\"",
+      "description" : "Aliases inside a CTE definition see the preceding CTEs, but not their own binding",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "Customer",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"Customer\"(\"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\") AS SELECT *\nFROM \"Customer_3\"",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "email",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "name",
+          "type" : "TEXT",
+          "nullable" : false
+        },
+        {
+          "name" : "lastUpdated",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "timestamp",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        }
+      ]
+    },
+    {
+      "name" : "CustomerBare",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CustomerBare\"(\"customerid\", \"c\") AS SELECT \"customerid\", \"c\"\nFROM \"CustomerBare_4\"",
+      "description" : "A bare alias derives its column name from the alias itself",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "c",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "CustomerRow",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"CustomerRow\"(\"customerid\", \"customer\") AS SELECT \"customerid\", \"customer\"\nFROM \"CustomerRow_5\"",
+      "description" : "The whole customer row nested under a named field",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "NestedCustomerRow",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"NestedCustomerRow\"(\"customer\") AS SELECT \"customer\"\nFROM \"NestedCustomerRow_6\"",
+      "description" : "Relation aliases are expanded in subqueries too",
+      "fields" : [
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "OrderWithCustomer",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"OrderWithCustomer\"(\"id\", \"order\", \"customer\") AS SELECT \"Orders_70\".\"id\", CAST(ROW(\"Orders_70\".\"id\", \"Orders_70\".\"customerid\", \"Orders_70\".\"time\", \"Orders_70\".\"entries\") AS JSONB) AS \"order\", CAST(ROW(\"Customer_30\".\"customerid\", \"Customer_30\".\"email\", \"Customer_30\".\"name\", \"Customer_30\".\"lastUpdated\", \"Customer_30\".\"timestamp\") AS JSONB) AS \"customer\"\nFROM \"Orders_7\" AS \"Orders_70\"\n INNER JOIN \"Customer_3\" AS \"Customer_30\" ON \"Orders_70\".\"customerid\" = \"Customer_30\".\"customerid\"",
+      "description" : "Both sides of a join can be nested, including array columns",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "order",
+          "type" : "JSONB",
+          "nullable" : false
+        },
+        {
+          "name" : "customer",
+          "type" : "JSONB",
+          "nullable" : false
+        }
+      ]
+    },
+    {
+      "name" : "Orders",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"Orders\"(\"id\", \"customerid\", \"time\", \"entries\") AS SELECT *\nFROM \"Orders_7\"",
+      "fields" : [
+        {
+          "name" : "id",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "time",
+          "type" : "TIMESTAMP WITH TIME ZONE",
+          "nullable" : false
+        },
+        {
+          "name" : "entries",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "ReservedAliasRow",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"ReservedAliasRow\"(\"customerid\", \"whole\") AS SELECT \"customerid\", \"whole\"\nFROM \"ReservedAliasRow_8\"",
+      "description" : "A quoted reserved word works as a relation alias",
+      "fields" : [
+        {
+          "name" : "customerid",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "whole",
+          "type" : "JSONB",
+          "nullable" : true
+        }
+      ]
+    },
+    {
+      "name" : "Shadowed",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"Shadowed\"(\"c\", \"label\") AS SELECT \"c\", \"label\"\nFROM \"Shadowed_9\"",
+      "fields" : [
+        {
+          "name" : "c",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "label",
+          "type" : "TEXT",
+          "nullable" : false
+        }
+      ]
+    },
+    {
+      "name" : "ShadowedAlias",
+      "type" : "VIEW",
+      "sql" : "CREATE OR REPLACE VIEW \"ShadowedAlias\"(\"c\", \"label\") AS SELECT \"c\", \"label\"\nFROM \"ShadowedAlias_10\"",
+      "description" : "A column of the same name takes precedence over the relation alias",
+      "fields" : [
+        {
+          "name" : "c",
+          "type" : "BIGINT",
+          "nullable" : false
+        },
+        {
+          "name" : "label",
+          "type" : "TEXT",
+          "nullable" : false
+        }
+      ]
+    }
+  ],
+  "standaloneExtensionStatements" : [ ]
+}
+>>>vertx.json
+{
+  "models" : {
+    "v1" : {
+      "queries" : [
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CteCustomerRow",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customerid\", \"customer\"\nFROM \"CteCustomerRow_1\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CteDefinitionRow",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customerid\", \"customer\"\nFROM \"CteDefinitionRow_2\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "Customer",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"Customer_3\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CustomerBare",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customerid\", \"c\"\nFROM \"CustomerBare_4\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CustomerRow",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customerid\", \"customer\"\nFROM \"CustomerRow_5\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "NestedCustomerRow",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customer\"\nFROM \"NestedCustomerRow_6\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "OrderWithCustomer",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"Orders_70\".\"id\", CAST(ROW(\"Orders_70\".\"id\", \"Orders_70\".\"customerid\", \"Orders_70\".\"time\", \"Orders_70\".\"entries\") AS JSONB) AS \"order\", CAST(ROW(\"Customer_30\".\"customerid\", \"Customer_30\".\"email\", \"Customer_30\".\"name\", \"Customer_30\".\"lastUpdated\", \"Customer_30\".\"timestamp\") AS JSONB) AS \"customer\"\nFROM \"Orders_7\" AS \"Orders_70\"\n INNER JOIN \"Customer_3\" AS \"Customer_30\" ON \"Orders_70\".\"customerid\" = \"Customer_30\".\"customerid\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "Orders",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT *\nFROM \"Orders_7\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "ReservedAliasRow",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"customerid\", \"whole\"\nFROM \"ReservedAliasRow_8\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "Shadowed",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"c\", \"label\"\nFROM \"Shadowed_9\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "ShadowedAlias",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT \"c\", \"label\"\nFROM \"ShadowedAlias_10\"",
+              "parameters" : [ ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        },
+        {
+          "type" : "args",
+          "parentType" : "Query",
+          "fieldName" : "CustomerRowById",
+          "exec" : {
+            "arguments" : [
+              {
+                "type" : "variable",
+                "path" : "limit"
+              },
+              {
+                "type" : "variable",
+                "path" : "id"
+              },
+              {
+                "type" : "variable",
+                "path" : "offset"
+              }
+            ],
+            "query" : {
+              "type" : "SqlQuery",
+              "sql" : "SELECT CAST(ROW(\"customerid\", \"email\", \"name\", \"lastUpdated\", \"timestamp\") AS JSONB) AS \"customer\"\nFROM \"Customer_3\"\nWHERE \"customerid\" = $1",
+              "parameters" : [
+                {
+                  "type" : "arg",
+                  "path" : "id",
+                  "sqlType" : "BIGINT"
+                }
+              ],
+              "pagination" : "LIMIT_AND_OFFSET",
+              "cacheDurationMs" : 0,
+              "database" : "POSTGRES"
+            }
+          }
+        }
+      ],
+      "mutations" : [ ],
+      "subscriptions" : [ ],
+      "operations" : [
+        {
+          "function" : {
+            "name" : "GetCteCustomerRow",
+            "description" : "CTEs stay in scope while the alias is resolved",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query CteCustomerRow($limit: Int = 10, $offset: Int = 0) {\nCteCustomerRow(limit: $limit, offset: $offset) {\ncustomerid\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "CteCustomerRow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CteCustomerRow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetCteDefinitionRow",
+            "description" : "Aliases inside a CTE definition see the preceding CTEs, but not their own binding",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query CteDefinitionRow($limit: Int = 10, $offset: Int = 0) {\nCteDefinitionRow(limit: $limit, offset: $offset) {\ncustomerid\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "CteDefinitionRow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CteDefinitionRow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetCustomer",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query Customer($limit: Int = 10, $offset: Int = 0) {\nCustomer(limit: $limit, offset: $offset) {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n\n}",
+            "queryName" : "Customer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Customer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "email" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "lastUpdated" : {
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetCustomerBare",
+            "description" : "A bare alias derives its column name from the alias itself",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query CustomerBare($limit: Int = 10, $offset: Int = 0) {\nCustomerBare(limit: $limit, offset: $offset) {\ncustomerid\nc {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "CustomerBare",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerBare{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "c" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetCustomerRow",
+            "description" : "The whole customer row nested under a named field",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query CustomerRow($limit: Int = 10, $offset: Int = 0) {\nCustomerRow(limit: $limit, offset: $offset) {\ncustomerid\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "CustomerRow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerRow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetNestedCustomerRow",
+            "description" : "Relation aliases are expanded in subqueries too",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query NestedCustomerRow($limit: Int = 10, $offset: Int = 0) {\nNestedCustomerRow(limit: $limit, offset: $offset) {\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "NestedCustomerRow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/NestedCustomerRow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetOrderWithCustomer",
+            "description" : "Both sides of a join can be nested, including array columns",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query OrderWithCustomer($limit: Int = 10, $offset: Int = 0) {\nOrderWithCustomer(limit: $limit, offset: $offset) {\nid\norder {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "OrderWithCustomer",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/OrderWithCustomer{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "order" : {
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "type" : "integer"
+                    },
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "time" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "entries" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "productid" : {
+                            "type" : "integer"
+                          },
+                          "quantity" : {
+                            "type" : "integer"
+                          },
+                          "unit_price" : {
+                            "type" : "number"
+                          },
+                          "discount" : {
+                            "type" : "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetOrders",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query Orders($limit: Int = 10, $offset: Int = 0) {\nOrders(limit: $limit, offset: $offset) {\nid\ncustomerid\ntime\nentries {\nproductid\nquantity\nunit_price\ndiscount\n}\n}\n\n}",
+            "queryName" : "Orders",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Orders{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "time" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                },
+                "entries" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "productid" : {
+                        "type" : "integer"
+                      },
+                      "quantity" : {
+                        "type" : "integer"
+                      },
+                      "unit_price" : {
+                        "type" : "number"
+                      },
+                      "discount" : {
+                        "type" : "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetReservedAliasRow",
+            "description" : "A quoted reserved word works as a relation alias",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query ReservedAliasRow($limit: Int = 10, $offset: Int = 0) {\nReservedAliasRow(limit: $limit, offset: $offset) {\ncustomerid\nwhole {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "ReservedAliasRow",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ReservedAliasRow{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerid" : {
+                  "type" : "integer"
+                },
+                "whole" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetShadowed",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query Shadowed($limit: Int = 10, $offset: Int = 0) {\nShadowed(limit: $limit, offset: $offset) {\nc\nlabel\n}\n\n}",
+            "queryName" : "Shadowed",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/Shadowed{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "c" : {
+                  "type" : "integer"
+                },
+                "label" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetShadowedAlias",
+            "description" : "A column of the same name takes precedence over the relation alias",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [ ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query ShadowedAlias($limit: Int = 10, $offset: Int = 0) {\nShadowedAlias(limit: $limit, offset: $offset) {\nc\nlabel\n}\n\n}",
+            "queryName" : "ShadowedAlias",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/ShadowedAlias{?offset,limit}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "c" : {
+                  "type" : "integer"
+                },
+                "label" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function" : {
+            "name" : "GetCustomerRowById",
+            "description" : "The nested row is available to table functions as well",
+            "parameters" : {
+              "type" : "object",
+              "properties" : {
+                "offset" : {
+                  "type" : "integer"
+                },
+                "limit" : {
+                  "type" : "integer"
+                },
+                "id" : {
+                  "type" : "integer"
+                }
+              },
+              "required" : [
+                "id"
+              ]
+            }
+          },
+          "apiQuery" : {
+            "query" : "query CustomerRowById($id: Long!, $limit: Int = 10, $offset: Int = 0) {\nCustomerRowById(id: $id, limit: $limit, offset: $offset) {\ncustomer {\ncustomerid\nemail\nname\nlastUpdated\ntimestamp\n}\n}\n\n}",
+            "queryName" : "CustomerRowById",
+            "operationType" : "QUERY"
+          },
+          "mcpMethod" : "TOOL",
+          "restMethod" : "GET",
+          "uriTemplate" : "queries/CustomerRowById{?offset,limit,id}",
+          "format" : "JSON",
+          "resultDefinition" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "customerid" : {
+                      "type" : "integer"
+                    },
+                    "email" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "lastUpdated" : {
+                      "type" : "integer"
+                    },
+                    "timestamp" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "schema" : {
+        "type" : "string",
+        "schema" : "\"CTEs stay in scope while the alias is resolved\"\ntype CteCustomerRow {\n  customerid: Long!\n  customer: CteCustomerRow_customerOutput!\n}\n\ntype CteCustomerRow_customerOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype Customer {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\n\"A bare alias derives its column name from the alias itself\"\ntype CustomerBare {\n  customerid: Long!\n  c: CustomerBare_cOutput!\n}\n\ntype CustomerBare_cOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\n\"The whole customer row nested under a named field\"\ntype CustomerRow {\n  customerid: Long!\n  customer: CustomerRow_customerOutput!\n}\n\n\"The nested row is available to table functions as well\"\ntype CustomerRowById {\n  customer: CustomerRowById_customerOutput!\n}\n\ntype CustomerRowById_customerOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype CustomerRow_customerOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\n\"An RFC-3339 compliant Full Date Scalar\"\nscalar Date\n\n\"A DateTime scalar that handles both full RFC3339 and shorter timestamp formats\"\nscalar DateTime\n\n\"A JSON scalar\"\nscalar JSON\n\n\"24-hour clock time value string in the format `hh:mm:ss` or `hh:mm:ss.sss`.\"\nscalar LocalTime\n\n\"A 64-bit signed integer\"\nscalar Long\n\n\"Relation aliases are expanded in subqueries too\"\ntype NestedCustomerRow {\n  customer: NestedCustomerRow_customerOutput!\n}\n\ntype NestedCustomerRow_customerOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\n\"Both sides of a join can be nested, including array columns\"\ntype OrderWithCustomer {\n  id: Long!\n  order: OrderWithCustomer_orderOutput!\n  customer: OrderWithCustomer_customerOutput!\n}\n\ntype OrderWithCustomer_customerOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype OrderWithCustomer_orderOutput {\n  id: Long!\n  customerid: Long!\n  time: DateTime!\n  entries: [OrderWithCustomer_order_entriesOutput]!\n}\n\ntype OrderWithCustomer_order_entriesOutput {\n  productid: Long!\n  quantity: Long!\n  unit_price: Float!\n  discount: Float\n}\n\ntype Orders {\n  id: Long!\n  customerid: Long!\n  time: DateTime!\n  entries: [Orders_entriesOutput]!\n}\n\ntype Orders_entriesOutput {\n  productid: Long!\n  quantity: Long!\n  unit_price: Float!\n  discount: Float\n}\n\ntype Query {\n  \"CTEs stay in scope while the alias is resolved\"\n  CteCustomerRow(limit: Int = 10, offset: Int = 0): [CteCustomerRow!]\n  \"Aliases inside a CTE definition see the preceding CTEs, but not their own binding\"\n  CteDefinitionRow(limit: Int = 10, offset: Int = 0): [CteCustomerRow!]\n  Customer(limit: Int = 10, offset: Int = 0): [Customer!]\n  \"A bare alias derives its column name from the alias itself\"\n  CustomerBare(limit: Int = 10, offset: Int = 0): [CustomerBare!]\n  \"The whole customer row nested under a named field\"\n  CustomerRow(limit: Int = 10, offset: Int = 0): [CustomerRow!]\n  \"Relation aliases are expanded in subqueries too\"\n  NestedCustomerRow(limit: Int = 10, offset: Int = 0): [NestedCustomerRow!]\n  \"Both sides of a join can be nested, including array columns\"\n  OrderWithCustomer(limit: Int = 10, offset: Int = 0): [OrderWithCustomer!]\n  Orders(limit: Int = 10, offset: Int = 0): [Orders!]\n  \"A quoted reserved word works as a relation alias\"\n  ReservedAliasRow(limit: Int = 10, offset: Int = 0): [ReservedAliasRow!]\n  Shadowed(limit: Int = 10, offset: Int = 0): [Shadowed!]\n  \"A column of the same name takes precedence over the relation alias\"\n  ShadowedAlias(limit: Int = 10, offset: Int = 0): [Shadowed!]\n  \"The nested row is available to table functions as well\"\n  CustomerRowById(id: Long!, limit: Int = 10, offset: Int = 0): [CustomerRowById!]\n}\n\n\"A quoted reserved word works as a relation alias\"\ntype ReservedAliasRow {\n  customerid: Long!\n  whole: ReservedAliasRow_wholeOutput!\n}\n\ntype ReservedAliasRow_wholeOutput {\n  customerid: Long!\n  email: String!\n  name: String!\n  lastUpdated: Long!\n  timestamp: DateTime!\n}\n\ntype Shadowed {\n  c: Long!\n  label: String!\n}\n\nenum _McpMethodType {\n  NONE\n  TOOL\n  RESOURCE\n}\n\nenum _RestMethodType {\n  NONE\n  GET\n  POST\n}\n\ndirective @api(mcp: _McpMethodType, rest: _RestMethodType, uri: String) on QUERY | MUTATION | FIELD_DEFINITION\n"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #2339

## Problem

A bare relation alias in a SELECT list was rejected with `Column 'p' not found in any table`:

```sql
Project := SELECT p AS project FROM Projects p;
```

Neither Calcite nor Flink resolve a single-part identifier to the row of a relation — `DelegatingScope.fullyQualify` only ever looks for a column of that name and throws when there is none. The only workaround was to spell out `CAST(ROW(p.col1, ...) AS ROW<col1 TYPE1, ...>)` by hand, which has to be kept in sync with the source table's columns.

## Solution

`RelationAliasExpander` rewrites the SqlNode tree before it reaches Flink's validator. For every `SELECT` whose list contains a bare identifier matching a relation alias in its `FROM` clause, it:

1. builds a probe query that keeps only the `FROM` clause and validates `SELECT *` against it, to learn the columns the query already has;
2. skips the alias if a column of the same name exists, so column resolution keeps precedence, exactly as in standard SQL;
3. validates `SELECT <alias>.*` against the same probe to get the field names and types the alias contributes (including outer-join nullability);
4. replaces the select item with `CAST(ROW(<alias>.<f1>, ...) AS ROW<...>)`, aliased to the name the item already had.

The probe is re-parsed from its serialized form for each validation because validation mutates the tree it is given — the same reason `addView` already re-parses the original SQL.

Anything that cannot be resolved is left untouched, so the regular validation still reports the original error. The rewrite is applied to table definitions, table functions, relationships and inline Flink `CREATE VIEW` / `INSERT INTO` statements.

## Scope

The nested field carries the source table's column names and types. It does **not** carry the source table's GraphQL relationships — that part of the issue's "ideally" is not addressed here.

## Testing

New `relationAliasRowTest.sqrl` DAG planner script covering:

* `c AS customer` — the whole row under a named field
* bare `c` — the column name is derived from the alias
* both sides of a join, including a nested `ROW ARRAY` column
* a column named like the alias, which keeps taking precedence
* expansion inside a subquery
* a table function with a parameter

`mvn -o test` shows no new failures; the pre-existing `DAGPlannerTest` / `GraphQLValidationTest` message-snapshot failures reproduce identically on a clean tree.

