### PR TITLE
perf: register views as QueryOperationCatalogView from the analyzed RelNode

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -51,6 +51,7 @@ import com.datasqrl.planner.tables.FlinkTableBuilder;
 import com.datasqrl.planner.tables.SourceSinkTableAnalysis;
 import com.datasqrl.planner.tables.SqrlFunctionParameter;
 import com.datasqrl.planner.tables.SqrlTableFunction;
+import com.datasqrl.planner.util.ViewQueryOperation;
 import com.datasqrl.server.MetadataType;
 import com.datasqrl.server.exec.FlinkExecFunction;
 import com.datasqrl.server.exec.FlinkExecFunctionFactory;
@@ -125,13 +126,13 @@ import org.apache.flink.table.catalog.Column.ComputedColumn;
 import org.apache.flink.table.catalog.Column.MetadataColumn;
 import org.apache.flink.table.catalog.Column.PhysicalColumn;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.QueryOperationCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.operations.Operation;
-import org.apache.flink.table.operations.ddl.AlterViewAsOperation;
 import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
-import org.apache.flink.table.operations.ddl.CreateViewOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -500,29 +501,41 @@ public class Sqrl2FlinkSQLTranslator {
     final var query = removeSort(originalQuery);
     var removedSort = originalQuery != query;
     final var rewrittenViewDef = updateViewQuery(query, viewDef);
-    // Add the view to Flink using the rewritten SqlNode from stage 1.
-    var op = executeSqlNode(rewrittenViewDef);
-    ObjectIdentifier identifier;
-    if (op instanceof AlterViewAsOperation operation) {
-      identifier = operation.getViewIdentifier();
+    planBuilder.add(rewrittenViewDef);
+    var isAlterView = viewDef instanceof SqlAlterViewAs;
+    var identifier = qualifyViewIdentifier(viewDef);
+    if (isAlterView) {
       tableLookup.removeView(identifier); // remove previously planned view
-    } else if (op instanceof CreateViewOperation operation) {
-      identifier = operation.getViewIdentifier();
-    } else {
-      throw new UnsupportedOperationException(op.getClass().toString());
     }
 
     /* Stage 2: Analyze the RelNode/RelRoot
        - pull out top-level sort
-     NOTE: Flink modifies the SqlSelect node during validation, so we have to re-create it from the original SQL
+     The analyzed RelNode is registered as the view in Flink so that references to the view reuse
+     the planned tree instead of re-parsing and re-validating the whole upstream view chain.
     */
-    var viewDef2 = parseSQL(originalSql);
-    var viewAnalysis = analyzeView(viewDef2, removedSort, hintsAndDoc, errors);
+    var viewAnalysis = analyzeView(viewDef, removedSort, hintsAndDoc, errors);
+    var catalogView =
+        new QueryOperationCatalogView(
+            new ViewQueryOperation(
+                viewAnalysis.originalRelnode(), () -> RelToFlinkSql.convertToString(query)));
+    if (isAlterView) {
+      catalogManager.alterTable(catalogView, identifier, false);
+    } else {
+      catalogManager.createTable(catalogView, identifier, false);
+    }
     var tableAnalysis =
         viewAnalysis.tableAnalysis().objectIdentifier(identifier).originalSql(originalSql).build();
     tableLookup.registerTable(tableAnalysis);
 
     return tableAnalysis;
+  }
+
+  private ObjectIdentifier qualifyViewIdentifier(SqlNode viewDef) {
+    var fullName =
+        viewDef instanceof SqlCreateView createView
+            ? createView.getFullName()
+            : ((SqlAlterViewAs) viewDef).getFullName();
+    return catalogManager.qualifyIdentifier(UnresolvedIdentifier.of(fullName));
   }
 
   /** Analyzes a query executed directly by an INSERT statement. */

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/analyzer/SQRLLogicalPlanAnalyzer.java
@@ -172,6 +172,7 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
 
   public record ViewAnalysis(
       RelNode relNode,
+      RelNode originalRelnode,
       RelBuilder relBuilder,
       TableAnalysis.TableAnalysisBuilder tableAnalysis,
       boolean hasMostRecentDistinct) {}
@@ -294,7 +295,8 @@ public class SQRLLogicalPlanAnalyzer implements SqrlRelShuttle {
             .tableStatistic(tableStatistic)
             .errors(errors);
 
-    return new ViewAnalysis(analysis.relNode, relBuilder, tableAnalysis, hasMostRecentDistinct);
+    return new ViewAnalysis(
+        analysis.relNode, originalRelnode, relBuilder, tableAnalysis, hasMostRecentDistinct);
   }
 
   /**

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/RelNodeCopier.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/RelNodeCopier.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttleImpl;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
+import org.apache.flink.calcite.shaded.com.google.common.collect.ImmutableList;
+import org.apache.flink.calcite.shaded.com.google.common.collect.ImmutableSet;
+
+/**
+ * Deep-copies a relational tree with fresh correlation ids, so that every reference to a planned
+ * view hands Flink a distinct tree just like expanding the view's SQL text would. Flink's optimizer
+ * treats RelNode instances shared between queries as common sub-graphs, and duplicate correlation
+ * ids within one query break decorrelation. The ids are shifted by a constant so that {@link
+ * com.datasqrl.planner.TableAnalysisLookup} still recognizes the copy as the same view.
+ */
+public class RelNodeCopier extends RelShuttleImpl {
+
+  private final RelOptCluster cluster;
+  private final int correlationIdShift;
+  private final RexShuttle rexCopier =
+      new RexShuttle() {
+        @Override
+        public RexNode visitCorrelVariable(RexCorrelVariable variable) {
+          return cluster.getRexBuilder().makeCorrel(variable.getType(), shift(variable.id));
+        }
+
+        @Override
+        public RexNode visitSubQuery(RexSubQuery subQuery) {
+          var copied = (RexSubQuery) super.visitSubQuery(subQuery);
+          return copied.clone(subQuery.rel.accept(RelNodeCopier.this));
+        }
+      };
+
+  public static RelNode copy(RelNode relNode) {
+    return relNode.accept(new RelNodeCopier(relNode));
+  }
+
+  private RelNodeCopier(RelNode relNode) {
+    this.cluster = relNode.getCluster();
+    this.correlationIdShift = reserveCorrelationIds(relNode);
+  }
+
+  private int reserveCorrelationIds(RelNode relNode) {
+    var collector = new CorrelationIdCollector();
+    relNode.accept(collector);
+    if (collector.ids.isEmpty()) {
+      return 0;
+    }
+    int min = Collections.min(collector.ids);
+    int max = Collections.max(collector.ids);
+    var first = cluster.createCorrel().getId();
+    for (var i = min + 1; i <= max; i++) {
+      cluster.createCorrel();
+    }
+    return first - min;
+  }
+
+  private CorrelationId shift(CorrelationId id) {
+    return new CorrelationId(id.getId() + correlationIdShift);
+  }
+
+  private ImmutableSet<CorrelationId> shift(Set<CorrelationId> ids) {
+    return ids.stream().map(this::shift).collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Override
+  protected RelNode visitChild(RelNode parent, int i, RelNode child) {
+    return visitChildren(parent);
+  }
+
+  @Override
+  protected RelNode visitChildren(RelNode rel) {
+    var inputs = rel.getInputs().stream().map(input -> input.accept(this)).toList();
+    return copy(rel, inputs).accept(rexCopier);
+  }
+
+  @Override
+  public RelNode visit(TableScan scan) {
+    if (scan instanceof LogicalTableScan logicalScan) {
+      return new LogicalTableScan(
+          cluster, scan.getTraitSet(), logicalScan.getHints(), scan.getTable());
+    }
+    return scan;
+  }
+
+  @Override
+  public RelNode visit(LogicalValues values) {
+    return visitChildren(values);
+  }
+
+  private RelNode copy(RelNode rel, List<RelNode> inputs) {
+    var traitSet = rel.getTraitSet();
+    if (rel instanceof LogicalCorrelate correlate) {
+      return correlate.copy(
+          traitSet,
+          inputs.get(0),
+          inputs.get(1),
+          shift(correlate.getCorrelationId()),
+          correlate.getRequiredColumns(),
+          correlate.getJoinType());
+    } else if (rel instanceof LogicalFilter filter) {
+      return new LogicalFilter(
+          cluster,
+          traitSet,
+          filter.getHints(),
+          inputs.get(0),
+          filter.getCondition(),
+          shift(filter.getVariablesSet()));
+    } else if (rel instanceof LogicalProject project) {
+      return new LogicalProject(
+          cluster,
+          traitSet,
+          project.getHints(),
+          inputs.get(0),
+          project.getProjects(),
+          project.getRowType(),
+          shift(project.getVariablesSet()));
+    } else if (rel instanceof LogicalJoin join) {
+      return new LogicalJoin(
+          cluster,
+          traitSet,
+          join.getHints(),
+          inputs.get(0),
+          inputs.get(1),
+          join.getCondition(),
+          shift(join.getVariablesSet()),
+          join.getJoinType(),
+          join.isSemiJoinDone(),
+          ImmutableList.copyOf(join.getSystemFieldList()));
+    }
+    return rel.copy(traitSet, inputs);
+  }
+
+  private static class CorrelationIdCollector extends RelShuttleImpl {
+
+    private final Set<Integer> ids = new HashSet<>();
+    private final RexShuttle rexCollector =
+        new RexShuttle() {
+          @Override
+          public RexNode visitCorrelVariable(RexCorrelVariable variable) {
+            ids.add(variable.id.getId());
+            return variable;
+          }
+
+          @Override
+          public RexNode visitSubQuery(RexSubQuery subQuery) {
+            subQuery.rel.accept(CorrelationIdCollector.this);
+            return super.visitSubQuery(subQuery);
+          }
+        };
+
+    private void collect(RelNode rel) {
+      rel.getVariablesSet().forEach(id -> ids.add(id.getId()));
+      rel.accept(rexCollector);
+    }
+
+    @Override
+    protected RelNode visitChild(RelNode parent, int i, RelNode child) {
+      return visitChildren(parent);
+    }
+
+    @Override
+    protected RelNode visitChildren(RelNode rel) {
+      collect(rel);
+      rel.getInputs().forEach(input -> input.accept(this));
+      return rel;
+    }
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/util/ViewQueryOperation.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/util/ViewQueryOperation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner.util;
+
+import java.util.function.Supplier;
+import org.apache.calcite.rel.RelNode;
+import org.apache.flink.table.planner.operations.PlannerQueryOperation;
+
+/** Backs a catalog view with its planned tree, handing out a fresh copy per reference. */
+public class ViewQueryOperation extends PlannerQueryOperation {
+
+  public ViewQueryOperation(RelNode calciteTree, Supplier<String> toSqlString) {
+    super(calciteTree, toSqlString);
+  }
+
+  @Override
+  public RelNode getCalciteTree() {
+    return RelNodeCopier.copy(super.getCalciteTree());
+  }
+}


### PR DESCRIPTION
## Summary
- Views were registered as text `CatalogView`s, so Flink's `FlinkCalciteCatalogReader` re-parsed, re-validated and re-converted the whole upstream view chain (depth up to 15 in real projects) on every reference, and `addView` validated each view twice (`getOperation` plus `analyzeView`).
- `addView` now analyses once and registers `QueryOperationCatalogView(ViewQueryOperation(relNode))`; the second parse and `getOperation` are gone for views.
- `RelNodeCopier` gives Flink a fresh tree with shifted correlation ids per reference: Flink's block splitting keys on RelNode identity, and sharing the analysed tree broke rowtime typing across blocks. `ViewAnalysis` keeps the raw RelNode next to the normalized one.

## Benchmark
Warm in-process compiles (compiler loaded once, then compiled repeatedly in the same JVM), cloud-backend `core`, `agent` and `metrics` with `package.json package-test-static.json`, 5 cycles each, control = unmodified `main`. Deterministic artifacts (`flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json`, `database-schema.sql`) identical to control in every cycle.

| module | control p50 / p80 | this PR p50 / p80 | p50 gain |
|---|---|---|---|
| core | 17.16 s / 17.29 s | 9.93 s / 11.27 s | -42% |
| agent | 1.48 s / 2.66 s | 1.20 s / 2.07 s | -18% |
| metrics | 26.04 s / 26.42 s | 19.52 s / 20.04 s | -25% |

## Test plan
- [x] `TableAnalysisLookupTest` 3/3
- [x] `DAGPlannerTest`: 88 pass, 13 differ only by `$cor` renumbering inside the Calcite logical plans of `pipeline_explain.txt` (the discarded conversion no longer consumes ids); generated SQL unchanged. Snapshots not regenerated yet, so CI will flag those 13 until they are.
- [x] cloud-backend core: SQL, schemas, `pipeline_explain.txt` byte-identical to main; compiled plan differs only in `coalesce` casing inside description strings and one correlation id
- [ ] CI