### PR TITLE
perf: skip Calc digest rendering in FlinkCalcMergeRule unless the merged Calc can equal the bottom Calc

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/sql/rules/SqrlCalcMergeRule.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/sql/rules/SqrlCalcMergeRule.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.stream.flink.sql.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rex.RexOver;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalc;
+import org.apache.flink.table.planner.plan.rules.logical.FlinkCalcMergeRule;
+import org.apache.flink.table.planner.plan.utils.FlinkRelUtil;
+import org.immutables.value.Value;
+
+/**
+ * {@link FlinkCalcMergeRule} that renders the digests of the merged and the bottom Calc only when
+ * the cheap prerequisites of digest equality hold, instead of on every merge.
+ */
+public class SqrlCalcMergeRule extends RelRule<SqrlCalcMergeRule.SqrlCalcMergeRuleConfig> {
+
+  public static final SqrlCalcMergeRule INSTANCE = SqrlCalcMergeRuleConfig.DEFAULT.toRule();
+  public static final SqrlCalcMergeRule STREAM_PHYSICAL_INSTANCE =
+      SqrlCalcMergeRuleConfig.STREAM_PHYSICAL.toRule();
+
+  protected SqrlCalcMergeRule(SqrlCalcMergeRuleConfig config) {
+    super(config);
+  }
+
+  public static RelOptRule replacing(RelOptRule rule) {
+    if (rule == FlinkCalcMergeRule.INSTANCE) {
+      return INSTANCE;
+    }
+    if (rule == FlinkCalcMergeRule.STREAM_PHYSICAL_INSTANCE) {
+      return STREAM_PHYSICAL_INSTANCE;
+    }
+    return rule;
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    Calc topCalc = call.rel(0);
+    Calc bottomCalc = call.rel(1);
+    if (RexOver.containsOver(topCalc.getProgram())) {
+      return false;
+    }
+    return FlinkRelUtil.isMergeable(topCalc, bottomCalc);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    Calc topCalc = call.rel(0);
+    Calc bottomCalc = call.rel(1);
+
+    var newCalc = FlinkRelUtil.merge(topCalc, bottomCalc);
+    if (mayShareDigest(newCalc, bottomCalc) && newCalc.getDigest().equals(bottomCalc.getDigest())) {
+      call.getPlanner().prune(topCalc);
+    }
+    call.transformTo(newCalc);
+  }
+
+  private static boolean mayShareDigest(Calc newCalc, Calc bottomCalc) {
+    return newCalc.getRelTypeName().equals(bottomCalc.getRelTypeName())
+        && newCalc.getTraitSet().equals(bottomCalc.getTraitSet())
+        && newCalc.getRowType().equals(bottomCalc.getRowType())
+        && (newCalc.getProgram().getCondition() == null)
+            == (bottomCalc.getProgram().getCondition() == null);
+  }
+
+  @Value.Immutable
+  public interface SqrlCalcMergeRuleConfig extends RelRule.Config {
+    SqrlCalcMergeRuleConfig DEFAULT =
+        ImmutableSqrlCalcMergeRuleConfig.builder()
+            .description("SqrlCalcMergeRule")
+            .operandSupplier(
+                b0 -> b0.operand(Calc.class).inputs(b1 -> b1.operand(Calc.class).anyInputs()))
+            .build();
+
+    SqrlCalcMergeRuleConfig STREAM_PHYSICAL =
+        ImmutableSqrlCalcMergeRuleConfig.builder()
+            .description("SqrlCalcMergeRule")
+            .operandSupplier(
+                b0 ->
+                    b0.operand(StreamPhysicalCalc.class)
+                        .inputs(b1 -> b1.operand(StreamPhysicalCalc.class).anyInputs()))
+            .build();
+
+    @Override
+    default SqrlCalcMergeRule toRule() {
+      return new SqrlCalcMergeRule(this);
+    }
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
@@ -16,6 +16,7 @@
 package com.datasqrl.planner;
 
 import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.engine.stream.flink.sql.rules.SqrlCalcMergeRule;
 import com.datasqrl.engine.stream.flink.sql.rules.SqrlMiniBatchIntervalInferRule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.plan.RelOptRule;
@@ -35,6 +37,7 @@ import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkChangelogModeInferenceProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkGroupProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
 import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
 import org.apache.flink.table.planner.plan.rules.logical.FlinkFilterProjectTransposeRule;
@@ -141,12 +144,16 @@ public class FlinkPlannerConfigBuilder {
         continue;
       }
 
+      replaceRules(programName, program, SqrlCalcMergeRule::replacing);
+
       if (programName.equals(FlinkStreamProgram.PHYSICAL_REWRITE())) {
         replaceRules(
             programName,
             program,
-            MiniBatchIntervalInferRule.class::isInstance,
-            SqrlMiniBatchIntervalInferRule.INSTANCE);
+            rule ->
+                rule instanceof MiniBatchIntervalInferRule
+                    ? SqrlMiniBatchIntervalInferRule.INSTANCE
+                    : rule);
         customStreamProgram.addLast(programName, program);
         continue;
       }
@@ -225,14 +232,8 @@ public class FlinkPlannerConfigBuilder {
   }
 
   private void replaceRules(
-      String programName,
-      FlinkOptimizeProgram<?> program,
-      Predicate<RelOptRule> shouldReplace,
-      RelOptRule replacement) {
-    rewriteRules(
-        programName,
-        program,
-        rules -> rules.replaceAll(rule -> shouldReplace.test(rule) ? replacement : rule));
+      String programName, FlinkOptimizeProgram<?> program, UnaryOperator<RelOptRule> replacement) {
+    rewriteRules(programName, program, rules -> rules.replaceAll(replacement));
   }
 
   // Rewrite the rule list of a FlinkOptimizeProgram instance.
@@ -252,6 +253,9 @@ public class FlinkPlannerConfigBuilder {
     for (var internalProgram : programs) {
       if (internalProgram instanceof FlinkGroupProgram) {
         rewriteRules(programName, (FlinkOptimizeProgram<?>) internalProgram, rewrite);
+        continue;
+      }
+      if (!(internalProgram instanceof FlinkRuleSetProgram)) {
         continue;
       }
 

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.datasqrl.config.PackageJson.CompilerConfig;
+import com.datasqrl.engine.stream.flink.sql.rules.SqrlCalcMergeRule;
 import com.datasqrl.engine.stream.flink.sql.rules.SqrlMiniBatchIntervalInferRule;
 import java.util.List;
 import org.apache.flink.configuration.Configuration;
@@ -28,11 +29,14 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
+import org.apache.flink.table.planner.plan.rules.logical.FlinkCalcMergeRule;
 import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import scala.Tuple2;
 
 class FlinkPlannerConfigBuilderTest {
@@ -70,6 +74,22 @@ class FlinkPlannerConfigBuilderTest {
       GROUP BY o.currency
       """;
 
+  private static final String NESTED_CALCS_QUERY =
+      """
+      SELECT * FROM (
+        SELECT id, currency FROM (
+          SELECT id, currency, ts FROM orders WHERE id > 1
+        ) WHERE id > 1
+      )
+      """;
+
+  private static final String RENAMING_CALCS_QUERY =
+      """
+      SELECT id AS order_id, currency AS ccy FROM (
+        SELECT id, currency, id + 1 AS next_id FROM orders WHERE currency <> 'EUR'
+      ) WHERE next_id > 2
+      """;
+
   @ParameterizedTest
   @EnumSource(PredicatePushdownRules.class)
   void givenAnyPushdownRules_whenBuild_thenPhysicalRewriteUsesSqrlMiniBatchRule(
@@ -96,16 +116,50 @@ class FlinkPlannerConfigBuilderTest {
         .isEmpty();
   }
 
+  @ParameterizedTest
+  @EnumSource(PredicatePushdownRules.class)
+  void givenAnyPushdownRules_whenBuild_thenCalcMergeRulesAreReplaced(PredicatePushdownRules rules) {
+    var flinkConf = new Configuration();
+    var plannerConfig =
+        (CalciteConfig) new FlinkPlannerConfigBuilder(config(rules), flinkConf).build();
+    var streamProgram = plannerConfig.getStreamProgram().get();
+
+    var logical = (FlinkRuleSetProgram<?>) streamProgram.get(FlinkStreamProgram.LOGICAL()).get();
+    var physical = (FlinkRuleSetProgram<?>) streamProgram.get(FlinkStreamProgram.PHYSICAL()).get();
+    var logicalRewrite =
+        subPrograms(streamProgram.get(FlinkStreamProgram.LOGICAL_REWRITE()).get()).stream()
+            .map(Tuple2::_1)
+            .map(FlinkRuleSetProgram.class::cast)
+            .toList();
+
+    assertThat(logical.contains(SqrlCalcMergeRule.INSTANCE)).isTrue();
+    assertThat(logical.contains(FlinkCalcMergeRule.INSTANCE)).isFalse();
+    assertThat(physical.contains(SqrlCalcMergeRule.STREAM_PHYSICAL_INSTANCE)).isTrue();
+    assertThat(physical.contains(FlinkCalcMergeRule.STREAM_PHYSICAL_INSTANCE)).isFalse();
+    assertThat(logicalRewrite).filteredOn(p -> p.contains(SqrlCalcMergeRule.INSTANCE)).hasSize(1);
+    assertThat(logicalRewrite).filteredOn(p -> p.contains(FlinkCalcMergeRule.INSTANCE)).isEmpty();
+  }
+
   @Test
   void givenMiniBatchTemporalJoin_whenExplain_thenPlanEqualsFlinkDefaultProgram() {
-    var sqrlPlan = explain(true);
-    var flinkPlan = explain(false);
+    var sqrlPlan = explain(true, QUERY);
+    var flinkPlan = explain(false, QUERY);
 
     assertThat(sqrlPlan).contains("MiniBatchAssigner").contains("TemporalJoin").contains("Rank");
     assertThat(sqrlPlan).isEqualTo(flinkPlan);
   }
 
-  private String explain(boolean sqrlPlannerConfig) {
+  @ParameterizedTest
+  @ValueSource(strings = {NESTED_CALCS_QUERY, RENAMING_CALCS_QUERY})
+  void givenNestedCalcs_whenExplain_thenPlanEqualsFlinkDefaultProgram(String query) {
+    var sqrlPlan = explain(true, query);
+    var flinkPlan = explain(false, query);
+
+    assertThat(sqrlPlan).contains("Calc(");
+    assertThat(sqrlPlan).isEqualTo(flinkPlan);
+  }
+
+  private String explain(boolean sqrlPlannerConfig, String query) {
     var flinkConf = new Configuration();
     flinkConf.setString("table.exec.mini-batch.enabled", "true");
     flinkConf.setString("table.exec.mini-batch.allow-latency", "5 s");
@@ -119,7 +173,7 @@ class FlinkPlannerConfigBuilderTest {
     }
     DDL.forEach(tEnv::executeSql);
 
-    return tEnv.explainSql(QUERY, ExplainFormat.TEXT);
+    return tEnv.explainSql(query, ExplainFormat.TEXT);
   }
 
   private CompilerConfig config(PredicatePushdownRules rules) {


### PR DESCRIPTION
## Summary

Volcano is the second largest cost of a large compile on `perf/combined-pr` and `FlinkCalcMergeRule` is its hottest rule. This PR profiles where that time goes and replaces `FlinkCalcMergeRule` with a copy that keeps the decision identical but skips the two Calc digest renderings Flink performs on every merge.

### What the profile says (JFR, stack depth 2048, warm server, cloud-backend core 3 cycles / metrics 3 cycles, combined build)

| | core (645 samples) | metrics (942 samples) |
|---|---|---|
| under `FlinkVolcanoProgram.optimize` | 36.9% | 14.2% |
| of which `VolcanoPlanner.getCost` (all from `propagateCostImprovements`) | 11.3% | 6.2% |
| of which `FlinkCalcMergeRule` (inclusive) | 11.9% | 3.4% |
| of which `ConverterRule` (logical + physical converters) | 14.0% | 5.9% |
| of which `registerImpl` digest hashing/equality | 4.3% | 1.1% |

Inside `FlinkCalcMergeRule` (core): `FlinkRelUtil.merge` 4.7% (`mergePrograms` + condition `simplify`), the two `getDigest()` calls of the trivial-top-Calc check 3.9%, `transformTo`/register 2.9%, `matches`/`isMergeable` 0.6%. Rendering a Calc digest (`CommonCalc.explainTerms` → `getExpressionString` per projection) is 11.0% of the whole core compile: 7.4% inside Volcano, 2.0% inside HepPlanner.

`getCost` never appears under a rule: every sample is `propagateCostImprovements` clearing the metadata cache of a parent and recomputing Flink's cost cascade (`FlinkRelMdSelectivity.estimateSelectivity`, row count, distinct row count, column interval, sizes). Not addressable from sqrl without changing costs.

Rule productions per compile (`RelOptPlanner` DEBUG, combined build):

| | core | metrics |
|---|---|---|
| `optimizeTree` runs | 126 = 42 sink blocks x 3 passes, no child blocks | 96 = 32 x 3 |
| `logical` (Volcano) share of optimize time | 54.5% (14.1 s of 25.8 s, cold + logging) | 19.7% |
| productions in `logical` | 56,463 | 16,995 |
| of which `FlinkCalcMergeRule` | 21,984 (10,992 `LogicalCalc` + 10,992 `FlinkLogicalCalc`) | 5,502 |
| of which `FlinkLogicalCalcConverter` | 12,798 | 4,251 |
| `FlinkCalcMergeRule` in `physical` | 450 | 201 |

### The change

`SqrlCalcMergeRule` is `FlinkCalcMergeRule` with one difference in `onMatch`: Flink computes `newCalc.getDigest().equals(bottomCalc.getDigest())` on every merge to decide whether the top Calc was trivial and can be pruned. The digest string of a Calc is `RelTypeName.traitSet(input=RelTypeName#id,select=...,where=...)`, so equality requires the same rel type name, trait set, output row type (names come from the `select` item, field types from Calcite's registration check) and the same presence of a condition. The copy tests those four cheap conditions first and only renders the two digests when they all hold, so it prunes exactly when Flink prunes. Wired in for the `logical`, `logical_rewrite` and `physical` programs through `FlinkPlannerConfigBuilder`, which now also skips non-rule-set programs instead of logging `Could not rewrite rules of program: physical_rewrite` three times per compile.

Also measured and not changed (identical plans, no measurable time difference): `table.optimizer.union-all-as-breakpoint-enabled=false`, `table.optimizer.multiple-input-enabled=true`, `table.optimizer.sql2rel.project-merge.enabled=false`. `reuse-source-enabled=false` changes the plan (source projection pushdown), `reuse-sub-plan-enabled=false` produces 7x the exec nodes, `reuse-optimize-block-with-digest-enabled=true` changes core's plan (381 vs 403 nodes) and fails metrics with `Event-Time Temporal Table Join requires both primary key and row time attribute in versioned table`.

### Benchmark

Two runs of `bench.py` (5 measured cycles per module after a warm-up cycle, one compile slot, 8 GB container) on a workstation shared with another job (1-minute load 2.2 at start, 4-5 during parts of the runs), so the noise is of the same order as the expected 4% on core. Run 1, combined first:

| module | variant | min | p50 | p80 | p95 | max | p50 vs combined |
|---|---|---|---|---|---|---|---|
| core | combined (1.0-perf-combined-SNAPSHOT) | 5.32 s | 5.44 s | 7.54 s | 7.73 s | 7.73 s | +0.0% |
| core | volcano (1.0-perf-volcano-SNAPSHOT) | 5.25 s | 5.35 s | 5.74 s | 6.01 s | 6.01 s | -1.7% |
| metrics | combined (1.0-perf-combined-SNAPSHOT) | 6.14 s | 7.24 s | 8.14 s | 9.89 s | 9.89 s | +0.0% |
| metrics | volcano (1.0-perf-volcano-SNAPSHOT) | 8.15 s | 8.25 s | 8.62 s | 9.20 s | 9.20 s | +13.9% |
| agent | combined (1.0-perf-combined-SNAPSHOT) | 0.48 s | 0.54 s | 0.57 s | 0.66 s | 0.66 s | +0.0% |
| agent | volcano (1.0-perf-volcano-SNAPSHOT) | 0.49 s | 0.51 s | 0.59 s | 0.62 s | 0.62 s | -4.8% |

Deterministic artifact digests (flink-sql-no-functions.sql, postgres-schema.sql, vertx.json, kafka.json, database-schema.sql): identical for every cycle; n = 5 cycles per module.

Run 2, reversed order (volcano first) to control for load drift; the combined metrics samples of run 1 fell from 9.9 s to 6.1 s over the five cycles while the volcano samples were flat:

| module | variant | min | p50 | p80 | p95 | max | p50 vs combined |
|---|---|---|---|---|---|---|---|
| core | combined (1.0-perf-combined-SNAPSHOT) | 4.95 s | 5.54 s | 6.52 s | 8.54 s | 8.54 s | +0.0% |
| core | volcano (1.0-perf-volcano-SNAPSHOT) | 5.21 s | 5.33 s | 5.38 s | 7.32 s | 7.32 s | -3.7% |
| metrics | combined (1.0-perf-combined-SNAPSHOT) | 6.99 s | 8.22 s | 8.30 s | 10.23 s | 10.23 s | +0.0% |
| metrics | volcano (1.0-perf-volcano-SNAPSHOT) | 7.62 s | 7.84 s | 8.28 s | 8.31 s | 8.31 s | -4.6% |
| agent | combined (1.0-perf-combined-SNAPSHOT) | 0.51 s | 0.53 s | 0.55 s | 0.78 s | 0.78 s | +0.0% |
| agent | volcano (1.0-perf-volcano-SNAPSHOT) | 0.48 s | 0.49 s | 0.55 s | 0.68 s | 0.68 s | -7.2% |

Deterministic artifact digests (flink-sql-no-functions.sql, postgres-schema.sql, vertx.json, kafka.json, database-schema.sql): identical for every cycle; n = 5 cycles per module.

The expected effect from the samples is about 4% on core (the two skipped digest renderings) and under 0.5% on metrics; run 2 matches that within noise, run 1's metrics row is load drift.

## Test plan

- [x] `FlinkPlannerConfigBuilderTest`: rule swap asserted for `logical`, `logical_rewrite`, `physical`; explained plans equal Flink's default program for the mini-batch temporal join query and two nested-Calc queries (11 tests)
- [x] `UseCaseCompileTest` 71 run, 0 failures (1 skipped, as on the base branch)
- [x] `DAGPlannerTest` 26 failures, the same 13 `$cor` snapshots and 13 `*-fail` cases as on `perf/combined-pr`
- [x] cloud-backend core, metrics and agent compiled with this jar and with the base jar: all 14/15 plan files byte-identical (including exec node ids)
