### PR TITLE
perf: resolve ON CONFLICT clauses inside the single Flink statement-set optimization

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictPlanner.java
@@ -72,12 +72,12 @@ final class FlinkInsertConflictPlanner {
       TableAnalysis table,
       boolean isUpsertSink) {
 
-    var explicitBehavior =
-        isUpsertSink
-            ? table
-                .getInsertConflictBehavior()
-                .map(FlinkInsertConflictPlanner::toSqlConflictBehavior)
-            : Optional.<SqlInsertConflictBehavior>empty();
+    var explicitBehavior = Optional.<SqlInsertConflictBehavior>empty();
+    if (isUpsertSink) {
+      explicitBehavior =
+          table.getInsertConflictBehavior().map(FlinkInsertConflictPlanner::toSqlConflictBehavior);
+    }
+
     if (!isUpsertSink || explicitBehavior.isPresent()) {
       planBuilder.addInsert(FlinkSqlNodes.createInsert(selectQuery, sinkTableId, explicitBehavior));
       return;
@@ -118,7 +118,7 @@ final class FlinkInsertConflictPlanner {
             conflictProgram.registerSink(pendingInsert.targetTableId(), pendingInsert.fallback()));
 
     try {
-      var compiledPlan = (ExecNodeGraphInternalPlan) getPlanner().compilePlan(operations);
+      var compiledPlan = (ExecNodeGraphInternalPlan) getPlannerBase().compilePlan(operations);
       pendingInserts.forEach(
           pendingInsert ->
               replaceInsert(
@@ -134,7 +134,8 @@ final class FlinkInsertConflictPlanner {
   }
 
   private List<ModifyOperation> toModifyOperations(List<RichSqlInsert> inserts) {
-    var flinkPlanner = getPlanner().createFlinkPlanner();
+    var flinkPlanner = getPlannerBase().createFlinkPlanner();
+
     return inserts.stream()
         .map(FlinkSqlNodes::copyInsert)
         .map(insert -> toModifyOperation(flinkPlanner, insert))
@@ -147,7 +148,7 @@ final class FlinkInsertConflictPlanner {
             .orElseThrow(() -> new TableException("Unsupported query: " + insert));
   }
 
-  private PlannerBase getPlanner() {
+  private PlannerBase getPlannerBase() {
     return (PlannerBase) tEnv.getPlanner();
   }
 

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictPlanner.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictPlanner.java
@@ -23,16 +23,13 @@ import com.datasqrl.planner.analyzer.TableOrFunctionAnalysis;
 import com.datasqrl.planner.tables.SourceSinkTableAnalysis;
 import com.datasqrl.planner.tables.SqrlTableFunction;
 import com.datasqrl.util.FlinkCompileException;
-import com.google.common.collect.Streams;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.sql.parser.dml.SqlStatementSet;
@@ -42,191 +39,97 @@ import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImp
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedSchema;
-import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.operations.SqlNodeToOperationConversion;
 import org.apache.flink.table.planner.plan.ExecNodeGraphInternalPlan;
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
-import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils;
-import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
-import org.apache.flink.types.RowKind;
 
 /**
- * Resolves generated Flink {@code ON CONFLICT} clauses from the optimized sink plans: insert-only
- * sinks get no clause, and sinks whose upsert key is not contained in the primary key get the
- * clause the forked Flink planner requires.
+ * Resolves generated Flink {@code ON CONFLICT} clauses while the statement set is compiled: the
+ * {@link FlinkInsertConflictProgram} installed in the stream optimizer derives each clause from the
+ * optimized sink plan, and the generated inserts are rewritten with the resolved clauses
+ * afterwards.
  */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class FlinkInsertConflictPlanner {
 
   private final List<PendingInsert> pendingInserts = new ArrayList<>();
 
-  private final RuntimeExecutionMode executionMode;
   private final StreamTableEnvironmentImpl tEnv;
   private final Builder planBuilder;
 
-  /** Adds a generated insert and registers upsert-capable sinks for post-planning resolution. */
+  @Getter
+  private final FlinkInsertConflictProgram conflictProgram = new FlinkInsertConflictProgram();
+
+  /**
+   * Adds a generated insert. Explicit conflict behavior is applied immediately; other
+   * upsert-capable sinks are registered for resolution from the optimized plan.
+   */
   void addInsert(
       SqlNode selectQuery,
       ObjectIdentifier sinkTableId,
       TableAnalysis table,
       boolean isUpsertSink) {
 
-    var insert = FlinkSqlNodes.createInsert(selectQuery, sinkTableId);
-    if (!isUpsertSink) {
-      planBuilder.addInsert(insert);
+    var explicitBehavior =
+        isUpsertSink
+            ? table
+                .getInsertConflictBehavior()
+                .map(FlinkInsertConflictPlanner::toSqlConflictBehavior)
+            : Optional.<SqlInsertConflictBehavior>empty();
+    if (!isUpsertSink || explicitBehavior.isPresent()) {
+      planBuilder.addInsert(FlinkSqlNodes.createInsert(selectQuery, sinkTableId, explicitBehavior));
       return;
     }
 
     var batchIdx = planBuilder.currentBatch();
-    var insertIdx = planBuilder.addInsert(insert);
-    pendingInserts.add(new PendingInsert(selectQuery, sinkTableId, table, batchIdx, insertIdx));
+    var insertIdx = planBuilder.addInsert(FlinkSqlNodes.createInsert(selectQuery, sinkTableId));
+    pendingInserts.add(
+        new PendingInsert(
+            selectQuery, sinkTableId, automaticConflictBehavior(table), batchIdx, insertIdx));
   }
 
-  /**
-   * Replaces generated inserts with conflict behavior derived from each Flink-optimized sink plan.
-   */
+  /** Applies the automatic conflict behavior to plans that are not compiled by Flink. */
   void resolve() {
-    if (pendingInserts.isEmpty()) {
-      return;
-    }
-
-    // Sink planning inspects StreamPhysicalSink, which is not used for batch plans.
-    var plannedSinks =
-        executionMode == RuntimeExecutionMode.STREAMING
-            ? planSinks()
-            : Collections.nCopies(pendingInserts.size(), Optional.<StreamPhysicalSink>empty());
-
-    Streams.forEachPair(
-        pendingInserts.stream(),
-        plannedSinks.stream(),
-        (pendingInsert, plannedSink) -> {
-          var conflictBehavior = resolveConflictBehavior(pendingInsert.table(), plannedSink);
-
-          planBuilder.replaceInsert(
-              pendingInsert.batchIdx(),
-              pendingInsert.insertIdx(),
-              FlinkSqlNodes.createInsert(
-                  pendingInsert.selectQuery(), pendingInsert.targetTableId(), conflictBehavior));
-        });
+    pendingInserts.forEach(pendingInsert -> replaceInsert(pendingInsert, pendingInsert.fallback()));
   }
 
   boolean hasPendingInserts() {
     return !pendingInserts.isEmpty();
   }
 
-  /** Compiles the generated statement set. */
+  /**
+   * Compiles the generated statement set once and rewrites the pending inserts with the conflict
+   * clauses resolved during that optimization. The fork's upsert-key validation is disabled for the
+   * pass since the pending inserts carry no clause yet; the program re-validates the other sinks.
+   */
   ExecNodeGraphInternalPlan compilePlan() {
     var execute = planBuilder.getExecuteStatements();
     var inserts = ((SqlStatementSet) execute.get(0).getStatement()).getInserts();
     var operations = toModifyOperations(inserts);
 
-    try {
-      return (ExecNodeGraphInternalPlan) getPlanner().compilePlan(operations);
-    } catch (Exception e) {
-      throw new FlinkCompileException(withStatements(RelToFlinkSql.convertToSqlString(execute)), e);
-    }
-  }
-
-  /**
-   * Preserves explicit behavior and otherwise derives the clause from the optimized sink plan,
-   * mirroring the forked Flink planner's validation: append and retract sinks reject the clause,
-   * upsert sinks whose primary key does not contain the upsert key require one (falling back to
-   * {@code DO NOTHING}), and insert-only inputs need none.
-   */
-  Optional<SqlInsertConflictBehavior> resolveConflictBehavior(
-      TableAnalysis table, Optional<StreamPhysicalSink> plannedSink) {
-
-    if (table.getInsertConflictBehavior().isPresent()) {
-      return table
-          .getInsertConflictBehavior()
-          .map(FlinkInsertConflictPlanner::toSqlConflictBehavior);
-    }
-
-    if (plannedSink.isEmpty()) {
-      // Batch plans have no stream-physical sink and no conflict validation in the fork.
-      return automaticConflictBehavior(table);
-    }
-
-    var sink = plannedSink.get();
-    var inputMode = inputChangelogMode(sink).orElse(ChangelogMode.all());
-    var sinkMode = sink.tableSink().getChangelogMode(inputMode);
-    if (sinkMode.containsOnly(RowKind.INSERT)) {
-      return Optional.empty();
-    }
-
-    if (!sink.primaryKeysContainsUpsertKey()) {
-      return automaticConflictBehavior(table)
-          .or(() -> Optional.of(SqlInsertConflictBehavior.NOTHING));
-    }
-
-    if (sinkMode.contains(RowKind.UPDATE_BEFORE)) {
-      return Optional.empty();
-    }
-
-    return inputMode.containsOnly(RowKind.INSERT)
-        ? Optional.empty()
-        : automaticConflictBehavior(table);
-  }
-
-  /**
-   * Plans the pending inserts without conflict clauses and returns their optimized sink nodes. The
-   * fork's upsert-key validation is disabled during planning since this pass determines the very
-   * clauses that validation requires.
-   */
-  private List<Optional<StreamPhysicalSink>> planSinks() {
     var config = tEnv.getConfig();
     var requireOnConflict = config.get(ExecutionConfigOptions.TABLE_EXEC_SINK_REQUIRE_ON_CONFLICT);
     config.set(ExecutionConfigOptions.TABLE_EXEC_SINK_REQUIRE_ON_CONFLICT, false);
+    conflictProgram.setRequireOnConflict(requireOnConflict);
+    pendingInserts.forEach(
+        pendingInsert ->
+            conflictProgram.registerSink(pendingInsert.targetTableId(), pendingInsert.fallback()));
 
     try {
-      var insertOperations =
-          toModifyOperations(
-              pendingInserts.stream()
-                  .map(
-                      insert ->
-                          FlinkSqlNodes.createInsert(insert.selectQuery(), insert.targetTableId()))
-                  .toList());
-
-      var optimizedPlans = optimize(insertOperations);
-
-      var plannedSinks = new ArrayList<Optional<StreamPhysicalSink>>();
-      var iterator = optimizedPlans.iterator();
-      for (var pendingInsert : pendingInserts) {
-        if (!iterator.hasNext()) {
-          throw new IllegalStateException(
-              "Missing optimized plan for INSERT INTO " + pendingInsert.targetTableId());
-        }
-
-        var plan = iterator.next();
-        plannedSinks.add(
-            plan instanceof StreamPhysicalSink plannedSink
-                ? Optional.of(plannedSink)
-                : Optional.empty());
-      }
-
-      return plannedSinks;
+      var compiledPlan = (ExecNodeGraphInternalPlan) getPlanner().compilePlan(operations);
+      pendingInserts.forEach(
+          pendingInsert ->
+              replaceInsert(
+                  pendingInsert, conflictProgram.resolvedBehavior(pendingInsert.targetTableId())));
+      return compiledPlan;
 
     } catch (Exception e) {
-      throw new FlinkCompileException(planBuilder.getFlinkSql(), e);
+      throw new FlinkCompileException(withStatements(RelToFlinkSql.convertToSqlString(execute)), e);
 
     } finally {
       config.set(ExecutionConfigOptions.TABLE_EXEC_SINK_REQUIRE_ON_CONFLICT, requireOnConflict);
-    }
-  }
-
-  private List<RelNode> optimize(List<ModifyOperation> insertOperations) {
-    var planner = getPlanner();
-    planner.beforeTranslation();
-    try {
-      var relNodes = insertOperations.stream().map(planner::translateToRel).toList();
-      return JavaScalaConversionUtil.toJava(
-          planner.optimize(JavaScalaConversionUtil.toScala(relNodes)));
-    } finally {
-      planner.afterTranslation();
     }
   }
 
@@ -248,21 +151,20 @@ final class FlinkInsertConflictPlanner {
     return (PlannerBase) tEnv.getPlanner();
   }
 
+  private void replaceInsert(
+      PendingInsert pendingInsert, Optional<SqlInsertConflictBehavior> conflictBehavior) {
+
+    planBuilder.replaceInsert(
+        pendingInsert.batchIdx(),
+        pendingInsert.insertIdx(),
+        FlinkSqlNodes.createInsert(
+            pendingInsert.selectQuery(), pendingInsert.targetTableId(), conflictBehavior));
+  }
+
   private List<String> withStatements(List<String> statements) {
     var flinkSql = new ArrayList<>(planBuilder.getFlinkSql());
     flinkSql.addAll(statements);
     return flinkSql;
-  }
-
-  private static Optional<ChangelogMode> inputChangelogMode(StreamPhysicalSink plannedSink) {
-    if (plannedSink.getInput() instanceof StreamPhysicalRel input) {
-      var changelogMode = ChangelogPlanUtils.getChangelogMode(input);
-      if (changelogMode.isDefined()) {
-        return Optional.of(changelogMode.get());
-      }
-    }
-
-    return Optional.empty();
   }
 
   private static Optional<SqlInsertConflictBehavior> automaticConflictBehavior(
@@ -316,7 +218,7 @@ final class FlinkInsertConflictPlanner {
   private record PendingInsert(
       SqlNode selectQuery,
       ObjectIdentifier targetTableId,
-      TableAnalysis table,
+      Optional<SqlInsertConflictBehavior> fallback,
       int batchIdx,
       int insertIdx) {}
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictProgram.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictProgram.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.calcite.rel.RelNode;
+import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
+import org.apache.flink.table.api.InsertConflictStrategy;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.ExecutionConfigOptions.UpsertMaterialize;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.trait.ModifyKindSetTraitDef;
+import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils;
+import org.apache.flink.types.RowKind;
+
+/**
+ * Runs right after the forked Flink planner's changelog mode inference and resolves the {@code ON
+ * CONFLICT} clause of each registered sink from the inferred sink plan, so that the statement set
+ * is optimized only once. It applies the fork's clause validation and upsert-materialize rule to
+ * the resolved clause and re-validates the sinks the fork could not check while the pending sinks
+ * were planned without a clause.
+ */
+final class FlinkInsertConflictProgram implements FlinkOptimizeProgram<StreamOptimizeContext> {
+
+  private final Map<ObjectIdentifier, Optional<SqlInsertConflictBehavior>> fallbacks =
+      new HashMap<>();
+  private final Map<ObjectIdentifier, Optional<SqlInsertConflictBehavior>> resolved =
+      new HashMap<>();
+  private boolean requireOnConflict =
+      ExecutionConfigOptions.TABLE_EXEC_SINK_REQUIRE_ON_CONFLICT.defaultValue();
+
+  void registerSink(ObjectIdentifier sinkTableId, Optional<SqlInsertConflictBehavior> fallback) {
+    fallbacks.put(sinkTableId, fallback);
+  }
+
+  void setRequireOnConflict(boolean requireOnConflict) {
+    this.requireOnConflict = requireOnConflict;
+  }
+
+  Optional<SqlInsertConflictBehavior> resolvedBehavior(ObjectIdentifier sinkTableId) {
+    var behavior = resolved.get(sinkTableId);
+    if (behavior == null) {
+      throw new IllegalStateException("Missing optimized plan for INSERT INTO " + sinkTableId);
+    }
+
+    return behavior;
+  }
+
+  @Override
+  public RelNode optimize(RelNode root, StreamOptimizeContext context) {
+    if (!(root instanceof StreamPhysicalSink sink)) {
+      return root;
+    }
+
+    var sinkTableId = sink.contextResolvedTable().getIdentifier();
+    var fallback = fallbacks.get(sinkTableId);
+    if (fallback == null) {
+      requireConflictClause(sink, context);
+      return root;
+    }
+
+    var behavior = resolveConflictBehavior(sink, fallback);
+    resolved.put(sinkTableId, behavior);
+    if (behavior.isEmpty()) {
+      return root;
+    }
+
+    var strategy = toConflictStrategy(behavior.get());
+    validateUpsertSink(sink);
+    if (strategy.getBehavior() != InsertConflictStrategy.ConflictBehavior.DEDUPLICATE) {
+      validateSourcesHaveWatermarks(sink, strategy);
+    }
+
+    var upsertMaterialize =
+        sink.upsertMaterialize()
+            && !(materializeMode(context) == UpsertMaterialize.AUTO
+                && inferredInputMode(sink).containsOnly(RowKind.INSERT)
+                && strategy.getBehavior() == InsertConflictStrategy.ConflictBehavior.DEDUPLICATE);
+
+    return new StreamPhysicalSink(
+        sink.getCluster(),
+        sink.getTraitSet(),
+        sink.getInput(),
+        sink.hints(),
+        sink.contextResolvedTable(),
+        sink.tableSink(),
+        sink.targetColumns(),
+        sink.abilitySpecs(),
+        upsertMaterialize,
+        strategy);
+  }
+
+  /**
+   * Derives the clause from the optimized sink plan: append and retract sinks reject the clause,
+   * upsert sinks whose primary key does not contain the upsert key require one (falling back to
+   * {@code DO NOTHING}), and insert-only inputs need none.
+   */
+  static Optional<SqlInsertConflictBehavior> resolveConflictBehavior(
+      StreamPhysicalSink sink, Optional<SqlInsertConflictBehavior> fallback) {
+
+    var inputMode = inputChangelogMode(sink).orElse(ChangelogMode.all());
+    var sinkMode = sink.tableSink().getChangelogMode(inputMode);
+    if (sinkMode.containsOnly(RowKind.INSERT)) {
+      return Optional.empty();
+    }
+
+    if (!sink.primaryKeysContainsUpsertKey()) {
+      return fallback.or(() -> Optional.of(SqlInsertConflictBehavior.NOTHING));
+    }
+
+    if (sinkMode.contains(RowKind.UPDATE_BEFORE)) {
+      return Optional.empty();
+    }
+
+    return inputMode.containsOnly(RowKind.INSERT) ? Optional.empty() : fallback;
+  }
+
+  private void requireConflictClause(StreamPhysicalSink sink, StreamOptimizeContext context) {
+    if (!requireOnConflict
+        || sink.conflictStrategy() != null
+        || materializeMode(context) != UpsertMaterialize.AUTO
+        || sink.contextResolvedTable().getResolvedSchema().getPrimaryKeyIndexes().length == 0) {
+      return;
+    }
+
+    var sinkMode = sink.tableSink().getChangelogMode(inferredInputMode(sink));
+    if (sinkMode.containsOnly(RowKind.INSERT)
+        || sinkMode.contains(RowKind.UPDATE_BEFORE)
+        || sink.primaryKeysContainsUpsertKey()) {
+      return;
+    }
+
+    throw new ValidationException(
+        "The query has an upsert key that differs from the primary key of the sink table '"
+            + sink.contextResolvedTable().getIdentifier().asSummaryString()
+            + "'. Primary key: "
+            + sink.getPrimaryKeyNames()
+            + ", upsert key: "
+            + sink.getUpsertKeyNames()
+            + ". This can lead to non-deterministic results when multiple records with different "
+            + "upsert keys map to the same primary key. "
+            + "Please specify an ON CONFLICT clause to define how conflicts should be handled: "
+            + "ON CONFLICT DO DEDUPLICATE (update to the latest record, state intensive, since we"
+            + " need to keep the entire history), or "
+            + "ON CONFLICT DO ERROR (fail on conflict), or "
+            + "ON CONFLICT DO NOTHING (keep first record).");
+  }
+
+  private static void validateUpsertSink(StreamPhysicalSink sink) {
+    var sinkMode = sink.tableSink().getChangelogMode(inferredInputMode(sink));
+    String reason;
+    if (sinkMode.containsOnly(RowKind.INSERT)) {
+      reason = "it only accepts INSERT (append-only) changes";
+    } else if (sinkMode.contains(RowKind.UPDATE_BEFORE)) {
+      reason = "it requires UPDATE_BEFORE (retract mode)";
+    } else {
+      return;
+    }
+
+    throw new ValidationException(
+        "ON CONFLICT clause is only allowed for upsert sinks. The sink '"
+            + sink.contextResolvedTable().getIdentifier().asSummaryString()
+            + "' is not an upsert sink because "
+            + reason
+            + ".");
+  }
+
+  private static void validateSourcesHaveWatermarks(
+      StreamPhysicalSink sink, InsertConflictStrategy strategy) {
+
+    var sourcesWithoutWatermarks = new ArrayList<String>();
+    collectSourcesWithoutWatermarks(sink.getInput(), sourcesWithoutWatermarks);
+    if (sourcesWithoutWatermarks.isEmpty()) {
+      return;
+    }
+
+    throw new ValidationException(
+        "ON CONFLICT DO "
+            + strategy.getBehavior()
+            + " requires all source tables to define watermarks, but the following source(s) do"
+            + " not: "
+            + String.join(", ", sourcesWithoutWatermarks)
+            + ". Please add a WATERMARK declaration to these tables.");
+  }
+
+  private static void collectSourcesWithoutWatermarks(RelNode rel, List<String> result) {
+    if (rel instanceof StreamPhysicalTableSourceScan scan) {
+      var table = scan.getTable().unwrap(TableSourceTable.class);
+      if (table != null
+          && table.contextResolvedTable().getResolvedSchema().getWatermarkSpecs().isEmpty()) {
+        result.add(table.contextResolvedTable().getIdentifier().asSummaryString());
+      }
+      return;
+    }
+
+    rel.getInputs().forEach(input -> collectSourcesWithoutWatermarks(input, result));
+  }
+
+  private static ChangelogMode inferredInputMode(StreamPhysicalSink sink) {
+    return sink.getInput()
+        .getTraitSet()
+        .getTrait(ModifyKindSetTraitDef.INSTANCE())
+        .modifyKindSet()
+        .toChangelogModeBuilder()
+        .build();
+  }
+
+  private static UpsertMaterialize materializeMode(StreamOptimizeContext context) {
+    return context.getTableConfig().get(ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE);
+  }
+
+  private static Optional<ChangelogMode> inputChangelogMode(StreamPhysicalSink sink) {
+    if (sink.getInput() instanceof StreamPhysicalRel input) {
+      var changelogMode = ChangelogPlanUtils.getChangelogMode(input);
+      if (changelogMode.isDefined()) {
+        return Optional.of(changelogMode.get());
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private static InsertConflictStrategy toConflictStrategy(SqlInsertConflictBehavior behavior) {
+    return switch (behavior) {
+      case ERROR -> InsertConflictStrategy.error();
+      case NOTHING -> InsertConflictStrategy.nothing();
+      case DEDUPLICATE -> InsertConflictStrategy.deduplicate();
+    };
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictProgram.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkInsertConflictProgram.java
@@ -49,8 +49,10 @@ final class FlinkInsertConflictProgram implements FlinkOptimizeProgram<StreamOpt
 
   private final Map<ObjectIdentifier, Optional<SqlInsertConflictBehavior>> fallbacks =
       new HashMap<>();
+
   private final Map<ObjectIdentifier, Optional<SqlInsertConflictBehavior>> resolved =
       new HashMap<>();
+
   private boolean requireOnConflict =
       ExecutionConfigOptions.TABLE_EXEC_SINK_REQUIRE_ON_CONFLICT.defaultValue();
 

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
@@ -30,6 +30,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.PlannerConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfigBuilder;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkChangelogModeInferenceProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkGroupProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
@@ -49,7 +50,7 @@ import scala.Tuple2;
 @Slf4j
 public class FlinkPlannerConfigBuilder {
 
-  /** We do not touch these programs. */
+  /** We do not strip rules from these programs. */
   private static final Set<String> IGNORED_PROGRAMS =
       Set.of(
           FlinkStreamProgram.DECORRELATE(),
@@ -101,10 +102,11 @@ public class FlinkPlannerConfigBuilder {
   private final CompilerConfig compilerConfig;
   private final SqrlFunctionCatalog sqrlFunctionCatalog;
   private final Configuration flinkConfig;
+  private final FlinkOptimizeProgram<StreamOptimizeContext> insertConflictProgram;
 
   @VisibleForTesting
   public FlinkPlannerConfigBuilder(CompilerConfig compilerConfig, Configuration flinkConfig) {
-    this(compilerConfig, null, flinkConfig);
+    this(compilerConfig, null, flinkConfig, null);
   }
 
   public PlannerConfig build() {
@@ -113,7 +115,8 @@ public class FlinkPlannerConfigBuilder {
       calciteConfigBuilder.addSqlOperatorTable(sqrlFunctionCatalog.getOperatorTable());
     }
 
-    if (compilerConfig.predicatePushdownRules() != PredicatePushdownRules.DEFAULT) {
+    if (compilerConfig.predicatePushdownRules() != PredicatePushdownRules.DEFAULT
+        || insertConflictProgram != null) {
       var streamProgram = buildCustomStreamProgram(compilerConfig.predicatePushdownRules());
       calciteConfigBuilder.replaceStreamProgram(streamProgram);
     }
@@ -129,6 +132,11 @@ public class FlinkPlannerConfigBuilder {
 
     for (var programName : origStreamProgram.getProgramNames()) {
       var program = origStreamProgram.get(programName).get();
+
+      if (programName.equals(FlinkStreamProgram.PHYSICAL_REWRITE())
+          && insertConflictProgram != null) {
+        addAfterChangelogModeInference(program, insertConflictProgram);
+      }
 
       // Programs that can be ignored.
       if (IGNORED_PROGRAMS.contains(programName)) {
@@ -153,6 +161,21 @@ public class FlinkPlannerConfigBuilder {
     }
 
     return customStreamProgram;
+  }
+
+  private void addAfterChangelogModeInference(
+      FlinkOptimizeProgram<StreamOptimizeContext> physicalRewrite,
+      FlinkOptimizeProgram<StreamOptimizeContext> program) {
+
+    var programs = extractGroupPrograms(physicalRewrite);
+    for (int i = 0; i < programs.size(); i++) {
+      if (programs.get(i)._1 instanceof FlinkChangelogModeInferenceProgram) {
+        programs.add(i + 1, new Tuple2<>(program, "insert conflict resolution"));
+        return;
+      }
+    }
+
+    throw new IllegalStateException("Stream program has no changelog mode inference");
   }
 
   private void removeTableSourceScanRules(

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -216,7 +216,7 @@ public class Sqrl2FlinkSQLTranslator {
             .withClassLoader(udfClassLoader)
             .build();
     this.tEnv = (StreamTableEnvironmentImpl) StreamTableEnvironment.create(sEnv, tEnvSettings);
-    this.insertConflictPlanner = new FlinkInsertConflictPlanner(executionMode, tEnv, planBuilder);
+    this.insertConflictPlanner = new FlinkInsertConflictPlanner(tEnv, planBuilder);
 
     // Extract a number of classes we need access to for planning
     this.validatorSupplier = ((PlannerBase) tEnv.getPlanner())::createFlinkPlanner;
@@ -228,7 +228,11 @@ public class Sqrl2FlinkSQLTranslator {
     sqrlFunctionCatalog = new SqrlFunctionCatalog(typeFactory);
 
     var plannerConfigBuilder =
-        new FlinkPlannerConfigBuilder(compilerConfig, sqrlFunctionCatalog, planBuilder.getConfig());
+        new FlinkPlannerConfigBuilder(
+            compilerConfig,
+            sqrlFunctionCatalog,
+            planBuilder.getConfig(),
+            insertConflictPlanner.getConflictProgram());
     this.tEnv.getConfig().setPlannerConfig(plannerConfigBuilder.build());
     this.catalogManager = tEnv.getCatalogManager();
 
@@ -264,14 +268,11 @@ public class Sqrl2FlinkSQLTranslator {
    * @return
    */
   public FlinkPhysicalPlan compileFlinkPlan() {
-    insertConflictPlanner.resolve();
     var execute = planBuilder.getExecuteStatements();
 
     if (executionMode != RuntimeExecutionMode.BATCH && execute.size() > 1) {
       throw new UnsupportedOperationException("Multiple batches are only supported in BATCH mode");
     }
-
-    var insert = RelToFlinkSql.convertToSqlString(execute);
 
     var compiledPlan = Optional.<ExecNodeGraphInternalPlan>empty();
     if (executionMode == RuntimeExecutionMode.STREAMING
@@ -281,9 +282,12 @@ public class Sqrl2FlinkSQLTranslator {
       if (compileFlinkPlan) {
         compiledPlan = Optional.of(finalPlan);
       }
-      execute = planBuilder.getExecuteStatements();
-      insert = RelToFlinkSql.convertToSqlString(execute);
+    } else {
+      insertConflictPlanner.resolve();
     }
+
+    execute = planBuilder.getExecuteStatements();
+    var insert = RelToFlinkSql.convertToSqlString(execute);
 
     planBuilder.add(execute, insert);
     return planBuilder.build(compiledPlan);

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkInsertConflictPlannerTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkInsertConflictPlannerTest.java
@@ -20,12 +20,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.datasqrl.config.PackageJson.CompilerConfig;
 import com.datasqrl.engine.stream.flink.FlinkCalciteParser;
 import com.datasqrl.engine.stream.flink.sql.RelToFlinkSql;
 import com.datasqrl.io.tables.TableType;
 import com.datasqrl.planner.analyzer.TableAnalysis;
 import java.util.Optional;
-import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.sql.parser.dml.SqlInsertConflictBehavior;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Exercises conflict-clause resolution against the real Flink planner: an updating query whose
  * upsert key is not contained in the sink primary key must receive an {@code ON CONFLICT} clause,
- * insert-only queries must not, and the resulting statement set must compile without retries.
+ * insert-only queries must not, and the clauses must be resolved by the single compilation pass.
  */
 class FlinkInsertConflictPlannerTest {
 
@@ -65,8 +65,14 @@ class FlinkInsertConflictPlannerTest {
             StreamTableEnvironment.create(
                 sEnv, EnvironmentSettings.newInstance().inStreamingMode().build());
     planBuilder = new FlinkPhysicalPlan.Builder(new Configuration());
-    conflictPlanner =
-        new FlinkInsertConflictPlanner(RuntimeExecutionMode.STREAMING, tEnv, planBuilder);
+    conflictPlanner = new FlinkInsertConflictPlanner(tEnv, planBuilder);
+    var compilerConfig = mock(CompilerConfig.class);
+    when(compilerConfig.predicatePushdownRules()).thenReturn(PredicatePushdownRules.DEFAULT);
+    tEnv.getConfig()
+        .setPlannerConfig(
+            new FlinkPlannerConfigBuilder(
+                    compilerConfig, null, new Configuration(), conflictPlanner.getConflictProgram())
+                .build());
 
     tEnv.executeSql(
         """
@@ -80,15 +86,15 @@ class FlinkInsertConflictPlannerTest {
   }
 
   @Test
-  void givenUpsertKeyNotInSinkPrimaryKey_whenResolve_thenAddsRequiredConflictClause() {
+  void givenUpsertKeyNotInSinkPrimaryKey_whenCompile_thenAddsRequiredConflictClause() {
     // Upsert key [name] is not contained in the sink primary key [cnt]; the RELATION type has no
     // automatic behavior, so the required clause falls back to DO NOTHING.
     addInsert(aggregateQuery(), MISMATCH_SINK, table(TableType.RELATION));
 
-    conflictPlanner.resolve();
+    var compiledPlan = conflictPlanner.compilePlan();
 
     assertThat(insertSql(0)).contains("ON CONFLICT DO NOTHING");
-    assertThat(conflictPlanner.compilePlan()).isNotNull();
+    assertThat(compiledPlan.asJsonString()).contains("\"conflictStrategy\"");
   }
 
   @Test
@@ -100,7 +106,9 @@ class FlinkInsertConflictPlannerTest {
     when(tableSink.getChangelogMode(any(ChangelogMode.class)))
         .thenReturn(ChangelogMode.newBuilder().addContainedKind(RowKind.UPDATE_BEFORE).build());
 
-    assertThat(conflictPlanner.resolveConflictBehavior(table(TableType.STREAM), Optional.of(sink)))
+    assertThat(
+            FlinkInsertConflictProgram.resolveConflictBehavior(
+                sink, Optional.of(SqlInsertConflictBehavior.DEDUPLICATE)))
         .contains(SqlInsertConflictBehavior.DEDUPLICATE);
   }
 
@@ -113,12 +121,14 @@ class FlinkInsertConflictPlannerTest {
     when(tableSink.getChangelogMode(any(ChangelogMode.class)))
         .thenReturn(ChangelogMode.insertOnly());
 
-    assertThat(conflictPlanner.resolveConflictBehavior(table(TableType.STREAM), Optional.of(sink)))
+    assertThat(
+            FlinkInsertConflictProgram.resolveConflictBehavior(
+                sink, Optional.of(SqlInsertConflictBehavior.DEDUPLICATE)))
         .isEmpty();
   }
 
   @Test
-  void givenInsertOnlyQueryWithUpsertKeyInPrimaryKey_whenResolve_thenOmitsConflictClause() {
+  void givenInsertOnlyQueryWithUpsertKeyInPrimaryKey_whenCompile_thenOmitsConflictClause() {
     // Keep-first rowtime deduplication stays insert-only and derives upsert key [name].
     var dedupQuery =
         """
@@ -127,43 +137,36 @@ class FlinkInsertConflictPlannerTest {
         ) WHERE rn = 1""";
     addInsert(dedupQuery, MATCHING_SINK, table(TableType.STREAM));
 
-    conflictPlanner.resolve();
-
-    assertThat(insertSql(0)).doesNotContain("ON CONFLICT");
     assertThat(conflictPlanner.compilePlan()).isNotNull();
+    assertThat(insertSql(0)).doesNotContain("ON CONFLICT");
   }
 
   @Test
-  void givenUpsertKeyContainedInSinkPrimaryKey_whenResolve_thenOmitsClauseForRelationTable() {
+  void givenUpsertKeyContainedInSinkPrimaryKey_whenCompile_thenOmitsClauseForRelationTable() {
     addInsert(aggregateQuery(), MATCHING_SINK, table(TableType.RELATION));
 
-    conflictPlanner.resolve();
-
-    assertThat(insertSql(0)).doesNotContain("ON CONFLICT");
     assertThat(conflictPlanner.compilePlan()).isNotNull();
+    assertThat(insertSql(0)).doesNotContain("ON CONFLICT");
   }
 
   @Test
-  void givenExplicitConflictBehavior_whenResolve_thenPreservesBehavior() {
+  void givenExplicitConflictBehavior_whenCompile_thenPreservesBehavior() {
     addInsert(
         aggregateQuery(),
         MISMATCH_SINK,
         table(TableType.RELATION, Optional.of(ConflictBehavior.DEDUPLICATE)));
 
-    conflictPlanner.resolve();
-
     assertThat(insertSql(0)).contains("ON CONFLICT DO DEDUPLICATE");
     assertThat(conflictPlanner.compilePlan()).isNotNull();
+    assertThat(insertSql(0)).contains("ON CONFLICT DO DEDUPLICATE");
   }
 
   @Test
-  void givenStateTableWithUpdatingQuery_whenResolve_thenDeduplicates() {
+  void givenStateTableWithUpdatingQuery_whenCompile_thenDeduplicates() {
     addInsert(aggregateQuery(), MATCHING_SINK, table(TableType.STATE));
 
-    conflictPlanner.resolve();
-
-    assertThat(insertSql(0)).contains("ON CONFLICT DO DEDUPLICATE");
     assertThat(conflictPlanner.compilePlan()).isNotNull();
+    assertThat(insertSql(0)).contains("ON CONFLICT DO DEDUPLICATE");
   }
 
   private void createJdbcSink(String name, String primaryKey) {


### PR DESCRIPTION
## Summary
- `FlinkInsertConflictPlanner` optimized the statement set twice: `planSinks` on the upsert subset to learn each sink's `ON CONFLICT` clause, then `compilePlan` on everything.
- New `FlinkInsertConflictProgram` sits in the stream program chain right after changelog mode inference; for each pending sink it resolves the conflict strategy from the inferred plan with the existing rules and returns a `StreamPhysicalSink` copy carrying it, so duplicate-changes inference, exec nodes and the compiled plan are produced natively.
- `compilePlan` runs once with `table.exec.sink.require-on-conflict` disabled (pending inserts have no clause yet); the program re-applies that check for non-pending sinks with the original messages. Resolved clauses are written back for `flink-sql.sql`. `planSinks` is removed.

## Benchmark
Warm in-process compiles (compiler loaded once, then compiled repeatedly in the same JVM), cloud-backend `core`, `agent` and `metrics` with `package.json package-test-static.json`, 5 cycles each, control = unmodified `main`. Deterministic artifacts (`flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json`, `database-schema.sql`) identical to control in every cycle.

| module | control p50 / p80 | this PR p50 / p80 | p50 gain |
|---|---|---|---|
| core | 17.16 s / 17.29 s | 13.56 s / 19.42 s | -21% |
| agent | 1.48 s / 2.66 s | 0.89 s / 2.34 s | -40% |
| metrics | 26.04 s / 26.42 s | 20.61 s / 21.04 s | -21% |

## Test plan
- [x] `FlinkInsertConflictPlannerTest` 7/7 (first test also asserts `conflictStrategy` in the compiled plan JSON)
- [x] `UseCaseCompileTest` 71/71, all `ON CONFLICT` snapshots unchanged
- [x] cloud-backend metrics: SQL and schemas byte-identical to main (18 `ON CONFLICT` clauses each); plan JSON identical after id normalization
- [ ] CI