### PR TITLE
perf: drop PyFlink-only rules from the Flink stream optimizer programs

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/FlinkPlannerConfigBuilder.java
@@ -35,8 +35,10 @@ import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkChangelogModeInferenceProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkGroupProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
 import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
+import org.apache.flink.table.planner.plan.rules.logical.CalcPythonCorrelateTransposeRule;
 import org.apache.flink.table.planner.plan.rules.logical.FlinkFilterProjectTransposeRule;
 import org.apache.flink.table.planner.plan.rules.logical.FlinkProjectJoinTransposeRule;
 import org.apache.flink.table.planner.plan.rules.logical.PushFilterInCalcIntoTableSourceScanRule;
@@ -46,7 +48,20 @@ import org.apache.flink.table.planner.plan.rules.logical.PushPartitionIntoLegacy
 import org.apache.flink.table.planner.plan.rules.logical.PushPartitionIntoTableSourceScanRule;
 import org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoLegacyTableSourceScanRule;
 import org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoTableSourceScanRule;
+import org.apache.flink.table.planner.plan.rules.logical.PythonCalcSplitRule;
+import org.apache.flink.table.planner.plan.rules.logical.PythonCorrelateSplitRule;
+import org.apache.flink.table.planner.plan.rules.logical.PythonMapMergeRule;
+import org.apache.flink.table.planner.plan.rules.logical.PythonMapRenameRule;
+import org.apache.flink.table.planner.plan.rules.logical.SplitPythonConditionFromCorrelateRule;
+import org.apache.flink.table.planner.plan.rules.logical.SplitPythonConditionFromJoinRule;
 import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonAsyncCalcRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonCalcRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonCorrelateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonGroupAggregateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonGroupTableAggregateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonGroupWindowAggregateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalPythonOverAggregateRule;
 import scala.Tuple2;
 
 @RequiredArgsConstructor
@@ -87,6 +102,35 @@ public class FlinkPlannerConfigBuilder {
               // subgraphs around (temporal) joins.
               FlinkProjectJoinTransposeRule.INSTANCE)
           .build();
+
+  /**
+   * Rules that only match PyFlink calls, which SQRL cannot produce: zero attempts over 38 compiled
+   * projects. Matched by identity because the calc split rules share classes with async variants.
+   */
+  @VisibleForTesting
+  static final List<RelOptRule> PYTHON_RULES =
+      List.of(
+          SplitPythonConditionFromJoinRule.INSTANCE,
+          SplitPythonConditionFromCorrelateRule.INSTANCE,
+          CalcPythonCorrelateTransposeRule.INSTANCE,
+          PythonCorrelateSplitRule.INSTANCE,
+          PythonCalcSplitRule.SPLIT_CONDITION_REX_FIELD(),
+          PythonCalcSplitRule.SPLIT_PROJECTION_REX_FIELD(),
+          PythonCalcSplitRule.SPLIT_CONDITION(),
+          PythonCalcSplitRule.SPLIT_PROJECT(),
+          PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT(),
+          PythonCalcSplitRule.EXPAND_PROJECT(),
+          PythonCalcSplitRule.PUSH_CONDITION(),
+          PythonCalcSplitRule.REWRITE_PROJECT(),
+          PythonMapRenameRule.INSTANCE,
+          PythonMapMergeRule.INSTANCE,
+          StreamPhysicalPythonCalcRule.INSTANCE(),
+          StreamPhysicalPythonAsyncCalcRule.INSTANCE,
+          StreamPhysicalPythonGroupAggregateRule.INSTANCE,
+          StreamPhysicalPythonGroupTableAggregateRule.INSTANCE,
+          StreamPhysicalPythonOverAggregateRule.INSTANCE,
+          StreamPhysicalPythonGroupWindowAggregateRule.INSTANCE,
+          StreamPhysicalPythonCorrelateRule.INSTANCE);
 
   /** Table source rules to remove in case of {@link PredicatePushdownRules#LIMITED_RULES}. */
   private static final List<RelOptRule> TABLE_SOURCE_RULES_TO_REMOVE =
@@ -140,6 +184,8 @@ public class FlinkPlannerConfigBuilder {
         customStreamProgram.addLast(programName, program);
         continue;
       }
+
+      stripRules(programName, program, FlinkPlannerConfigBuilder::isPythonRule);
 
       if (programName.equals(FlinkStreamProgram.PHYSICAL_REWRITE())) {
         replaceRules(
@@ -205,6 +251,10 @@ public class FlinkPlannerConfigBuilder {
     return rulesToMatch.stream().map(RelOptRule::getClass).anyMatch(cls -> cls.isInstance(rule));
   }
 
+  private static boolean isPythonRule(RelOptRule rule) {
+    return PYTHON_RULES.stream().anyMatch(python -> python == rule);
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
   ///// Reflection utils to access private Flink class fields
   ////////////////////////////////////////////////////////////////////////////////
@@ -255,8 +305,12 @@ public class FlinkPlannerConfigBuilder {
         continue;
       }
 
+      if (!(internalProgram instanceof FlinkRuleSetProgram)) {
+        continue;
+      }
+
       try {
-        var f = internalProgram.getClass().getSuperclass().getDeclaredField("rules");
+        var f = FlinkRuleSetProgram.class.getDeclaredField("rules");
         f.setAccessible(true);
 
         var current = (List<RelOptRule>) f.get(internalProgram);

--- a/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/planner/FlinkPlannerConfigBuilderTest.java
@@ -26,10 +26,14 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ExplainFormat;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkGroupProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkRuleSetProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram;
+import org.apache.flink.table.planner.plan.rules.logical.FlinkCalcMergeRule;
 import org.apache.flink.table.planner.plan.rules.physical.stream.MiniBatchIntervalInferRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCalcRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -96,6 +100,32 @@ class FlinkPlannerConfigBuilderTest {
         .isEmpty();
   }
 
+  @ParameterizedTest
+  @EnumSource(PredicatePushdownRules.class)
+  void givenAnyPushdownRules_whenBuild_thenNoProgramContainsPythonRules(
+      PredicatePushdownRules rules) {
+    var plannerConfig =
+        (CalciteConfig) new FlinkPlannerConfigBuilder(config(rules), new Configuration()).build();
+    var streamProgram = plannerConfig.getStreamProgram().get();
+
+    var ruleSetPrograms =
+        streamProgram.getProgramNames().stream()
+            .map(name -> streamProgram.get(name).get())
+            .flatMap(program -> ruleSetPrograms(program).stream())
+            .toList();
+
+    assertThat(ruleSetPrograms).hasSizeGreaterThan(20);
+    assertThat(ruleSetPrograms)
+        .filteredOn(p -> p.contains(FlinkCalcMergeRule.INSTANCE))
+        .hasSizeGreaterThanOrEqualTo(2);
+    assertThat(ruleSetPrograms)
+        .filteredOn(p -> p.contains(StreamPhysicalCalcRule.INSTANCE()))
+        .hasSize(1);
+    for (var pythonRule : FlinkPlannerConfigBuilder.PYTHON_RULES) {
+      assertThat(ruleSetPrograms).filteredOn(p -> p.contains(pythonRule)).isEmpty();
+    }
+  }
+
   @Test
   void givenMiniBatchTemporalJoin_whenExplain_thenPlanEqualsFlinkDefaultProgram() {
     var sqrlPlan = explain(true);
@@ -126,6 +156,18 @@ class FlinkPlannerConfigBuilderTest {
     var compilerConf = mock(CompilerConfig.class);
     when(compilerConf.predicatePushdownRules()).thenReturn(rules);
     return compilerConf;
+  }
+
+  private List<FlinkRuleSetProgram<?>> ruleSetPrograms(FlinkOptimizeProgram<?> program) {
+    if (program instanceof FlinkRuleSetProgram<?> ruleSetProgram) {
+      return List.of(ruleSetProgram);
+    }
+    if (program instanceof FlinkGroupProgram) {
+      return subPrograms(program).stream()
+          .flatMap(sub -> ruleSetPrograms(sub._1).stream())
+          .toList();
+    }
+    return List.of();
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Instrumented Flink's optimizer with Calcite's rule event logging (`org.apache.calcite.plan.RelOptPlanner` at DEBUG, attributed to programs via the `FlinkChainedProgram` / `FlinkGroupProgram` debug markers) over 38 compiled projects (three cloud-backend modules plus every compile job of datasqrl-examples' CI workflow; 17 of the 38 fail early on schema validation, which still exercises nothing past parsing) and counted rule attempts (`onMatch` calls) and productions (`transformTo` calls) per HEP/Volcano program and per rule.

Result: 102 of the 152 HEP rule instances never produced anything, but almost all of them can legitimately fire on SQL shapes, connector abilities or Flink config that the corpus simply does not contain (sub-queries, INTERSECT/EXCEPT, lookup joins, group windows, async UDFs, watermark push-down into sources, two-phase aggregates, ...). Removing those would change plans for programs outside the corpus, so they stay. The only rules that SQRL structurally cannot exercise are the PyFlink ones: SQRL has no Python function loader (`ClasspathFunctionLoader` accepts Java `ScalarFunction`, `AggregateFunction`, `TableFunction`, `TableAggregateFunction`, `ProcessTableFunction` and `AsyncScalarFunction` only).

This PR:

- removes the 21 PyFlink-only rule instances from the stream program through the existing rule-rewrite mechanism in `FlinkPlannerConfigBuilder`: 14 from the `logical_rewrite` HEP `RULE_SEQUENCE` program (46 -> 32 rules; each `RULE_SEQUENCE` rule costs one HepPlanner graph iteration per block per pass even when it never matches) and 7 converter rules from the `physical` Volcano program (52 -> 45). Matching is by identity because the Python `RemoteCalc*Rule` instances share their classes with the async variants, which must stay.
- fixes the cosmetic `WARN Could not rewrite rules of program: physical_rewrite ... NoSuchFieldException: rules` that `rewriteRules` logged twice per compile for the rule-less sub-programs of `physical_rewrite` (changelog inference, trait init programs, the insert-conflict program): non-`FlinkRuleSetProgram` entries are now skipped silently.

Plans are identical by construction (the removed rules had zero attempts, so no other rule ever saw a different input) and verified: cloud-backend `flink-sql.sql`, `flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json` and `flink-compiled-plan.json` are byte-identical to the base branch for core, agent and metrics, and the rule attempt/production counts of every remaining rule are unchanged across all 38 projects.

## Rule statistics

Attempts = `onMatch` calls, productions = `transformTo` calls, summed over the 38 projects (one cold compile each, `compile` CLI with the base-branch jar). The "rules" column is Flink's default program; after this PR `logical_rewrite` has 32 and `physical` 45 rules, every other program is unchanged. Volcano programs are listed for context only.

#### combined jar (before): per program

| program (Flink) | kind | rules | never attempted | attempted, never produced | attempts | productions |
|---|---|---|---|---|---|---|
| `subquery_rewrite/convert table references before rewriting sub-queries to semi-join` | HEP BOTTOM_UP/RULE_SEQUENCE | 1 | 1 | 0 | 0 | 0 |
| `subquery_rewrite/rewrite sub-queries to semi-join` | HEP BOTTOM_UP/RULE_SEQUENCE | 5 | 3 | 1 | 25789 | 390 |
| `subquery_rewrite/sub-queries remove` | HEP BOTTOM_UP/RULE_COLLECTION | 3 | 3 | 0 | 0 | 0 |
| `subquery_rewrite/convert table references after sub-queries removed` | HEP BOTTOM_UP/RULE_SEQUENCE | 1 | 1 | 0 | 0 | 0 |
| `temporal_join_rewrite/convert correlate to temporal table join` | HEP BOTTOM_UP/RULE_SEQUENCE | 5 | 4 | 0 | 1251 | 1251 |
| `temporal_join_rewrite/convert enumerable table scan` | HEP BOTTOM_UP/RULE_SEQUENCE | 1 | 1 | 0 | 0 | 0 |
| `decorrelate/pre-rewrite before decorrelation` | HEP BOTTOM_UP/RULE_SEQUENCE | 1 | 1 | 0 | 0 | 0 |
| `decorrelate/#0` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `default_rewrite` | HEP BOTTOM_UP/RULE_SEQUENCE | 32 | 13 | 7 | 76169 | 14463 |
| `predicate_pushdown/predicate rewrite/join predicate rewrite` | HEP BOTTOM_UP/RULE_SEQUENCE | 1 | 0 | 1 | 5625 | 0 |
| `predicate_pushdown/predicate rewrite/filter rules` | HEP BOTTOM_UP/RULE_COLLECTION | 14 | 6 | 6 | 122024 | 435 |
| `predicate_pushdown/push predicate into table scan/push down partitions into table scan` | HEP BOTTOM_UP/RULE_SEQUENCE | 2 | 2 | 0 | 0 | 0 |
| `predicate_pushdown/push predicate into table scan/push down filters into table scan` | HEP BOTTOM_UP/RULE_SEQUENCE | 2 | 2 | 0 | 0 | 0 |
| `predicate_pushdown/prune empty after predicate push down` | HEP BOTTOM_UP/RULE_SEQUENCE | 10 | 10 | 0 | 0 | 0 |
| `multi_join/merge binary regular joins into MultiJoin` | HEP BOTTOM_UP/RULE_COLLECTION | 1 | 1 | 0 | 0 | 0 |
| `project_rewrite` | HEP BOTTOM_UP/RULE_COLLECTION | 9 | 2 | 1 | 116516 | 6045 |
| `logical` | VOLCANO  | 88 | 53 | 8 | 85997 | 78038 |
| `logical_rewrite/#0` | HEP BOTTOM_UP/RULE_SEQUENCE | 46 | 40 | 0 | 17527 | 17527 |
| `time_indicator` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `physical` | VOLCANO  | 52 | 32 | 0 | 12282 | 12282 |
| `physical_rewrite/mark changelog normalize reusing same source` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `physical_rewrite/watermark transpose` | HEP BOTTOM_UP/RULE_COLLECTION | 3 | 2 | 0 | 12 | 12 |
| `physical_rewrite/Changelog mode inference` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `physical_rewrite/Initialization for mini-batch interval inference` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `physical_rewrite/mini-batch interval rules` (SqrlMiniBatchIntervalInferRule) | HEP TOP_DOWN/RULE_SEQUENCE | 1 | 0 | 0 | 1038116 | 5904 |
| `physical_rewrite/initialization for duplicate changes inference` | OTHER  | 1 | 1 | 0 | 0 | 0 |
| `physical_rewrite/duplicate changes rules` | HEP TOP_DOWN/RULE_SEQUENCE | 1 | 0 | 0 | 1659294 | 14013 |
| `physical_rewrite/physical rewrite` | HEP BOTTOM_UP/RULE_COLLECTION | 4 | 3 | 0 | 37 | 37 |

#### Rules with zero productions over all 38 workloads (HEP programs only)

| program | rule | attempts | class | verdict |
|---|---|---|---|---|
| `subquery_rewrite/convert table references before rewriting sub-queries to semi-join` | EnumerableToLogicalTableScan | 0 | EnumerableToLogicalTableScan | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/rewrite sub-queries to semi-join` | FlinkRewriteSubQueryRule:Filter | 0 | FlinkRewriteSubQueryRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/rewrite sub-queries to semi-join` | FlinkSubQueryRemoveRule:Filter | 0 | FlinkSubQueryRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/rewrite sub-queries to semi-join` | JoinConditionTypeCoerceRule | 0 | JoinConditionTypeCoerceRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/rewrite sub-queries to semi-join` | JoinPushExpressionsRule | 90 | JoinPushExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/sub-queries remove` | SubQueryRemoveRule:Filter | 0 | SubQueryRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/sub-queries remove` | SubQueryRemoveRule:Project | 0 | SubQueryRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/sub-queries remove` | SubQueryRemoveRule:Join | 0 | SubQueryRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `subquery_rewrite/convert table references after sub-queries removed` | EnumerableToLogicalTableScan | 0 | EnumerableToLogicalTableScan | kept: fires on user SQL shapes absent from the corpus |
| `temporal_join_rewrite/convert correlate to temporal table join` | LogicalCorrelateToJoinFromLookupTableRuleWithFilter | 0 | LogicalCorrelateToJoinFromLookupTableRuleWithFilter | kept: depends on connector abilities / features outside the corpus |
| `temporal_join_rewrite/convert correlate to temporal table join` | LogicalCorrelateToJoinFromLookupTableRuleWithoutFilter | 0 | LogicalCorrelateToJoinFromLookupTableRuleWithoutFilter | kept: depends on connector abilities / features outside the corpus |
| `temporal_join_rewrite/convert correlate to temporal table join` | LogicalCorrelateToJoinFromTemporalTableRuleWithoutFilter | 0 | LogicalCorrelateToJoinFromTemporalTableRuleWithoutFilter | kept: fires on user SQL shapes absent from the corpus |
| `temporal_join_rewrite/convert correlate to temporal table join` | LogicalCorrelateToJoinFromTemporalTableFunctionRule | 0 | LogicalCorrelateToJoinFromTemporalTableFunctionRule | kept: fires on user SQL shapes absent from the corpus |
| `temporal_join_rewrite/convert enumerable table scan` | EnumerableToLogicalTableScan | 0 | EnumerableToLogicalTableScan | kept: fires on user SQL shapes absent from the corpus |
| `decorrelate/pre-rewrite before decorrelation` | CorrelateSortToRankRule | 0 | CorrelateSortToRankRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | SimplifyFilterConditionRule | 2158 | SimplifyFilterConditionRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | SimplifyJoinConditionRule | 1341 | SimplifyJoinConditionRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | JoinConditionTypeCoerceRule | 0 | JoinConditionTypeCoerceRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | JoinPushExpressionsRule | 1341 | JoinPushExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | SimplifyCoalesceWithEquiJoinConditionRule | 45 | SimplifyCoalesceWithEquiJoinConditionRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | ReduceExpressionsRule(Calc) | 0 | ReduceExpressionsRule$CalcReduceExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | AggregateProjectPullUpConstantsRule | 166 | AggregateProjectPullUpConstantsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | StreamLogicalWindowAggregateRule | 0 | StreamLogicalWindowAggregateRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | WindowPropertiesRule | 0 | WindowPropertiesRules$WindowPropertiesRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | WindowPropertiesHavingRule | 0 | WindowPropertiesRules$WindowPropertiesHavingRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | CoerceInputsRule:org.apache.calcite.rel.logical.LogicalIntersect | 0 | CoerceInputsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | CoerceInputsRule:org.apache.calcite.rel.logical.LogicalMinus | 0 | CoerceInputsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | ConvertToNotInOrInRule | 2158 | ConvertToNotInOrInRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | PruneSortLimit0 | 0 | PruneEmptyRules$SortFetchZeroRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | UncollectToTableFunctionScanRule | 0 | UncollectToTableFunctionScanRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | ConstantVectorSearchCallToCorrelateRule | 0 | ConstantVectorSearchCallToCorrelateRule | kept: depends on connector abilities / features outside the corpus |
| `default_rewrite` | JoinTableFunctionScanToCorrelateRule | 0 | JoinTableFunctionScanToCorrelateRule | kept: depends on connector abilities / features outside the corpus |
| `default_rewrite` | WrapJsonAggFunctionArgumentsRule | 0 | WrapJsonAggFunctionArgumentsRule | kept: fires on user SQL shapes absent from the corpus |
| `default_rewrite` | PruneCountStarInputRule | 0 | PruneCountStarInputRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/join predicate rewrite` | JoinDependentConditionDerivationRule | 5625 | JoinDependentConditionDerivationRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | FlinkJoinConditionPushRule | 960 | FlinkFilterJoinRule$FlinkJoinConditionPushRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | FilterAggregateTransposeRule | 0 | FilterAggregateTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | FlinkFilterProjectTransposeRule | 0 | FlinkFilterProjectTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | FilterSetOpTransposeRule | 0 | FilterSetOpTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | FilterMergeRule | 0 | FilterMergeRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | SimplifyFilterConditionRule | 17321 | SimplifyFilterConditionRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | SimplifyJoinConditionRule | 13818 | SimplifyJoinConditionRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | JoinConditionTypeCoerceRule | 0 | JoinConditionTypeCoerceRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | JoinPushExpressionsRule | 13818 | JoinPushExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | ReduceExpressionsRule(Filter) | 17321 | ReduceExpressionsRule$FilterReduceExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | ReduceExpressionsRule(Calc) | 0 | ReduceExpressionsRule$CalcReduceExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/predicate rewrite/filter rules` | ReduceExpressionsRule(Join) | 13818 | ReduceExpressionsRule$JoinReduceExpressionsRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/push predicate into table scan/push down partitions into table scan` | PushPartitionIntoLegacyTableSourceScanRule | 0 | PushPartitionIntoLegacyTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `predicate_pushdown/push predicate into table scan/push down partitions into table scan` | PushPartitionIntoTableSourceScanRule | 0 | PushPartitionIntoTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `predicate_pushdown/push predicate into table scan/push down filters into table scan` | PushFilterIntoTableSourceScanRule | 0 | PushFilterIntoTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `predicate_pushdown/push predicate into table scan/push down filters into table scan` | PushFilterIntoLegacyTableSourceScanRule | 0 | PushFilterIntoLegacyTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `predicate_pushdown/prune empty after predicate push down` | Union | 0 | FlinkPruneEmptyRules$UnionEmptyPruneRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | Intersect | 0 | PruneEmptyRules$IntersectEmptyPruneRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | Minus | 0 | FlinkPruneEmptyRules$MinusEmptyPruneRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptyProject | 0 | PruneEmptyRules$RemoveEmptySingleRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptyFilter | 0 | PruneEmptyRules$RemoveEmptySingleRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptySort | 0 | PruneEmptyRules$RemoveEmptySingleRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptyAggregate | 0 | PruneEmptyRules$RemoveEmptySingleRule | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptyJoin(left) | 0 | PruneEmptyRules$JoinLeftEmptyRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | PruneEmptyJoin(right) | 0 | PruneEmptyRules$JoinRightEmptyRuleConfig$1 | kept: fires on user SQL shapes absent from the corpus |
| `predicate_pushdown/prune empty after predicate push down` | AggregateValuesRule | 0 | AggregateValuesRule | kept: fires on user SQL shapes absent from the corpus |
| `multi_join/merge binary regular joins into MultiJoin` | JoinToMultiJoinRule | 0 | JoinToMultiJoinRule | kept: gated by `table.optimizer.multi-join.enabled` |
| `project_rewrite` | ProjectMultiJoinTransposeRule | 0 | ProjectMultiJoinTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `project_rewrite` | ProjectSemiAntiJoinTransposeRule | 0 | ProjectSemiAntiJoinTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `project_rewrite` | AggregateProjectPullUpConstantsRule | 5088 | AggregateProjectPullUpConstantsRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | PushWatermarkIntoTableSourceScanRule | 0 | PushWatermarkIntoTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `logical_rewrite/#0` | SplitAggregateRule | 0 | SplitAggregateRule | kept: gated by `table.optimizer.distinct-agg.split.enabled` |
| `logical_rewrite/#0` | CalcSnapshotTransposeRule | 0 | CalcSnapshotTransposeRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | SplitRemoteConditionFromJoinRule | 0 | SplitRemoteConditionFromJoinRule | removed: PyFlink only |
| `logical_rewrite/#0` | SplitPythonConditionFromCorrelateRule | 0 | SplitPythonConditionFromCorrelateRule | removed: PyFlink only |
| `logical_rewrite/#0` | CalcPythonCorrelateTransposeRule | 0 | CalcPythonCorrelateTransposeRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCorrelateSplitRule-Python | 0 | RemoteCorrelateSplitRule | removed: PyFlink only |
| `logical_rewrite/#0` | RedundantRankNumberColumnRemoveRule | 0 | RedundantRankNumberColumnRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | CalcRemoveRule | 0 | CalcRemoveRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | PushFilterInCalcIntoTableSourceScanRule | 0 | PushFilterInCalcIntoTableSourceScanRule | kept: depends on connector abilities / features outside the corpus |
| `logical_rewrite/#0` | RemoteCalcSplitConditionRexFieldRule | 0 | RemoteCalcSplitConditionRexFieldRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcSplitProjectionRexFieldRule | 0 | RemoteCalcSplitProjectionRexFieldRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcSplitConditionRule | 0 | RemoteCalcSplitConditionRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcSplitProjectionRule | 0 | RemoteCalcSplitProjectionRule | removed: PyFlink only |
| `logical_rewrite/#0` | PythonCalcSplitPandasInProjectionRule | 0 | PythonCalcSplitPandasInProjectionRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcExpandProjectRule | 0 | RemoteCalcExpandProjectRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcPushConditionRule | 0 | RemoteCalcPushConditionRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCalcRewriteProjectionRule | 0 | RemoteCalcRewriteProjectionRule | removed: PyFlink only |
| `logical_rewrite/#0` | PythonMapRenameRule | 0 | PythonMapRenameRule | removed: PyFlink only |
| `logical_rewrite/#0` | PythonMapMergeRule | 0 | PythonMapMergeRule | removed: PyFlink only |
| `logical_rewrite/#0` | RemoteCorrelateSplitRule-Async | 0 | RemoteCorrelateSplitRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCorrelateSplitRule-Async | 0 | RemoteCorrelateSplitRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcSplitConditionRexFieldRule | 0 | RemoteCalcSplitConditionRexFieldRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcSplitProjectionRexFieldRule | 0 | RemoteCalcSplitProjectionRexFieldRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | SplitRemoteConditionFromJoinRule | 0 | SplitRemoteConditionFromJoinRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcSplitConditionRule | 0 | RemoteCalcSplitConditionRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcSplitProjectionRule | 0 | RemoteCalcSplitProjectionRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcExpandProjectRule | 0 | RemoteCalcExpandProjectRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcPushConditionRule | 0 | RemoteCalcPushConditionRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | RemoteCalcRewriteProjectionRule | 0 | RemoteCalcRewriteProjectionRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | AsyncCalcSplitNestedRule | 0 | AsyncCalcSplitRule$AsyncCalcSplitNestedRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | AsyncCalcSplitOnePerCalcRule | 0 | AsyncCalcSplitRule$AsyncCalcSplitOnePerCalcRule | kept: async UDF rule, SQRL loads AsyncScalarFunction UDFs |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_CALC_SNAPSHOT_CALC_WMA_CALC | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_CALC_SNAPSHOT_CALC_WMA | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_CALC_SNAPSHOT_WMA_CALC | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_CALC_SNAPSHOT_WMA | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_SNAPSHOT_CALC_WMA_CALC | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_SNAPSHOT_CALC_WMA | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_SNAPSHOT_WMA_CALC | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `logical_rewrite/#0` | EventTimeTemporalJoinRewriteRule_SNAPSHOT_WMA | 0 | EventTimeTemporalJoinRewriteRule | kept: fires on user SQL shapes absent from the corpus |
| `physical_rewrite/watermark transpose` | WatermarkAssignerChangelogNormalizeTransposeRuleWithCalc | 0 | WatermarkAssignerChangelogNormalizeTransposeRule | kept: depends on connector abilities / features outside the corpus |
| `physical_rewrite/watermark transpose` | WatermarkAssignerChangelogNormalizeTransposeRuleWithoutCalc | 0 | WatermarkAssignerChangelogNormalizeTransposeRule | kept: depends on connector abilities / features outside the corpus |
| `physical_rewrite/physical rewrite` | TwoStageOptimizedAggregateRule | 0 | TwoStageOptimizedAggregateRule | kept: gated by `agg-phase-strategy + mini-batch` |
| `physical_rewrite/physical rewrite` | IncrementalAggregateRule | 0 | IncrementalAggregateRule | kept: gated by `incremental-agg + mini-batch` |
| `physical_rewrite/physical rewrite` | DeltaJoinRewriteRule | 0 | DeltaJoinRewriteRule | kept: gated by `table.optimizer.delta-join.strategy` |


## Benchmark

Warm server-side compile time (`X-Sqrl-Duration-Ms`) of cloud-backend `core`, `agent` and `metrics` with `package.json package-test-static.json` against the compilation server image, one warm-up compile per module, `combined` = base branch jar. Deterministic artifacts identical in every cycle (digest column). The machine was shared with other build jobs during both runs (1-minute load average 1.4-5.4, median 2.0), so the noise floor is around +-10%.

Alternating A/B, both servers up at the same time, compiles alternate between the two jars, 10 cycles (load 2.51 at start, 1.85 at end):

| module | variant | n | min | p50 | p80 | p95 | max | digest |
|---|---|---|---|---|---|---|---|---|
| core | combined | 10 | 4613 | 5479 | 5765 | 6665 | 7345 | dd2374da6213 |
| core | prune-rules | 10 | 4535 | 5254 | 5500 | 6306 | 6878 | dd2374da6213 |
| agent | combined | 10 | 445 | 560 | 1009 | 2636 | 2704 | 9db971d89c67 |
| agent | prune-rules | 10 | 456 | 508 | 1006 | 1979 | 2419 | 9db971d89c67 |
| metrics | combined | 10 | 6299 | 6828 | 8196 | 8508 | 8557 | abf1e1301083 |
| metrics | prune-rules | 10 | 6191 | 7319 | 8060 | 9260 | 10230 | abf1e1301083 |

Paired per-cycle deltas (prune-rules minus combined, same cycle): core median -68 ms (faster in 5/10 cycles), agent -44 ms (7/10), metrics +156 ms (4/10).

Sequential run, 5 cycles per jar (load 2.08 at start, 2.17 at end):

| module | variant | n | min | p50 | p80 | p95 | max | digest |
|---|---|---|---|---|---|---|---|---|
| core | combined | 5 | 4855 | 5356 | 6011 | 7582 | 8106 | dd2374da6213 |
| core | prune-rules | 5 | 5370 | 5457 | 7383 | 7463 | 7489 | dd2374da6213 |
| agent | combined | 5 | 517 | 565 | 724 | 996 | 1087 | 9db971d89c67 |
| agent | prune-rules | 5 | 468 | 514 | 564 | 661 | 694 | 9db971d89c67 |
| metrics | combined | 5 | 6193 | 7063 | 7710 | 7774 | 7796 | abf1e1301083 |
| metrics | prune-rules | 5 | 7645 | 8298 | 8635 | 9153 | 9325 | abf1e1301083 |

Conclusion: no measurable wall-clock change. The removed rules never matched, so what disappears is one HepPlanner graph iteration plus one operand check per vertex for each of the 14 `logical_rewrite` rules per block per pass (about 130 program runs on core), which is below the noise floor of this machine. The value of this PR is the evidence table above (rule pruning on the HEP side is exhausted: every other never-firing rule is legitimately reachable), the smaller rule sets, and the removed warning.

The two `TOP_DOWN` trait-inference programs dominate what is left of HEP time on large projects: `DuplicateChangesInferRule` needs 1.66M attempts for 14k productions and `SqrlMiniBatchIntervalInferRule` 1.04M attempts for 5.9k productions (each real transformation restarts the pass from the root). That is a different change (single-pass inference), not rule pruning.

## Test plan

- [x] `FlinkPlannerConfigBuilderTest` (9 tests): new parameterized test asserts no program contains any `PYTHON_RULES` instance while `FlinkCalcMergeRule` / `StreamPhysicalCalcRule` are still present; the existing explain-equality test against Flink's default program still passes.
- [x] `UseCaseCompileTest`: 71 run, 0 failures, 1 skipped.
- [x] `DAGPlannerTest`: 101 run, 13 failures, identical set to the base branch run on the same machine (`comprehensiveTest`, `createTable`, `databasejoin-w-hash`, `importScriptInlineTest`, `lateralJoinTableFunction`, `mutationInsertTypeTest`, `mutationNestedTypeTest`, `nestedTableWithUnnest`, `overview`, `selectDistinctTest`, `subqueryTest`, `tableRowCounts`, `temporalJoinTest`; all diffs are `$cor` correlation-id renumbering already present on the base branch).
- [x] cloud-backend core, agent, metrics artifacts byte-identical to the base branch jar (`flink-sql.sql`, `flink-sql-no-functions.sql`, `postgres-schema.sql`, `vertx.json`, `kafka.json`, `flink-compiled-plan.json`).
- [x] Rule event logging re-run with this branch's jar over the same 38 projects: identical attempt/production counts for every remaining rule, identical exit codes.
- [x] The `Could not rewrite rules of program: physical_rewrite` warning no longer appears in compile output.
