### PR TITLE
perf: close UDF classloaders when a compile finishes

### DIFF
--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -64,12 +64,17 @@ public class CompilationProcess {
   private final ErrorCollector errors;
 
   public Pair<PhysicalPlan, TestPlan> executeCompilation(Optional<Path> testsPath) {
-
-    var environment =
+    try (var environment =
         new Sqrl2FlinkSQLTranslator(
             workspacePaths,
             (FlinkStreamEngine) planner.getStreamStage().engine(),
-            config.getCompilerConfig());
+            config.getCompilerConfig())) {
+      return executeCompilation(testsPath, environment);
+    }
+  }
+
+  private Pair<PhysicalPlan, TestPlan> executeCompilation(
+      Optional<Path> testsPath, Sqrl2FlinkSQLTranslator environment) {
     planner.planMain(mainScript, Optional.empty(), environment);
     var dagBuilder = planner.getDagBuilder();
     var dag = dagPlanner.optimize(dagBuilder.getDag());

--- a/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
+++ b/sqrl-cli/src/main/java/com/datasqrl/compile/CompilationProcess.java
@@ -69,12 +69,14 @@ public class CompilationProcess {
             workspacePaths,
             (FlinkStreamEngine) planner.getStreamStage().engine(),
             config.getCompilerConfig())) {
-      return executeCompilation(testsPath, environment);
+
+      return executeCompilationInternal(testsPath, environment);
     }
   }
 
-  private Pair<PhysicalPlan, TestPlan> executeCompilation(
+  private Pair<PhysicalPlan, TestPlan> executeCompilationInternal(
       Optional<Path> testsPath, Sqrl2FlinkSQLTranslator environment) {
+
     planner.planMain(mainScript, Optional.empty(), environment);
     var dagBuilder = planner.getDagBuilder();
     var dag = dagPlanner.optimize(dagBuilder.getDag());

--- a/sqrl-cli/src/test/java/com/datasqrl/util/SqrlInjectorTest.java
+++ b/sqrl-cli/src/test/java/com/datasqrl/util/SqrlInjectorTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -33,7 +34,7 @@ class SqrlInjectorTest {
     var scanned =
         new ClassPathScanningCandidateComponentProvider(true)
             .findCandidateComponents("com.datasqrl").stream()
-                .map(definition -> definition.getBeanClassName())
+                .map(BeanDefinition::getBeanClassName)
                 .filter(name -> !isConfiguration(name))
                 .collect(Collectors.toSet());
 

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PlannerComponents.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PlannerComponents.java
@@ -18,6 +18,7 @@ package com.datasqrl.config;
 import com.datasqrl.calcite.type.TypeFactory;
 import com.datasqrl.loaders.ClasspathFunctionLoader;
 import com.datasqrl.loaders.ModuleLoaders;
+import com.datasqrl.loaders.UdfJarClassLoaders;
 import com.datasqrl.plan.MainScriptImpl;
 import com.datasqrl.planner.SqlScriptPlanner;
 import com.datasqrl.planner.dag.DAGPlanner;
@@ -41,6 +42,7 @@ import org.springframework.context.annotation.Import;
   SqrlConfigPipeline.class,
   ClasspathFunctionLoader.class,
   ModuleLoaders.class,
+  UdfJarClassLoaders.class,
   MainScriptImpl.class,
   DAGPlanner.class,
   SqrlStatementParser.class,

--- a/sqrl-planner/src/main/java/com/datasqrl/loaders/ModuleLoaderImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/loaders/ModuleLoaderImpl.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -61,11 +60,17 @@ public class ModuleLoaderImpl implements ModuleLoader {
   private final SqrlStatementParser sqrlStatementParser;
   private final WorkspacePaths workspacePaths;
   private final ClasspathFunctionLoader classpathFunctionLoader;
+  private final UdfJarClassLoaders udfJarClassLoaders;
   private final ErrorCollector errors;
 
   private ModuleLoaderImpl withResourceResolver(ResourceResolver resourceResolver) {
     return new ModuleLoaderImpl(
-        resourceResolver, sqrlStatementParser, workspacePaths, classpathFunctionLoader, errors);
+        resourceResolver,
+        sqrlStatementParser,
+        workspacePaths,
+        classpathFunctionLoader,
+        udfJarClassLoaders,
+        errors);
   }
 
   @Override
@@ -203,10 +208,7 @@ public class ModuleLoaderImpl implements ModuleLoader {
 
   @SneakyThrows
   private Class<?> loadClass(URL jarPath, String functionClassName) {
-    URL[] urls = {jarPath};
-    var classLoader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
-
-    return Class.forName(functionClassName, true, classLoader);
+    return Class.forName(functionClassName, true, udfJarClassLoaders.forJar(jarPath));
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/loaders/ModuleLoaders.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/loaders/ModuleLoaders.java
@@ -54,17 +54,24 @@ public final class ModuleLoaders {
       SqrlStatementParser sqrlStatementParser,
       WorkspacePaths workspacePaths,
       ClasspathFunctionLoader classpathFunctionLoader,
+      UdfJarClassLoaders udfJarClassLoaders,
       ErrorCollector errors) {
 
     mainLoader =
         new ModuleLoaderImpl(
-            resourceResolver, sqrlStatementParser, workspacePaths, classpathFunctionLoader, errors);
+            resourceResolver,
+            sqrlStatementParser,
+            workspacePaths,
+            classpathFunctionLoader,
+            udfJarClassLoaders,
+            errors);
     rootLoader =
         new ModuleLoaderImpl(
             new FileResourceResolver(workspacePaths.buildDir()),
             sqrlStatementParser,
             workspacePaths,
             classpathFunctionLoader,
+            udfJarClassLoaders,
             errors);
     includeNamespaces =
         packageJson.getScriptConfig().getIncludeConfigs().stream()

--- a/sqrl-planner/src/main/java/com/datasqrl/loaders/UdfJarClassLoaders.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/loaders/UdfJarClassLoaders.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.loaders;
+
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UdfJarClassLoaders implements AutoCloseable {
+
+  private final Map<URL, URLClassLoader> loaders = new LinkedHashMap<>();
+
+  public synchronized ClassLoader forJar(URL jarUrl) {
+    return loaders.computeIfAbsent(
+        jarUrl,
+        url -> new URLClassLoader(new URL[] {url}, Thread.currentThread().getContextClassLoader()));
+  }
+
+  @PreDestroy
+  @Override
+  public synchronized void close() throws IOException {
+    for (var loader : loaders.values()) {
+      loader.close();
+    }
+    loaders.clear();
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -236,7 +236,7 @@ public class Sqrl2FlinkSQLTranslator implements AutoCloseable {
     this.tEnv.getConfig().setPlannerConfig(plannerConfigBuilder.build());
     this.catalogManager = tEnv.getCatalogManager();
 
-    execFnFactory = new FlinkExecFunctionFactory(tEnv.getConfig(), typeFactory);
+    execFnFactory = new FlinkExecFunctionFactory(tEnv.getConfig());
     relDataTypeParser = new RelDataTypeParser(this);
 
     // Register SQRL standard library functions
@@ -254,6 +254,7 @@ public class Sqrl2FlinkSQLTranslator implements AutoCloseable {
   @SneakyThrows
   public void close() {
     udfClassLoader.close();
+    catalogManager.close();
   }
 
   public SqrlRexUtil getRexUtil() {

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -161,13 +161,14 @@ import org.apache.flink.table.types.DataType;
  *   <li>Keeps track of everything we add to Flink the builder for the {@link FlinkPhysicalPlan}.
  * </ul>
  */
-public class Sqrl2FlinkSQLTranslator {
+public class Sqrl2FlinkSQLTranslator implements AutoCloseable {
 
   private static final String SCHEMA_SUFFIX = "__schema";
   private static final String TEMP_VIEW_SUFFIX = "__view";
 
   private final RuntimeExecutionMode executionMode;
   private final boolean compileFlinkPlan;
+  private final URLClassLoader udfClassLoader;
   private final StreamTableEnvironmentImpl tEnv;
   private final Supplier<FlinkPlannerImpl> validatorSupplier;
   private final SqrlFunctionCatalog sqrlFunctionCatalog;
@@ -190,8 +191,7 @@ public class Sqrl2FlinkSQLTranslator {
     // Set up a StreamExecution Environment in Flink with configuration and access to jars
     var jarUrls = getUdfUrls(workspacePaths);
     // Create a UDF class loader and configure
-    ClassLoader udfClassLoader =
-        new URLClassLoader(jarUrls.toArray(new URL[0]), getClass().getClassLoader());
+    udfClassLoader = new URLClassLoader(jarUrls.toArray(new URL[0]), getClass().getClassLoader());
 
     // Init Flink config
     var config = flink.getBaseConfiguration();
@@ -248,6 +248,12 @@ public class Sqrl2FlinkSQLTranslator {
                 FunctionUtil.getFunctionName(fct.getClass()).getDisplay(),
                 fct.getClass().getName(),
                 true));
+  }
+
+  @Override
+  @SneakyThrows
+  public void close() {
+    udfClassLoader.close();
   }
 
   public SqrlRexUtil getRexUtil() {

--- a/sqrl-planner/src/test/java/com/datasqrl/loaders/UdfJarClassLoadersTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/loaders/UdfJarClassLoadersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.loaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class UdfJarClassLoadersTest {
+
+  private static final String RESOURCE = "marker.txt";
+
+  @TempDir Path tempDir;
+
+  private URL firstJar;
+  private URL secondJar;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    firstJar = writeJar(tempDir.resolve("first.jar"));
+    secondJar = writeJar(tempDir.resolve("second.jar"));
+  }
+
+  @Test
+  void givenSameJar_whenForJar_thenReusesLoader() throws IOException {
+    try (var loaders = new UdfJarClassLoaders()) {
+      assertThat(loaders.forJar(firstJar)).isSameAs(loaders.forJar(firstJar));
+      assertThat(loaders.forJar(firstJar)).isNotSameAs(loaders.forJar(secondJar));
+    }
+  }
+
+  @Test
+  void givenOpenLoaders_whenClose_thenJarsAreNoLongerReadable() throws IOException {
+    var loaders = new UdfJarClassLoaders();
+    var first = loaders.forJar(firstJar);
+    var second = loaders.forJar(secondJar);
+    assertThat(first.getResource(RESOURCE)).isNotNull();
+    assertThat(second.getResource(RESOURCE)).isNotNull();
+
+    loaders.close();
+
+    assertThat(first.getResource(RESOURCE)).isNull();
+    assertThat(second.getResource(RESOURCE)).isNull();
+  }
+
+  @Test
+  void givenSpringManagedBean_whenContextCloses_thenLoadersAreClosed() {
+    var ctx = new AnnotationConfigApplicationContext(UdfJarClassLoaders.class);
+    var loader = ctx.getBean(UdfJarClassLoaders.class).forJar(firstJar);
+    assertThat(loader.getResource(RESOURCE)).isNotNull();
+
+    ctx.close();
+
+    assertThat(loader.getResource(RESOURCE)).isNull();
+  }
+
+  private static URL writeJar(Path path) throws IOException {
+    try (var jar = new JarOutputStream(Files.newOutputStream(path))) {
+      jar.putNextEntry(new JarEntry(RESOURCE));
+      jar.write("marker".getBytes());
+      jar.closeEntry();
+    }
+    return path.toUri().toURL();
+  }
+}

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslatorTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslatorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.planner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.config.WorkspacePaths;
+import com.datasqrl.engine.stream.flink.FlinkStreamEngine;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@EnabledOnOs(OS.LINUX)
+class Sqrl2FlinkSQLTranslatorTest {
+
+  @TempDir Path workspace;
+
+  @Test
+  void givenUdfJarOpenedDuringCompile_whenClose_thenJarHandleIsReleased() throws IOException {
+    var workspacePaths = new WorkspacePaths(workspace, workspace, workspace, workspace);
+    var jar = writeJar(workspacePaths.getUdfPath().resolve("udf.jar"));
+    var flink = mock(FlinkStreamEngine.class);
+    when(flink.getExecutionMode()).thenReturn(RuntimeExecutionMode.STREAMING);
+    when(flink.getBaseConfiguration()).thenReturn(new Configuration());
+    when(flink.getStreamingSpecificConfig()).thenReturn(new Configuration());
+    var compilerConfig = mock(CompilerConfig.class);
+    when(compilerConfig.predicatePushdownRules()).thenReturn(PredicatePushdownRules.DEFAULT);
+
+    var translator = new Sqrl2FlinkSQLTranslator(workspacePaths, flink, compilerConfig);
+    assertThatThrownBy(() -> translator.addUserDefinedFunction("missing", "no.such.Udf", true))
+        .isInstanceOf(Exception.class);
+    assertThat(openFiles()).contains(jar);
+
+    translator.close();
+
+    assertThat(openFiles()).doesNotContain(jar);
+  }
+
+  private static Path writeJar(Path path) throws IOException {
+    Files.createDirectories(path.getParent());
+    try (var jar = new JarOutputStream(Files.newOutputStream(path))) {
+      jar.putNextEntry(new JarEntry("marker.txt"));
+      jar.write("marker".getBytes());
+      jar.closeEntry();
+    }
+    return path.toRealPath();
+  }
+
+  private static Set<Path> openFiles() throws IOException {
+    var open = new HashSet<Path>();
+    try (var fds = Files.list(Path.of("/proc/self/fd"))) {
+      for (var fd : fds.toList()) {
+        try {
+          open.add(Files.readSymbolicLink(fd));
+        } catch (IOException ignored) {
+        }
+      }
+    }
+    return open;
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/exec/FlinkExecFunctionFactory.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/exec/FlinkExecFunctionFactory.java
@@ -39,7 +39,6 @@ public class FlinkExecFunctionFactory {
   AtomicInteger fnCounter = new AtomicInteger();
 
   TableConfig tableConfig;
-  FlinkTypeFactory typeFactory;
 
   public FlinkExecFunction create(
       RexNode expression, String description, RelDataType inputType, boolean listOutput) {
@@ -53,7 +52,7 @@ public class FlinkExecFunctionFactory {
       RelDataType inputType,
       boolean listOutput) {
     // Translate type information
-    var inRowType = (RowType) typeFactory.toLogicalType(inputType);
+    var inRowType = (RowType) FlinkTypeFactory.toLogicalType(inputType);
     var outRowType = toRowTypeFromRexNodes(expressions);
 
     var uniqueFunctionName = String.format(FUNCTON_NAME_TEMPLATE, fnCounter.getAndIncrement());


### PR DESCRIPTION
## Summary

Every compile creates `URLClassLoader`s over the project's UDF jars and never closes them: `Sqrl2FlinkSQLTranslator` builds one over `lib/*.jar` for the Flink table environment, and `ModuleLoaderImpl` builds one per UDF jar it inspects while resolving `IMPORT`s. The open `JarFile` handles survive until the loader is garbage collected, which in a long-running JVM that compiles repeatedly means file descriptors on already-deleted jars pile up.

- `Sqrl2FlinkSQLTranslator` now owns its loader as `AutoCloseable`; `CompilationProcess.executeCompilation` closes it in a try-with-resources once the plan is assembled, rewritten and the compatibility check has run.
- `ModuleLoaderImpl` takes its per-jar loaders from a new per-compile `UdfJarClassLoaders` bean (one loader per jar URL, reused across functions in the same jar) that is closed by `@PreDestroy` when the compile's Spring context shuts down, so classes loaded from it stay usable for the whole compile.

Compiled artifacts are byte-identical to `main` (digests of the deterministic artifacts match across all benchmark cycles).

## Open descriptors of the compiler JVM, 300 warm compiles of a project with a UDF jar

Sampled from `/proc/1/fd` of the JVM every 50 compiles (three package variants of the same project, cycled); "deleted" counts handles on jars whose file has already been removed.

| compiles | control fds | control (deleted) | change fds | change (deleted) |
|---|---|---|---|---|
| 0 | 95 | 0 | 95 | 0 |
| 50 | 136 | 36 | 100 | 0 |
| 100 | 176 | 76 | 100 | 0 |
| 150 | 226 | 126 | 100 | 0 |
| 200 | 276 | 176 | 100 | 0 |
| 250 | 326 | 226 | 100 | 0 |
| 300 | 376 | 276 | 100 | 0 |

Statuses: control {'200': 300}, change {'200': 300}; mean compile time control 315 ms, change 354 ms.
Load average at end: control `5.39`, change `6.47`.

## Warm compile time, cloud-backend core/agent/metrics, 5 cycles

Both jars served from identical containers side by side (8 GB, one compile slot), compiles alternating between the two so background load hits both equally; numbers are the server-side `X-Sqrl-Duration-Ms`. 1-minute load average stayed between 1.5 and 3.3 during the run.

| workload | control min / p50 / max | close-loaders min / p50 / max | delta p50 |
|---|---|---|---|
| core | 16161 / 18413 / 18900 ms | 15554 / 15809 / 18017 ms | -14.1% |
| agent | 860 / 886 / 2849 ms | 832 / 1615 / 2684 ms | +82.3% |
| metrics | 25356 / 25637 / 27055 ms | 25233 / 25960 / 27216 ms | +1.3% |

Statuses: control [200], close-loaders [200]; deterministic artifact digests identical across variants and cycles.

Per-compile minimums, the statistic least affected by other processes on the box, differ by under 4% on all three workloads (core 16161 vs 15554 ms, agent 860 vs 832 ms, metrics 25356 vs 25233 ms). The agent workload is bimodal (0.85 s or 2.5-2.9 s) on both jars alike; a sequential control-then-change run of the same 5 cycles showed the same spread and the same lack of a consistent direction. Closing the loaders is expected to be time-neutral: it happens after the plan is written and the jars are reopened lazily by the next compile.

## Test plan

- [x] `UdfJarClassLoadersTest`: one loader per jar URL, `close()` releases the jars, and a Spring context shutdown closes the bean
- [x] `Sqrl2FlinkSQLTranslatorTest`: a UDF jar handle opened by the table environment is released by `close()` (checked through `/proc/self/fd`, Linux only)
- [x] `ModuleLoadersTest`
- [x] `UseCaseCompileTest` 71/71 (1 pre-existing manual-only test skipped), including the `udf` use case
- [x] 300 warm compiles of a UDF-jar project against the compilation server with this jar and with `main`: descriptor table above, all compiles successful
- [x] 5-cycle core/agent/metrics benchmark against `main`: table above, artifacts identical
