### PR TITLE
perf: replace Flink MiniBatchIntervalInferRule with a value-comparing copy

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/sql/rules/SqrlMiniBatchIntervalInferRule.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/sql/rules/SqrlMiniBatchIntervalInferRule.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.stream.flink.sql.rules;
+
+import java.util.List;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDataStreamScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalGroupWindowAggregate;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacyTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMiniBatchAssigner;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWatermarkAssigner;
+import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
+import org.apache.flink.table.planner.plan.trait.MiniBatchInterval;
+import org.apache.flink.table.planner.plan.trait.MiniBatchIntervalTrait;
+import org.apache.flink.table.planner.plan.trait.MiniBatchIntervalTraitDef;
+import org.apache.flink.table.planner.plan.trait.MiniBatchMode;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.immutables.value.Value;
+
+/**
+ * Drop-in replacement for Flink's {@link MiniBatchIntervalInferRule} that compares mini-batch
+ * traits by value instead of identity, so inputs whose interval is unchanged are not copied. Flink
+ * builds a fresh trait per match, which makes the identity check fire on every watermark-requiring
+ * operator and costs the HepPlanner a full-graph garbage collection per no-op transformation.
+ */
+public class SqrlMiniBatchIntervalInferRule
+    extends RelRule<SqrlMiniBatchIntervalInferRule.SqrlMiniBatchIntervalInferRuleConfig> {
+
+  public static final SqrlMiniBatchIntervalInferRule INSTANCE =
+      SqrlMiniBatchIntervalInferRuleConfig.DEFAULT.toRule();
+
+  protected SqrlMiniBatchIntervalInferRule(SqrlMiniBatchIntervalInferRuleConfig config) {
+    super(config);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    StreamPhysicalRel rel = call.rel(0);
+    var miniBatchIntervalTrait = rel.getTraitSet().getTrait(MiniBatchIntervalTraitDef.INSTANCE());
+    var inputs = getInputs(rel);
+    var updatedTrait = getUpdatedTrait(rel, miniBatchIntervalTrait);
+    var updatedInputs = inputs.stream().map(input -> getUpdatedInput(input, updatedTrait)).toList();
+
+    if (!inputs.equals(updatedInputs)) {
+      call.transformTo(rel.copy(rel.getTraitSet(), updatedInputs));
+    }
+  }
+
+  private MiniBatchIntervalTrait getUpdatedTrait(
+      StreamPhysicalRel rel, MiniBatchIntervalTrait miniBatchIntervalTrait) {
+    if (rel instanceof StreamPhysicalGroupWindowAggregate) {
+      return MiniBatchIntervalTrait.NO_MINIBATCH();
+    }
+    if (rel instanceof StreamPhysicalWatermarkAssigner
+        || rel instanceof StreamPhysicalMiniBatchAssigner) {
+      return MiniBatchIntervalTrait.NONE();
+    }
+
+    var tableConfig = ShortcutUtils.unwrapTableConfig(rel);
+    var miniBatchEnabled = tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED);
+    if (rel.requireWatermark() && miniBatchEnabled) {
+      var mergedInterval =
+          FlinkRelOptUtil.mergeMiniBatchInterval(
+              miniBatchIntervalTrait.getMiniBatchInterval(),
+              new MiniBatchInterval(0, MiniBatchMode.RowTime));
+      return new MiniBatchIntervalTrait(mergedInterval);
+    }
+    return miniBatchIntervalTrait;
+  }
+
+  private RelNode getUpdatedInput(RelNode input, MiniBatchIntervalTrait updatedTrait) {
+    if (shouldAppendMiniBatchAssignerNode(input)) {
+      return new StreamPhysicalMiniBatchAssigner(
+          input.getCluster(),
+          input.getTraitSet(),
+          input.copy(input.getTraitSet().plus(MiniBatchIntervalTrait.NONE()), input.getInputs()));
+    }
+
+    var originTrait = input.getTraitSet().getTrait(MiniBatchIntervalTraitDef.INSTANCE());
+    if (originTrait.equals(updatedTrait)) {
+      return input;
+    }
+
+    var inferredTrait =
+        new MiniBatchIntervalTrait(
+            FlinkRelOptUtil.mergeMiniBatchInterval(
+                originTrait.getMiniBatchInterval(), updatedTrait.getMiniBatchInterval()));
+    if (inferredTrait.equals(originTrait)) {
+      return input;
+    }
+    return input.copy(input.getTraitSet().plus(inferredTrait), input.getInputs());
+  }
+
+  private List<RelNode> getInputs(RelNode parent) {
+    return parent.getInputs().stream().map(i -> ((HepRelVertex) i).getCurrentRel()).toList();
+  }
+
+  private boolean shouldAppendMiniBatchAssignerNode(RelNode node) {
+    var mode =
+        node.getTraitSet()
+            .getTrait(MiniBatchIntervalTraitDef.INSTANCE())
+            .getMiniBatchInterval()
+            .getMode();
+    if (node instanceof StreamPhysicalDataStreamScan
+        || node instanceof StreamPhysicalLegacyTableSourceScan
+        || node instanceof StreamPhysicalTableSourceScan
+        || node instanceof StreamPhysicalWatermarkAssigner) {
+      return mode == MiniBatchMode.RowTime || mode == MiniBatchMode.ProcTime;
+    }
+    return false;
+  }
+
+  @Value.Immutable
+  public interface SqrlMiniBatchIntervalInferRuleConfig extends RelRule.Config {
+    SqrlMiniBatchIntervalInferRuleConfig DEFAULT =
+        ImmutableSqrlMiniBatchIntervalInferRuleConfig.builder()
+            .description("SqrlMiniBatchIntervalInferRule")
+            .operandSupplier(b0 -> b0.operand(StreamPhysicalRel.class).anyInputs())
+            .build();
+
+    @Override
+    default SqrlMiniBatchIntervalInferRule toRule() {
+      return new SqrlMiniBatchIntervalInferRule(this);
+    }
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
@@ -16,11 +16,13 @@
 package com.datasqrl.planner;
 
 import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.engine.stream.flink.sql.rules.SqrlMiniBatchIntervalInferRule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +45,7 @@ import org.apache.flink.table.planner.plan.rules.logical.PushPartitionIntoLegacy
 import org.apache.flink.table.planner.plan.rules.logical.PushPartitionIntoTableSourceScanRule;
 import org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoLegacyTableSourceScanRule;
 import org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoTableSourceScanRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
 import scala.Tuple2;
 
 @RequiredArgsConstructor
@@ -51,10 +54,7 @@ public class FlinkPlannerConfigBuilder {
 
   /** We do not touch these programs. */
   private static final Set<String> IGNORED_PROGRAMS =
-      Set.of(
-          FlinkStreamProgram.DECORRELATE(),
-          FlinkStreamProgram.PHYSICAL_REWRITE(),
-          FlinkStreamProgram.TIME_INDICATOR());
+      Set.of(FlinkStreamProgram.DECORRELATE(), FlinkStreamProgram.TIME_INDICATOR());
 
   /**
    * Downstream filter rules to remove in case of {@link
@@ -113,10 +113,8 @@ public class FlinkPlannerConfigBuilder {
       calciteConfigBuilder.addSqlOperatorTable(sqrlFunctionCatalog.getOperatorTable());
     }
 
-    if (compilerConfig.predicatePushdownRules() != PredicatePushdownRules.DEFAULT) {
-      var streamProgram = buildCustomStreamProgram(compilerConfig.predicatePushdownRules());
-      calciteConfigBuilder.replaceStreamProgram(streamProgram);
-    }
+    var streamProgram = buildCustomStreamProgram(compilerConfig.predicatePushdownRules());
+    calciteConfigBuilder.replaceStreamProgram(streamProgram);
 
     return calciteConfigBuilder.build();
   }
@@ -132,6 +130,16 @@ public class FlinkPlannerConfigBuilder {
 
       // Programs that can be ignored.
       if (IGNORED_PROGRAMS.contains(programName)) {
+        customStreamProgram.addLast(programName, program);
+        continue;
+      }
+
+      if (programName.equals(FlinkStreamProgram.PHYSICAL_REWRITE())) {
+        replaceRules(
+            programName,
+            program,
+            MiniBatchIntervalInferRule.class::isInstance,
+            SqrlMiniBatchIntervalInferRule.INSTANCE);
         customStreamProgram.addLast(programName, program);
         continue;
       }
@@ -189,11 +197,27 @@ public class FlinkPlannerConfigBuilder {
     return programs.removeIf(shouldRemove);
   }
 
-  // Strip rule(s) from a FlinkOptimizeProgram instance based on a predicate.
-  // In case of a FlinkGroupProgram, rule strip happens for every program.
-  @SuppressWarnings("unchecked")
   private void stripRules(
       String programName, FlinkOptimizeProgram<?> program, Predicate<RelOptRule> shouldRemove) {
+    rewriteRules(programName, program, rules -> rules.removeIf(shouldRemove));
+  }
+
+  private void replaceRules(
+      String programName,
+      FlinkOptimizeProgram<?> program,
+      Predicate<RelOptRule> shouldReplace,
+      RelOptRule replacement) {
+    rewriteRules(
+        programName,
+        program,
+        rules -> rules.replaceAll(rule -> shouldReplace.test(rule) ? replacement : rule));
+  }
+
+  // Rewrite the rule list of a FlinkOptimizeProgram instance.
+  // In case of a FlinkGroupProgram, the rewrite happens for every program.
+  @SuppressWarnings("unchecked")
+  private void rewriteRules(
+      String programName, FlinkOptimizeProgram<?> program, Consumer<List<RelOptRule>> rewrite) {
 
     List<?> programs;
     if (program instanceof FlinkGroupProgram) {
@@ -205,7 +229,7 @@ public class FlinkPlannerConfigBuilder {
 
     for (var internalProgram : programs) {
       if (internalProgram instanceof FlinkGroupProgram) {
-        stripRules(programName, (FlinkOptimizeProgram<?>) internalProgram, shouldRemove);
+        rewriteRules(programName, (FlinkOptimizeProgram<?>) internalProgram, rewrite);
         continue;
       }
 
@@ -216,12 +240,12 @@ public class FlinkPlannerConfigBuilder {
         var current = (List<RelOptRule>) f.get(internalProgram);
         var mutable = new ArrayList<>(current);
 
-        var changed = mutable.removeIf(shouldRemove);
-        if (changed) {
+        rewrite.accept(mutable);
+        if (!mutable.equals(current)) {
           f.set(internalProgram, List.copyOf(mutable));
         }
       } catch (ReflectiveOperationException e) {
-        log.warn("Could not strip rules from program: " + programName, e);
+        log.warn("Could not rewrite rules of program: " + programName, e);
       }
     }
   }

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.engine.stream.flink.sql.rules.SqrlMiniBatchIntervalInferRule;
+import java.util.List;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.ExplainFormat;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
+import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import scala.Tuple2;
+
+class FlinkPlannerConfigBuilderTest {
+
+  private static final List<String> DDL =
+      List.of(
+          """
+          CREATE TABLE orders (
+            id INT,
+            currency STRING,
+            ts TIMESTAMP_LTZ(3),
+            WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+          ) WITH ('connector' = 'datagen')
+          """,
+          """
+          CREATE TABLE rates (
+            currency STRING,
+            rate DECIMAL(10, 2),
+            ts TIMESTAMP_LTZ(3),
+            WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+          ) WITH ('connector' = 'datagen')
+          """,
+          """
+          CREATE VIEW versioned_rates AS
+          SELECT currency, rate, ts FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY currency ORDER BY ts DESC) AS rn FROM rates
+          ) WHERE rn = 1
+          """);
+
+  private static final String QUERY =
+      """
+      SELECT o.currency, COUNT(*) AS cnt, SUM(r.rate) AS total
+      FROM orders o
+      LEFT JOIN versioned_rates FOR SYSTEM_TIME AS OF o.ts AS r ON o.currency = r.currency
+      GROUP BY o.currency
+      """;
+
+  @ParameterizedTest
+  @EnumSource(PredicatePushdownRules.class)
+  void givenAnyPushdownRules_whenBuild_thenPhysicalRewriteUsesSqrlMiniBatchRule(
+      PredicatePushdownRules rules) {
+    var flinkConf = new Configuration();
+    var plannerConfig =
+        (CalciteConfig) new FlinkPlannerConfigBuilder(config(rules), flinkConf).build();
+    var physicalRewrite =
+        plannerConfig.getStreamProgram().get().get(FlinkStreamProgram.PHYSICAL_REWRITE()).get();
+
+    var ruleSetPrograms =
+        subPrograms(physicalRewrite).stream()
+            .map(Tuple2::_1)
+            .filter(FlinkHepRuleSetProgram.class::isInstance)
+            .map(FlinkHepRuleSetProgram.class::cast)
+            .toList();
+
+    assertThat(ruleSetPrograms).isNotEmpty();
+    assertThat(ruleSetPrograms)
+        .filteredOn(p -> p.contains(SqrlMiniBatchIntervalInferRule.INSTANCE))
+        .hasSize(1);
+    assertThat(ruleSetPrograms)
+        .filteredOn(p -> p.contains(MiniBatchIntervalInferRule.INSTANCE))
+        .isEmpty();
+  }
+
+  @Test
+  void givenMiniBatchTemporalJoin_whenExplain_thenPlanEqualsFlinkDefaultProgram() {
+    var sqrlPlan = explain(true);
+    var flinkPlan = explain(false);
+
+    assertThat(sqrlPlan).contains("MiniBatchAssigner").contains("TemporalJoin").contains("Rank");
+    assertThat(sqrlPlan).isEqualTo(flinkPlan);
+  }
+
+  private String explain(boolean sqrlPlannerConfig) {
+    var flinkConf = new Configuration();
+    flinkConf.setString("table.exec.mini-batch.enabled", "true");
+    flinkConf.setString("table.exec.mini-batch.allow-latency", "5 s");
+    flinkConf.setString("table.exec.mini-batch.size", "1000");
+
+    var tEnv = TableEnvironment.create(flinkConf);
+    if (sqrlPlannerConfig) {
+      var plannerConfig =
+          new FlinkPlannerConfigBuilder(config(PredicatePushdownRules.DEFAULT), flinkConf).build();
+      tEnv.getConfig().setPlannerConfig(plannerConfig);
+    }
+    DDL.forEach(tEnv::executeSql);
+
+    return tEnv.explainSql(QUERY, ExplainFormat.TEXT);
+  }
+
+  private CompilerConfig config(PredicatePushdownRules rules) {
+    var compilerConf = mock(CompilerConfig.class);
+    when(compilerConf.predicatePushdownRules()).thenReturn(rules);
+    return compilerConf;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Tuple2<FlinkOptimizeProgram<?>, String>> subPrograms(
+      FlinkOptimizeProgram<?> groupProgram) {
+    try {
+      var f = groupProgram.getClass().getDeclaredField("programs");
+      f.setAccessible(true);
+      return (List<Tuple2<FlinkOptimizeProgram<?>, String>>) f.get(groupProgram);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Flink 2.3.0's `MiniBatchIntervalInferRule.getUpdatedInput` compares `originTrait != updatedTrait` by identity against a freshly built trait, so every operator that requires a watermark produces a no-op copy on every top-down pass, and Calcite's `HepPlanner` runs a full-graph `collectGarbage` per production. On a mini-batch project this was ~290k productions and the largest single cost of the compile.
- `SqrlMiniBatchIntervalInferRule` is a copy comparing with `equals` and short-circuiting unchanged intervals; `FlinkPlannerConfigBuilder` swaps it into `physical_rewrite` for every project.
- `FlinkPlannerConfigBuilderTest` asserts the swap and a byte-identical plan for a mini-batch + dedup + temporal join + aggregate query. Rule productions on the benchmark project: 290,253 -> 10,155, all other rule counts unchanged. Upstream Flink ticket to follow.

## Benchmark
Warm in-process compiles (compiler loaded once, then compiled repeatedly in the same JVM), cloud-backend `core`, `agent` and `metrics` with `package.json package-test-static.json`, 5 cycles each, control = unmodified `main`. Deterministic artifacts (`flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json`, `database-schema.sql`) identical to control in every cycle.

| module | control p50 / p80 | this PR p50 / p80 | p50 gain |
|---|---|---|---|
| core | 17.16 s / 17.29 s | 16.26 s / 16.66 s | -5% |
| agent | 1.48 s / 2.66 s | 0.91 s / 1.52 s | -38% |
| metrics | 26.04 s / 26.42 s | 20.43 s / 21.32 s | -22% |

## Test plan
- [x] `FlinkPlannerConfigBuilderTest` 5/5, `PredicatePushdownTest` 36 passed with unchanged snapshots
- [x] cloud-backend metrics: all plan files including `flink-compiled-plan.json` byte-identical to main
- [ ] CI