### PR TITLE
feat: Log forwarded client addresses in Vert.x

### DIFF
--- a/sqrl-cli/src/main/resources/templates/server-config.json
+++ b/sqrl-cli/src/main/resources/templates/server-config.json
@@ -6,6 +6,7 @@
     "mcpEndpoint" : "/mcp",
     "usePgPool" : true
   },
+  "logForwardedClientAddress" : false,
   "graphQLHandlerOptions" : {
     "requestBatchingEnabled" : false,
     "requestMultipartEnabled" : false

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/ClientAddressResolver.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/ClientAddressResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server;
+
+import com.google.common.net.InetAddresses;
+import io.vertx.core.http.HttpServerRequest;
+import java.net.InetAddress;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+/** Resolves the client address from the configured request source. */
+public class ClientAddressResolver {
+
+  private final boolean logForwardedClientAddress;
+
+  public ClientAddressResolver(boolean logForwardedClientAddress) {
+    this.logForwardedClientAddress = logForwardedClientAddress;
+  }
+
+  public String resolve(HttpServerRequest request) {
+    var remoteAddress = request.remoteAddress();
+    if (remoteAddress == null) {
+      return "unknown";
+    }
+
+    var peerAddress = remoteAddress.host();
+    if (!logForwardedClientAddress) {
+      return peerAddress;
+    }
+
+    return firstForwardedAddress(request.getHeader("X-Forwarded-For")).orElse(peerAddress);
+  }
+
+  private Optional<String> firstForwardedAddress(String forwardedFor) {
+    if (StringUtils.isBlank(forwardedFor)) {
+      return Optional.empty();
+    }
+
+    var firstAddress = forwardedFor.split(",", 2)[0].trim();
+
+    return parseAddress(firstAddress).map(ignored -> firstAddress);
+  }
+
+  private static Optional<InetAddress> parseAddress(String value) {
+    if (!InetAddresses.isInetAddress(value)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(InetAddresses.forString(value));
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/DetailedRequestTracer.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/DetailedRequestTracer.java
@@ -29,7 +29,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DetailedRequestTracer implements Handler<RoutingContext> {
 
+  private final ClientAddressResolver clientAddressResolver;
+
   public DetailedRequestTracer() {
+    this(new ClientAddressResolver(true));
+  }
+
+  public DetailedRequestTracer(ClientAddressResolver clientAddressResolver) {
+    this.clientAddressResolver = clientAddressResolver;
     log.info("DetailedRequestTracer enabled");
   }
 
@@ -96,7 +103,7 @@ public class DetailedRequestTracer implements Handler<RoutingContext> {
         request.uri(),
         headers.isEmpty() ? "none" : headers,
         params.isEmpty() ? "none" : params,
-        request.remoteAddress() != null ? request.remoteAddress().toString() : "unknown",
+        clientAddressResolver.resolve(request),
         requestBody,
         requestBodySize);
   }

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/ForwardedClientAddressLogFormatter.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/ForwardedClientAddressLogFormatter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server;
+
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerFormatter;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+
+/** Formats Vert.x's default access log layout with the resolved client address. */
+@RequiredArgsConstructor
+public class ForwardedClientAddressLogFormatter implements LoggerFormatter {
+
+  private final ClientAddressResolver clientAddressResolver;
+
+  @Override
+  public String format(RoutingContext context, long duration) {
+    var request = context.request();
+    var response = request.response();
+    var referrer = request.getHeader("Referrer");
+    if (referrer == null) {
+      referrer = request.getHeader("Referer");
+    }
+    var userAgent = request.getHeader("User-Agent");
+
+    return String.format(
+        "%s - - [%s] \"%s %s %s\" %d %d \"%s\" \"%s\"",
+        clientAddressResolver.resolve(request),
+        DateTimeFormatter.RFC_1123_DATE_TIME.format(
+            Instant.ofEpochMilli(System.currentTimeMillis() - duration).atZone(ZoneOffset.UTC)),
+        request.method(),
+        request.uri(),
+        formatHttpVersion(request.version()),
+        response.getStatusCode(),
+        response.bytesWritten(),
+        referrer == null ? "-" : referrer,
+        userAgent == null ? "-" : userAgent);
+  }
+
+  private String formatHttpVersion(HttpVersion version) {
+    return switch (version) {
+      case HTTP_1_0 -> "HTTP/1.0";
+      case HTTP_1_1 -> "HTTP/1.1";
+      case HTTP_2 -> "HTTP/2.0";
+      default -> "-";
+    };
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/ServerConfig.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/config/ServerConfig.java
@@ -66,6 +66,7 @@ public class ServerConfig {
   private GraphQLParserConfig graphQLParserConfig = new GraphQLParserConfig();
   private Map<String, Object> jwtAuth;
   private OAuthConfig oauthConfig;
+  private boolean logForwardedClientAddress = true;
 
   private KafkaConfig.KafkaMutationConfig kafkaMutationConfig;
   private KafkaConfig.KafkaSubscriptionConfig kafkaSubscriptionConfig;

--- a/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/modules/GlobalHandlersModule.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/main/java/com/datasqrl/server/modules/GlobalHandlersModule.java
@@ -15,11 +15,14 @@
  */
 package com.datasqrl.server.modules;
 
+import com.datasqrl.server.ClientAddressResolver;
 import com.datasqrl.server.DetailedRequestTracer;
+import com.datasqrl.server.ForwardedClientAddressLogFormatter;
 import com.datasqrl.server.config.CorsHandlerOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.handler.LoggerFormat;
 import io.vertx.ext.web.handler.LoggerHandler;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -30,13 +33,22 @@ public class GlobalHandlersModule implements ServerModule<VertxServerModuleConte
   @Override
   public CompletionStage<Void> configure(VertxServerModuleContext ctx) {
     var router = ctx.router();
+    var logForwardedClientAddress = ctx.config().isLogForwardedClientAddress();
+    var clientAddressResolver = new ClientAddressResolver(logForwardedClientAddress);
 
     router.route().handler(toCorsHandler(ctx.config().getCorsHandlerOptions()));
     router.route().handler(BodyHandler.create());
 
     // Detailed tracing reads request bodies, so it must remain after BodyHandler.
     if (System.getenv("SQRL_DEBUG") != null) {
-      router.route().handler(new DetailedRequestTracer());
+      router.route().handler(new DetailedRequestTracer(clientAddressResolver));
+
+    } else if (logForwardedClientAddress) {
+      var handler =
+          LoggerHandler.create(LoggerFormat.CUSTOM)
+              .customFormatter(new ForwardedClientAddressLogFormatter(clientAddressResolver));
+      router.route().handler(handler);
+
     } else {
       router.route().handler(LoggerHandler.create());
     }

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/ClientAddressResolverTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/ClientAddressResolverTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import org.junit.jupiter.api.Test;
+
+class ClientAddressResolverTest {
+
+  @Test
+  void givenForwardedAddressDisabled_whenResolvingAddress_thenReturnsPeerAddress() {
+    var request = requestFrom("203.0.113.10", "198.51.100.20");
+
+    var address = new ClientAddressResolver(false).resolve(request);
+
+    assertThat(address).isEqualTo("203.0.113.10");
+  }
+
+  @Test
+  void givenForwardedAddressEnabled_whenResolvingAddress_thenReturnsOriginalClient() {
+    var request = requestFrom("10.11.5.76", "198.51.100.20, 10.11.5.76");
+
+    var address = new ClientAddressResolver(true).resolve(request);
+
+    assertThat(address).isEqualTo("198.51.100.20");
+  }
+
+  @Test
+  void givenInvalidForwardedAddress_whenResolvingAddress_thenReturnsPeerAddress() {
+    var request = requestFrom("10.11.5.76", "not-an-address");
+
+    var address = new ClientAddressResolver(true).resolve(request);
+
+    assertThat(address).isEqualTo("10.11.5.76");
+  }
+
+  @Test
+  void givenShorthandNumericForwardedAddress_whenResolvingAddress_thenReturnsPeerAddress() {
+    var request = requestFrom("10.11.5.76", "123");
+
+    var address = new ClientAddressResolver(true).resolve(request);
+
+    assertThat(address).isEqualTo("10.11.5.76");
+  }
+
+  private HttpServerRequest requestFrom(String peerAddress, String forwardedFor) {
+    var request = mock(HttpServerRequest.class);
+    when(request.remoteAddress()).thenReturn(SocketAddress.inetSocketAddress(8080, peerAddress));
+    when(request.getHeader("X-Forwarded-For")).thenReturn(forwardedFor);
+    return request;
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/ForwardedClientAddressLogFormatterTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/ForwardedClientAddressLogFormatterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+
+class ForwardedClientAddressLogFormatterTest {
+
+  @Test
+  void givenForwardedClientAddress_whenFormatting_thenUsesVertxDefaultLogLayout() {
+    var context = mock(RoutingContext.class);
+    var request = mock(HttpServerRequest.class);
+    var response = mock(HttpServerResponse.class);
+    when(context.request()).thenReturn(request);
+    when(request.remoteAddress()).thenReturn(SocketAddress.inetSocketAddress(8080, "10.11.5.76"));
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(request.getHeader("Referer")).thenReturn("https://example.com");
+    when(request.getHeader("User-Agent")).thenReturn("test-client");
+    when(request.method()).thenReturn(HttpMethod.POST);
+    when(request.uri()).thenReturn("/graphql");
+    when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+    when(request.response()).thenReturn(response);
+    when(response.getStatusCode()).thenReturn(200);
+    when(response.bytesWritten()).thenReturn(42L);
+
+    var logLine =
+        new ForwardedClientAddressLogFormatter(new ClientAddressResolver(true)).format(context, 0);
+
+    assertThat(logLine)
+        .matches(
+            "1\\.2\\.3\\.4 - - \\[.+] \\\"POST /graphql HTTP/1\\.1\\\" 200 42 \\\"https://example\\.com\\\" \\\"test-client\\\"");
+  }
+}

--- a/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
+++ b/sqrl-server/sqrl-server-vertx-base/src/test/java/com/datasqrl/server/config/ServerConfigTest.java
@@ -44,6 +44,7 @@ class ServerConfigTest {
     assertThat(serverConfig.getGraphQLParserConfig().getMaxTokens()).isNull();
     assertThat(serverConfig.getKafkaMutationConfig()).isNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNull();
+    assertThat(serverConfig.isLogForwardedClientAddress()).isTrue();
   }
 
   @Test
@@ -59,6 +60,7 @@ class ServerConfigTest {
     json.set("poolOptions", MAPPER.createObjectNode().put("maxSize", 20));
     json.set("corsHandlerOptions", MAPPER.createObjectNode().put("allowCredentials", true));
     json.set("jwtAuth", MAPPER.createObjectNode().put("algorithm", "HS256"));
+    json.put("logForwardedClientAddress", false);
     json.set("openApiConfig", MAPPER.createObjectNode().put("enabled", true));
     json.set(
         "graphQLTailSampleTracingConfig",
@@ -121,6 +123,7 @@ class ServerConfigTest {
     assertThat(serverConfig.getGraphQLParserConfig().getRedactTokenParserErrorMessages()).isTrue();
     assertThat(serverConfig.getKafkaMutationConfig()).isNotNull();
     assertThat(serverConfig.getKafkaSubscriptionConfig()).isNotNull();
+    assertThat(serverConfig.isLogForwardedClientAddress()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Key Changes

- Add `logForwardedClientAddress`, disabled by default, to control forwarded client IP logging.
- Enable the setting in cloud environment deployments where ingress validates `X-Forwarded-For`.
- Use Vert.x's custom `LoggerHandler` formatter to preserve native log lifecycle and severity handling.
- Validate forwarded IP literals with Guava's `InetAddresses`.