### PR TITLE
perf: cache discovered data file schemas by content hash

### DIFF
--- a/documentation/docs/compiler.md
+++ b/documentation/docs/compiler.md
@@ -159,6 +159,19 @@ Upon successful compilation, the compiler writes:
 - Visual representation to `build/pipeline_visual.html` (open in browser to inspect the DAG)
 - Deployment artifacts to the target folder
 
+### Schema Discovery
+
+When a `CREATE TABLE ... LIKE` statement references a local `.jsonl` or `.csv` file, the compiler infers the
+table schema from every record in that file. To reuse inferred schemas across compilations, point the compiler
+at a cache directory with the `SQRL_DISCOVERY_CACHE_DIR` environment variable or the `sqrl.discovery.cache.dir`
+system property (the system property takes precedence). Entries are keyed by the SHA-256 of the file content, the
+file name, the discovery settings, and the compiler version, so a cached schema is only reused when discovery
+would produce the same result. Without either setting the cache is disabled.
+
+To infer the schema from only the first N records of each file, set `SQRL_DISCOVERY_MAX_RECORDS` or
+`sqrl.discovery.max-records`. Sampling changes the inferred schema when later records introduce new fields or
+types, so it is disabled by default.
+
 ## Run Command
 
 The `run` command compiles and runs the generated data pipeline in Docker.

--- a/sqrl-discovery/pom.xml
+++ b/sqrl-discovery/pom.xml
@@ -45,6 +45,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/AbstractDiscoveryTableSchemaFactory.java
+++ b/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/AbstractDiscoveryTableSchemaFactory.java
@@ -27,6 +27,7 @@ import com.datasqrl.io.schema.flexible.converters.FlexibleTable2RelDataTypeConve
 import com.datasqrl.io.schema.flexible.input.FlexibleTableSchema;
 import com.datasqrl.io.schema.flexible.input.SchemaAdjustmentSettings;
 import com.datasqrl.util.FileCompression;
+import com.datasqrl.util.FileCompression.CompressionIO;
 import com.datasqrl.util.FilenameAnalyzer;
 import com.datasqrl.util.ServiceLoaderDiscovery;
 import java.io.FileInputStream;
@@ -70,41 +71,66 @@ public abstract class AbstractDiscoveryTableSchemaFactory implements TableSchema
         location,
         fileComponents.compression());
 
-    // 2. Compute table statistics from file records
+    var reader = readerOpt.get();
+    var tableName = Name.system(location.getFileName().toString());
+    var cache = DiscoverySchemaCache.fromEnvironment();
+    var cacheKey = cache.key(location, reader.getFormat(), SchemaAdjustmentSettings.DEFAULT);
+    var schema =
+        cacheKey
+            .flatMap(key -> cache.lookup(key, tableName))
+            .orElseGet(
+                () -> {
+                  var discovered =
+                      discoverSchema(
+                          location,
+                          compressionOpt.get(),
+                          reader,
+                          cache.getMaxRecords(),
+                          tableName,
+                          localErrors);
+                  cacheKey.ifPresent(key -> cache.store(key, discovered));
+                  return discovered;
+                });
+
+    var rowType = convert(schema, tableName);
+    var options = new LinkedHashMap<String, String>();
+    options.put("connector", "filesystem");
+    options.put("format", reader.getFormat());
+    options.put("path", "${" + DATA_PATH + "}/" + location.getFileName().toString());
+
+    return new SchemaConversionResult(rowType, options);
+  }
+
+  private FlexibleTableSchema discoverSchema(
+      Path location,
+      CompressionIO compression,
+      RecordReader reader,
+      long maxRecords,
+      Name tableName,
+      ErrorCollector errors) {
     Optional<SourceTableStatistics> statistics;
-    try (var io = compressionOpt.get().decompress(new FileInputStream(location.toFile()))) {
-      var dataflow = readerOpt.get().read(io);
+    try (var io = compression.decompress(new FileInputStream(location.toFile()))) {
       statistics =
-          dataflow
+          reader
+              .read(io)
+              .limit(maxRecords)
               .flatMap(this::getTableStatistics)
               .reduce(
                   (base, add) -> {
                     base.merge(add);
                     return base;
                   });
-
     } catch (IOException e) {
-      throw localErrors.exception(
+      throw errors.exception(
           "Could not infer schema of file [%s] due to IO error: %s", location, e);
     }
-    localErrors.checkFatal(
+    errors.checkFatal(
         statistics.isPresent() && statistics.get().getCount() > 0,
         "Could not infer schema for data file [%s] because it contained no valid records",
         location);
 
-    // 3. Infer schema from table statistics
     var generator = new DefaultSchemaGenerator(SchemaAdjustmentSettings.DEFAULT);
-    FlexibleTableSchema schema;
-    var tableName = location.getFileName().toString();
-    schema = generator.mergeSchema(statistics.get(), Name.system(tableName), localErrors);
-
-    var rowType = convert(schema, tableName);
-    var options = new LinkedHashMap<String, String>();
-    options.put("connector", "filesystem");
-    options.put("format", readerOpt.get().getFormat());
-    options.put("path", "${" + DATA_PATH + "}/" + location.getFileName().toString());
-
-    return new SchemaConversionResult(rowType, options);
+    return generator.mergeSchema(statistics.get(), tableName, errors);
   }
 
   private Stream<SourceTableStatistics> getTableStatistics(Map<String, Object> data) {
@@ -123,8 +149,8 @@ public abstract class AbstractDiscoveryTableSchemaFactory implements TableSchema
     return Stream.of(acc);
   }
 
-  private static RelDataType convert(FlexibleTableSchema tableSchema, String tableName) {
-    var converter = new FlexibleTableConverter(tableSchema, Name.system(tableName));
+  private static RelDataType convert(FlexibleTableSchema tableSchema, Name tableName) {
+    var converter = new FlexibleTableConverter(tableSchema, tableName);
     var relDataTypeConverter = new FlexibleTable2RelDataTypeConverter();
     return converter.apply(relDataTypeConverter);
   }

--- a/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/DiscoverySchemaCache.java
+++ b/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/DiscoverySchemaCache.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.discovery.preprocessor;
+
+import com.datasqrl.canonicalizer.Name;
+import com.datasqrl.io.schema.flexible.input.FlexibleTableSchema;
+import com.datasqrl.io.schema.flexible.input.SchemaAdjustmentSettings;
+import com.datasqrl.util.ProjectConstants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DiscoverySchemaCache {
+
+  public static final String CACHE_DIR_PROPERTY = "sqrl.discovery.cache.dir";
+  public static final String CACHE_DIR_ENV = "SQRL_DISCOVERY_CACHE_DIR";
+  public static final String MAX_RECORDS_PROPERTY = "sqrl.discovery.max-records";
+  public static final String MAX_RECORDS_ENV = "SQRL_DISCOVERY_MAX_RECORDS";
+
+  private static final String FORMAT_VERSION = "1";
+  private static final String ENTRY_SUFFIX = ".json";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Optional<Path> directory;
+  @Getter private final long maxRecords;
+
+  public DiscoverySchemaCache(Optional<Path> directory, long maxRecords) {
+    Preconditions.checkArgument(maxRecords > 0, "Max records must be positive: %s", maxRecords);
+    this.directory = directory;
+    this.maxRecords = maxRecords;
+  }
+
+  public static DiscoverySchemaCache fromEnvironment() {
+    var directory = setting(CACHE_DIR_PROPERTY, CACHE_DIR_ENV).map(Path::of);
+    var maxRecords =
+        setting(MAX_RECORDS_PROPERTY, MAX_RECORDS_ENV).map(Long::parseLong).orElse(Long.MAX_VALUE);
+    return new DiscoverySchemaCache(directory, maxRecords);
+  }
+
+  private static Optional<String> setting(String property, String env) {
+    return Optional.ofNullable(System.getProperty(property))
+        .or(() -> Optional.ofNullable(System.getenv(env)))
+        .filter(value -> !value.isBlank());
+  }
+
+  public Optional<String> key(Path dataFile, String format, SchemaAdjustmentSettings settings) {
+    if (directory.isEmpty()) {
+      return Optional.empty();
+    }
+    var digest = sha256();
+    try (InputStream in = Files.newInputStream(dataFile)) {
+      var buffer = new byte[64 * 1024];
+      int read;
+      while ((read = in.read(buffer)) >= 0) {
+        digest.update(buffer, 0, read);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    var metadata =
+        String.join(
+            "\n",
+            FORMAT_VERSION,
+            ProjectConstants.SQRL_VERSION,
+            format,
+            dataFile.getFileName().toString(),
+            Long.toString(maxRecords),
+            fingerprint(settings));
+    digest.update(metadata.getBytes(StandardCharsets.UTF_8));
+    return Optional.of(HexFormat.of().formatHex(digest.digest()));
+  }
+
+  public Optional<FlexibleTableSchema> lookup(String key, Name tableName) {
+    var entry = entry(key);
+    if (!Files.isRegularFile(entry)) {
+      return Optional.empty();
+    }
+    try {
+      var json = MAPPER.readValue(entry.toFile(), FlexibleSchemaJson.class);
+      var builder = new FlexibleTableSchema.Builder();
+      builder.setName(tableName);
+      builder.setPartialSchema(false);
+      builder.setFields(json.toRelation());
+      log.debug("Loaded discovered schema for {} from {}", tableName, entry);
+      return Optional.of(builder.build());
+    } catch (IOException | RuntimeException e) {
+      log.warn("Ignoring unreadable discovery cache entry {}: {}", entry, e.toString());
+      return Optional.empty();
+    }
+  }
+
+  public void store(String key, FlexibleTableSchema schema) {
+    var entry = entry(key);
+    try {
+      Files.createDirectories(entry.getParent());
+      var temp = Files.createTempFile(entry.getParent(), key, ".tmp");
+      MAPPER.writeValue(temp.toFile(), FlexibleSchemaJson.of(schema.getFields()));
+      Files.move(temp, entry, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException | RuntimeException e) {
+      log.warn("Could not write discovery cache entry {}: {}", entry, e.toString());
+    }
+  }
+
+  private Path entry(String key) {
+    return directory.orElseThrow().resolve(key + ENTRY_SUFFIX);
+  }
+
+  private static String fingerprint(SchemaAdjustmentSettings settings) {
+    return String.join(
+        ",",
+        Boolean.toString(settings.deepenArrays()),
+        Boolean.toString(settings.removeListNulls()),
+        Boolean.toString(settings.null2EmptyArray()),
+        Boolean.toString(settings.castDataType()),
+        Integer.toString(settings.maxCastingTypeDistance()),
+        Boolean.toString(settings.forceCastDataType()),
+        Integer.toString(settings.maxForceCastingTypeDistance()),
+        Boolean.toString(settings.dropFields()));
+  }
+
+  private static MessageDigest sha256() {
+    try {
+      return MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/FlexibleSchemaJson.java
+++ b/sqrl-discovery/src/main/java/com/datasqrl/discovery/preprocessor/FlexibleSchemaJson.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.discovery.preprocessor;
+
+import com.datasqrl.canonicalizer.Name;
+import com.datasqrl.canonicalizer.SpecialName;
+import com.datasqrl.canonicalizer.StandardName;
+import com.datasqrl.error.ErrorCollector;
+import com.datasqrl.io.schema.flexible.constraint.Constraint;
+import com.datasqrl.io.schema.flexible.input.FlexibleFieldSchema;
+import com.datasqrl.io.schema.flexible.input.FlexibleFieldSchema.Field;
+import com.datasqrl.io.schema.flexible.input.FlexibleFieldSchema.FieldType;
+import com.datasqrl.io.schema.flexible.input.RelationType;
+import com.datasqrl.io.schema.flexible.type.Type;
+import com.datasqrl.io.schema.flexible.type.basic.BasicType;
+import com.datasqrl.io.schema.flexible.type.basic.BasicTypeManager;
+import java.util.List;
+import java.util.Map;
+
+record FlexibleSchemaJson(List<FieldJson> fields) {
+
+  private static final List<Name> SPECIAL_NAMES =
+      List.of(SpecialName.SINGLETON, SpecialName.LOCAL, SpecialName.VALUE);
+
+  record NameJson(String canonical, String display) {
+
+    static NameJson of(Name name) {
+      return new NameJson(name.getCanonical(), name.getDisplay());
+    }
+
+    Name toName() {
+      return SPECIAL_NAMES.stream()
+          .filter(special -> special.getCanonical().equals(canonical))
+          .findFirst()
+          .orElseGet(() -> new StandardName(canonical, display));
+    }
+  }
+
+  record ConstraintJson(String name, Map<String, Object> parameters) {
+
+    static ConstraintJson of(Constraint constraint) {
+      return new ConstraintJson(constraint.getName().getDisplay(), constraint.export());
+    }
+
+    Constraint toConstraint() {
+      var factory = Constraint.FACTORY_LOOKUP.get(name);
+      if (factory == null) {
+        throw new IllegalArgumentException("Unknown constraint: " + name);
+      }
+      var errors = ErrorCollector.root();
+      var constraint = factory.create(parameters == null ? Map.of() : parameters, errors);
+      if (constraint.isEmpty()) {
+        throw new IllegalArgumentException("Invalid constraint %s: %s".formatted(name, errors));
+      }
+      return constraint.get();
+    }
+  }
+
+  record FieldTypeJson(
+      NameJson variant,
+      String basicType,
+      List<FieldJson> fields,
+      int arrayDepth,
+      List<ConstraintJson> constraints) {
+
+    static FieldTypeJson of(FieldType fieldType) {
+      var type = fieldType.getType();
+      String basicType = null;
+      List<FieldJson> fields = null;
+      if (type instanceof BasicType<?> basic) {
+        basicType = basic.getName();
+      } else if (type instanceof RelationType<?> relation) {
+        fields = fieldsOf((RelationType<Field>) relation);
+      } else {
+        throw new IllegalArgumentException("Unsupported field type: " + type);
+      }
+      return new FieldTypeJson(
+          NameJson.of(fieldType.getVariantName()),
+          basicType,
+          fields,
+          fieldType.getArrayDepth(),
+          fieldType.getConstraints().stream().map(ConstraintJson::of).toList());
+    }
+
+    FieldType toFieldType() {
+      Type type;
+      if (basicType != null) {
+        type = BasicTypeManager.getTypeByName(basicType);
+        if (type == null) {
+          throw new IllegalArgumentException("Unknown type: " + basicType);
+        }
+      } else {
+        type = toRelation(fields);
+      }
+      return new FieldType(
+          variant.toName(),
+          type,
+          arrayDepth,
+          constraints.stream().map(ConstraintJson::toConstraint).toList());
+    }
+  }
+
+  record FieldJson(NameJson name, List<FieldTypeJson> types) {
+
+    static FieldJson of(Field field) {
+      return new FieldJson(
+          NameJson.of(field.getName()), field.getTypes().stream().map(FieldTypeJson::of).toList());
+    }
+
+    Field toField() {
+      var builder = new FlexibleFieldSchema.Field.Builder();
+      builder.setName(name.toName());
+      builder.setTypes(types.stream().map(FieldTypeJson::toFieldType).toList());
+      return builder.build();
+    }
+  }
+
+  static FlexibleSchemaJson of(RelationType<Field> relation) {
+    return new FlexibleSchemaJson(fieldsOf(relation));
+  }
+
+  private static List<FieldJson> fieldsOf(RelationType<Field> relation) {
+    return relation.getFields().stream().map(FieldJson::of).toList();
+  }
+
+  RelationType<Field> toRelation() {
+    return toRelation(fields);
+  }
+
+  private static RelationType<Field> toRelation(List<FieldJson> fields) {
+    RelationType.Builder<Field> builder = RelationType.build();
+    fields.forEach(field -> builder.add(field.toField()));
+    return builder.build();
+  }
+}

--- a/sqrl-discovery/src/test/java/com/datasqrl/discovery/preprocessor/DiscoverySchemaCacheTest.java
+++ b/sqrl-discovery/src/test/java/com/datasqrl/discovery/preprocessor/DiscoverySchemaCacheTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.discovery.preprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datasqrl.error.ErrorCollector;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+@ExtendWith(SystemStubsExtension.class)
+class DiscoverySchemaCacheTest {
+
+  private static final String RECORDS =
+      """
+      {"id": 1, "name": "a", "time": "2024-01-01T10:00:00Z", "tags": ["x", "y"], "nested": {"k": 1}, "mixed": {"v": 1}}
+      {"id": 2, "name": null, "time": "2024-01-02T10:00:00Z", "tags": [], "nested": {"k": 2, "extra": "e"}, "mixed": "scalar"}
+      {"id": "3", "name": "c", "time": "2024-01-03T10:00:00Z", "tags": ["z"], "nested": null, "mixed": null, "late": 1.5}
+      """;
+
+  private static final String STRING = "VARCHAR(2147483647) CHARACTER SET \"UTF-16LE\"";
+
+  @SystemStub private SystemProperties properties;
+
+  @TempDir Path tempDir;
+
+  private Path dataFile;
+  private Path cacheDir;
+  private final JsonlDiscoveryTableSchemaFactory factory = new JsonlDiscoveryTableSchemaFactory();
+
+  @BeforeEach
+  void setUp() throws IOException {
+    dataFile = tempDir.resolve("records.jsonl");
+    Files.writeString(dataFile, RECORDS);
+    cacheDir = tempDir.resolve("cache");
+  }
+
+  @Test
+  void disabledWithoutConfiguration() {
+    discover();
+    assertThat(tempDir.resolve("cache")).doesNotExist();
+  }
+
+  @Test
+  void hitMatchesUncachedDiscovery() throws IOException {
+    var uncached = discover();
+    properties.set(DiscoverySchemaCache.CACHE_DIR_PROPERTY, cacheDir.toString());
+
+    var miss = discover();
+    var entry = singleEntry();
+    var written = Files.readString(entry);
+    var hit = discover();
+
+    assertThat(miss).isEqualTo(uncached);
+    assertThat(hit).isEqualTo(uncached);
+    assertThat(Files.readString(entry)).isEqualTo(written);
+    assertThat(uncached)
+        .isEqualTo(
+            "RecordType(BIGINT NOT NULL id, "
+                + STRING
+                + " name, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL time, "
+                + STRING
+                + " NOT NULL ARRAY tags, RecordType(BIGINT k, "
+                + STRING
+                + " extra) nested, RecordType(BIGINT v, "
+                + STRING
+                + " _value) mixed, DOUBLE late) NOT NULL");
+  }
+
+  @Test
+  void hitIsServedFromCache() throws IOException {
+    properties.set(DiscoverySchemaCache.CACHE_DIR_PROPERTY, cacheDir.toString());
+    discover();
+    var entry = singleEntry();
+    Files.writeString(
+        entry,
+        """
+        {"fields":[{"name":{"canonical":"only","display":"only"},"types":[{"variant":{"canonical":" #singleton","display":" #singleton"},"basicType":"STRING","fields":null,"arrayDepth":0,"constraints":[{"name":"not_null","parameters":null}]}]}]}
+        """);
+
+    assertThat(discover()).isEqualTo("RecordType(" + STRING + " NOT NULL only) NOT NULL");
+  }
+
+  @Test
+  void corruptEntryIsReplaced() throws IOException {
+    var uncached = discover();
+    properties.set(DiscoverySchemaCache.CACHE_DIR_PROPERTY, cacheDir.toString());
+    discover();
+    var entry = singleEntry();
+    var written = Files.readString(entry);
+    Files.writeString(entry, "{not json");
+
+    assertThat(discover()).isEqualTo(uncached);
+    assertThat(Files.readString(entry)).isEqualTo(written);
+  }
+
+  @Test
+  void unknownTypeInEntryIsReplaced() throws IOException {
+    var uncached = discover();
+    properties.set(DiscoverySchemaCache.CACHE_DIR_PROPERTY, cacheDir.toString());
+    discover();
+    var entry = singleEntry();
+    var written = Files.readString(entry);
+    Files.writeString(entry, written.replace("\"STRING\"", "\"NO_SUCH_TYPE\""));
+
+    assertThat(discover()).isEqualTo(uncached);
+    assertThat(Files.readString(entry)).isEqualTo(written);
+  }
+
+  @Test
+  void keyChangesWithContentAndSettings() throws IOException {
+    properties.set(DiscoverySchemaCache.CACHE_DIR_PROPERTY, cacheDir.toString());
+    discover();
+    var full = singleEntry();
+
+    properties.set(DiscoverySchemaCache.MAX_RECORDS_PROPERTY, "1");
+    var sampled = discover();
+    assertThat(sampled)
+        .doesNotContain("late")
+        .contains("RecordType(BIGINT NOT NULL k) NOT NULL nested");
+    assertThat(entries()).hasSize(2).contains(full);
+
+    Files.writeString(dataFile, RECORDS + "{\"id\": 4}\n");
+    discover();
+    assertThat(entries()).hasSize(3);
+  }
+
+  private String discover() {
+    return factory.convert(dataFile, Map.of(), ErrorCollector.root()).type().getFullTypeString();
+  }
+
+  private Path singleEntry() throws IOException {
+    var entries = entries();
+    assertThat(entries).hasSize(1);
+    return entries.get(0);
+  }
+
+  private List<Path> entries() throws IOException {
+    try (Stream<Path> files = Files.list(cacheDir)) {
+      return files.filter(path -> path.toString().endsWith(".json")).toList();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Schema discovery over local data files (`CREATE TABLE ... LIKE 'file.jsonl'`) type-detects every record of every referenced file on every compile. For `law-enforcement` (5.1 MB of JSONL test data) that is 2.3 s of a 2.4 s compile, while the other examples compile in 25-120 ms.

This adds an opt-in, content-addressed cache for the inferred schema:

- `AbstractDiscoveryTableSchemaFactory` now hashes the data file (SHA-256 over the raw bytes, plus file name, reader format, `SchemaAdjustmentSettings`, sampling limit and compiler version) and looks the key up in `DiscoverySchemaCache` before reading records. On a miss it runs the existing statistics + `DefaultSchemaGenerator` path and stores the resulting `FlexibleTableSchema` as JSON (`FlexibleSchemaJson`, written atomically via temp file + move).
- On a hit the cached `FlexibleTableSchema` goes through the same `FlexibleTableConverter` / `FlexibleTable2RelDataTypeConverter` as a freshly discovered one, so the `RelDataType` and connector options are identical by construction. Unreadable or unparseable entries (corrupt JSON, unknown type or constraint names) are logged and treated as a miss, then overwritten.
- Hashing a 5 MB file costs a few milliseconds of sequential I/O versus seconds of JSON parsing and type detection, so the hash check is cheap even on a miss.

## Configuration

| setting | system property | environment variable | default |
|---|---|---|---|
| cache directory | `sqrl.discovery.cache.dir` | `SQRL_DISCOVERY_CACHE_DIR` | unset: cache disabled |
| sample only the first N records | `sqrl.discovery.max-records` | `SQRL_DISCOVERY_MAX_RECORDS` | unset: all records |

The system property takes precedence over the environment variable. There is deliberately no default directory: the `build` directory is wiped by `Packager` on every compile, and a per-user default would let cached schemas outlive compiler changes in development builds (every dev build reports the same `1.0-SNAPSHOT` version). Sampling changes the inferred schema when later records introduce new fields or types, so it is off unless requested. Both knobs are documented in `documentation/docs/compiler.md`.

## Benchmarks

Warm compilation server, one compile slot, 8 GB container, each example compiled 20 times per variant. "cache cold" is the first compile with an empty cache directory (hash + discovery + write), "cache warm" the following 19.

| example | status | control 1st compile | control warm min / p50 / max | cache cold 1st compile | cache warm min / p50 / max | p50 change |
|---|---|---|---|---|---|---|
| law-enforcement | 200 | 15737 ms | 2657 / 2832 / 3876 ms | 16061 ms | 518 / 624 / 1715 ms | -78% |
| logistics | 200 | 292 ms | 167 / 205 / 246 ms | 290 ms | 174 / 201 / 225 ms | -2% |
| usage-analytics | 200 | 249 ms | 102 / 133 / 184 ms | 243 ms | 113 / 140 / 198 ms | +5% |
| iceberg-dedup/datagen | 200 | 511 ms | 69 / 90 / 153 ms | 512 ms | 65 / 83 / 159 ms | -8% |
| iceberg-dedup/compaction | 200 | 1033 ms | 422 / 496 / 859 ms | 1045 ms | 394 / 475 / 799 ms | -4% |
| iceberg-dedup/delete | 200 | 155 ms | 106 / 119 / 170 ms | 164 ms | 108 / 123 / 170 ms | +3% |
| canary-batch | 200 | 74 ms | 73 / 85 / 102 ms | 68 ms | 52 / 68 / 81 ms | -20% |
| canary-scheduled-batch/scheduled | 200 | 70 ms | 61 / 76 / 91 ms | 71 ms | 54 / 64 / 78 ms | -16% |
| canary-scheduled-batch/simple | 200 | 60 ms | 60 / 70 / 102 ms | 56 ms | 48 / 58 / 67 ms | -17% |
| iot-sensor/test | 422 | 69 ms | 46 / 51 / 69 ms | 71 ms | 46 / 51 / 60 ms | +0% |

The first compile of each variant is also the JVM cold start (both variants around 15.7-16.1 s for `law-enforcement`), so the cold-cache cost is the +324 ms of that first compile relative to control: hashing 5.1 MB and writing four small JSON entries. `iot-sensor` fails after discovery on both variants (`Multiple ROWTIME columns`), so only its duration is compared. `canary-*` and `iceberg-dedup` reference files of a few KB, where discovery was never the bottleneck; their differences are run-to-run noise.

Build artifacts (`flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json` and all `*schema*` files) of the first and second compile of every example are byte-identical between control and the cached variant.

Standard 5-cycle cloud-backend benchmark (no local data files, so the change is a no-op there):

Samples per module: 5 (p80/p90/p95 are nearest-rank; with 5 samples they sit at the top sample). Load average at start 3.17, at end 1.69. Per cycle, ms:

| module | control | discovery-cache |
|---|---|---|
| core | 17879, 18687, 16784, 15588, 15534 | 18050, 16422, 16781, 15816, 15898 |
| agent | 3197, 936, 2580, 818, 883 | 1066, 2820, 2803, 3482, 845 |
| metrics | 28077, 27266, 24679, 24512, 24586 | 26718, 26231, 25549, 25507, 27320 |

`agent` is bimodal on both jars (0.8-1.1 s, or 2.6-3.5 s when it directly follows a `core`/`metrics` compile and inherits their GC), so its p50 flips with how many of the five samples land in each mode; the minimums (0.82 s vs 0.84 s) are the comparable figure. cloud-backend has no local data files, so the cache directory is never consulted there.

### core

| variant | version | min | p50 | p80 | p90 | p95 | max | p50 vs control |
|---|---|---|---|---|---|---|---|---|
| control | 1.0-perf-control-SNAPSHOT | 15.53 s | 16.78 s | 17.88 s | 18.69 s | 18.69 s | 18.69 s | +0% |
| discovery-cache | 1.0-perf-discovery-cache-SNAPSHOT | 15.82 s | 16.42 s | 16.78 s | 18.05 s | 18.05 s | 18.05 s | -2% |

### agent

| variant | version | min | p50 | p80 | p90 | p95 | max | p50 vs control |
|---|---|---|---|---|---|---|---|---|
| control | 1.0-perf-control-SNAPSHOT | 0.82 s | 0.94 s | 2.58 s | 3.20 s | 3.20 s | 3.20 s | +0% |
| discovery-cache | 1.0-perf-discovery-cache-SNAPSHOT | 0.84 s | 2.80 s | 2.82 s | 3.48 s | 3.48 s | 3.48 s | +199% |

### metrics

| variant | version | min | p50 | p80 | p90 | p95 | max | p50 vs control |
|---|---|---|---|---|---|---|---|---|
| control | 1.0-perf-control-SNAPSHOT | 24.51 s | 24.68 s | 27.27 s | 28.08 s | 28.08 s | 28.08 s | +0% |
| discovery-cache | 1.0-perf-discovery-cache-SNAPSHOT | 25.51 s | 26.23 s | 26.72 s | 27.32 s | 27.32 s | 27.32 s | +6% |

### Artifacts vs control

| variant | result |
|---|---|
| control | identical deterministic artifacts |
| discovery-cache | identical deterministic artifacts |

## Test plan

- [x] `DiscoverySchemaCacheTest`: disabled without configuration, miss then hit equals uncached discovery, hit is served from the cache, corrupt entry and unknown type name are replaced, key changes with content and sampling limit
- [x] `UseCaseCompileTest` 71/71, snapshots unchanged
- [x] per-example benchmark above, artifacts byte-identical to control
