### PR TITLE
feat: Add Trino shallow query engine support

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/TrinoSqlConverters.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/convert/TrinoSqlConverters.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.calcite;
+package com.datasqrl.calcite.convert;
 
-public enum Dialect {
-  SQRL,
-  CALCITE,
-  FLINK,
-  POSTGRES,
-  SNOWFLAKE,
-  DUCKDB,
-  SPARK_SQL,
-  REDSHIFT,
-  TRINO
+import com.datasqrl.calcite.Dialect;
+import com.datasqrl.calcite.dialect.ExtendedTrinoSqlDialect;
+import com.google.auto.service.AutoService;
+
+@AutoService(SqlConverters.class)
+public class TrinoSqlConverters extends AbstractSqlConverters {
+
+  public TrinoSqlConverters() {
+    super(Dialect.TRINO, ExtendedTrinoSqlDialect.DEFAULT, false);
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/calcite/dialect/ExtendedTrinoSqlDialect.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/calcite/dialect/ExtendedTrinoSqlDialect.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.calcite.dialect;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.config.NullCollation;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.dialect.PrestoSqlDialect;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.util.RelToSqlConverterUtil;
+
+/**
+ * Temporary copy of Calcite 1.41's Trino dialect for the Calcite version bundled with Flink.
+ * Replace this class with {@code TrinoSqlDialect} when Flink upgrades Calcite.
+ */
+public class ExtendedTrinoSqlDialect extends PrestoSqlDialect {
+
+  public static final Context DEFAULT_CONTEXT =
+      // TRINO was added to Calcite's DatabaseProduct enum in 1.41. Use Presto's equivalent
+      // context until Flink upgrades Calcite.
+      PrestoSqlDialect.DEFAULT_CONTEXT
+          .withIdentifierQuoteString("\"")
+          .withUnquotedCasing(Casing.UNCHANGED)
+          .withNullCollation(NullCollation.LAST);
+
+  public static final ExtendedTrinoSqlDialect DEFAULT =
+      new ExtendedTrinoSqlDialect(DEFAULT_CONTEXT);
+
+  public ExtendedTrinoSqlDialect(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void unparseOffsetFetch(SqlWriter writer, SqlNode offset, SqlNode fetch) {
+    unparseFetchUsingAnsi(writer, offset, fetch);
+  }
+
+  @Override
+  public void unparseCall(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    if (call.getOperator() == SqlStdOperatorTable.SUBSTRING) {
+      // Bypass Presto's SUBSTR rendering; Trino uses the standard SUBSTRING spelling.
+      RelToSqlConverterUtil.specialOperatorByName("SUBSTRING").unparse(writer, call, 0, 0);
+    } else if (call.getOperator().getName().equalsIgnoreCase("APPROX_COUNT_DISTINCT")) {
+      RelToSqlConverterUtil.specialOperatorByName("APPROX_DISTINCT").unparse(writer, call, 0, 0);
+    } else {
+      super.unparseCall(writer, call, leftPrec, rightPrec);
+    }
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/AbstractJdbcStatementFactory.java
@@ -28,6 +28,7 @@ import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
 import com.datasqrl.deployment.model.JdbcStatementModel.Type;
 import com.datasqrl.engine.database.relational.CreateTableJdbcStatement.CreateTableDdlFactory;
 import com.datasqrl.engine.database.relational.ddl.GenericCreateViewDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.ViewIdentifierResolver;
 import com.datasqrl.planner.dag.plan.MaterializationStagePlan.Query;
 import com.datasqrl.planner.hint.DataTypeHint;
 import com.datasqrl.planner.hint.PartitionKeyHint;
@@ -85,6 +86,15 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
 
   protected abstract SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint);
 
+  protected GenericCreateViewDdlFactory getCreateViewDdlFactory() {
+    return new GenericCreateViewDdlFactory(
+        sqlConverters.getCalciteSqlDialect(), getViewIdentifierResolver());
+  }
+
+  protected ViewIdentifierResolver getViewIdentifierResolver() {
+    return viewName -> new SqlIdentifier(viewName, SqlParserPos.ZERO);
+  }
+
   @Override
   public QueryResult createQuery(
       Query query, boolean withView, Map<String, JdbcEngineCreateTable> tableIdMap) {
@@ -122,8 +132,7 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
     var viewName = query.function().getSimpleName();
     var rowType = query.relNode().getRowType();
     var viewSql =
-        new GenericCreateViewDdlFactory(sqlConverters.getCalciteSqlDialect())
-            .createView(viewName, rowType.getFieldNames(), passthroughSql);
+        getCreateViewDdlFactory().createView(viewName, rowType.getFieldNames(), passthroughSql);
     var view =
         new GenericJdbcStatement(
             viewName,
@@ -172,9 +181,7 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
 
     JdbcStatement view = null;
     if (withView) {
-      var viewSql =
-          new GenericCreateViewDdlFactory(sqlConverters.getCalciteSqlDialect())
-              .createView(viewName, rowType.getFieldNames(), sql);
+      var viewSql = getCreateViewDdlFactory().createView(viewName, rowType.getFieldNames(), sql);
 
       view = createViewStatement(viewName, rowType, viewSql, documentation);
     }
@@ -268,10 +275,6 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
     return sqlConverters.convert(createView);
   }
 
-  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
-    return new SqlIdentifier(viewName, SqlParserPos.ZERO);
-  }
-
   protected Set<DatabaseTypeExtension> extractTypeExtensions(
       Stream<RelNode> relNodes, List<DatabaseTypeExtension> extensions) {
     return relNodes
@@ -329,7 +332,7 @@ public abstract class AbstractJdbcStatementFactory implements JdbcStatementFacto
       RelDataType rowType,
       SqlNode sqlNode,
       Documented.Documentation documentation) {
-    var viewNameIdentifier = getViewStatementIdentifier(viewName);
+    var viewNameIdentifier = getCreateViewDdlFactory().getViewIdentifier(viewName);
     var columnList =
         new SqlNodeList(
             rowType.getFieldList().stream()

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/IcebergEngine.java
@@ -61,7 +61,8 @@ public class IcebergEngine extends AbstractJDBCTableFormatEngine {
     return engine instanceof SnowflakeEngine
         || engine instanceof DuckDBEngine
         || engine instanceof SparkSqlEngine
-        || engine instanceof RedshiftEngine;
+        || engine instanceof RedshiftEngine
+        || engine instanceof TrinoEngine;
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/RedshiftStatementFactory.java
@@ -18,15 +18,13 @@ package com.datasqrl.engine.database.relational;
 import com.datasqrl.calcite.Dialect;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.ddl.GenericCreateTableDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.ViewIdentifierResolver;
 import com.datasqrl.plan.global.IndexDefinition;
 import com.datasqrl.planner.hint.DataTypeHint;
-import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.dialect.RedshiftSqlDialect;
-import org.apache.calcite.sql.parser.SqlParserPos;
 
 public class RedshiftStatementFactory extends AbstractJdbcStatementFactory {
 
@@ -43,18 +41,9 @@ public class RedshiftStatementFactory extends AbstractJdbcStatementFactory {
   }
 
   @Override
-  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
-    var names = new ArrayList<String>();
-    var database = engineConfig.getPropertyOptional("view-database");
-    if (database.isPresent()) {
-      names.add(database.get());
-      names.add(engineConfig.getPropertyOptional("view-schema").orElse("public"));
-    } else {
-      engineConfig.getPropertyOptional("view-schema").ifPresent(names::add);
-    }
-    names.add(viewName);
-
-    return new SqlIdentifier(names, SqlParserPos.ZERO);
+  protected ViewIdentifierResolver getViewIdentifierResolver() {
+    return ViewIdentifierResolver.propertyHierarchy(
+        engineConfig, "view-database", "view-schema", "public");
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/SparkSqlStatementFactory.java
@@ -19,14 +19,12 @@ import com.datasqrl.calcite.Dialect;
 import com.datasqrl.calcite.dialect.ExtendedSparkSqlDialect;
 import com.datasqrl.config.PackageJson.EngineConfig;
 import com.datasqrl.engine.database.relational.ddl.GenericCreateTableDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.ViewIdentifierResolver;
 import com.datasqrl.plan.global.IndexDefinition;
 import com.datasqrl.planner.hint.DataTypeHint;
-import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.parser.SqlParserPos;
 
 public class SparkSqlStatementFactory extends AbstractJdbcStatementFactory {
 
@@ -43,17 +41,9 @@ public class SparkSqlStatementFactory extends AbstractJdbcStatementFactory {
   }
 
   @Override
-  protected SqlIdentifier getViewStatementIdentifier(String viewName) {
-    var names = new ArrayList<String>();
-    var catalog = engineConfig.getPropertyOptional("view-catalog");
-    if (catalog.isPresent()) {
-      names.add(catalog.get());
-      names.add(engineConfig.getPropertyOptional("view-database").orElse("default"));
-    } else {
-      engineConfig.getPropertyOptional("view-database").ifPresent(names::add);
-    }
-    names.add(viewName);
-    return new SqlIdentifier(names, SqlParserPos.ZERO);
+  protected ViewIdentifierResolver getViewIdentifierResolver() {
+    return ViewIdentifierResolver.propertyHierarchy(
+        engineConfig, "view-catalog", "view-database", "default");
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoEngine.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoEngine.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import com.datasqrl.config.ConnectorFactoryFactory;
+import com.datasqrl.config.JdbcDialect;
+import com.datasqrl.config.PackageJson;
+import jakarta.inject.Inject;
+import lombok.NonNull;
+
+public class TrinoEngine extends AbstractJDBCShallowQueryEngine {
+
+  @Inject
+  public TrinoEngine(@NonNull PackageJson json, ConnectorFactoryFactory connectorFactory) {
+    super(
+        TrinoEngineFactory.ENGINE_NAME,
+        json.getEngines().getEngineConfigOrEmpty(TrinoEngineFactory.ENGINE_NAME),
+        connectorFactory);
+  }
+
+  @Override
+  protected JdbcDialect getDialect() {
+    return JdbcDialect.Iceberg;
+  }
+
+  @Override
+  public JdbcStatementFactory getStatementFactory() {
+    return new TrinoStatementFactory(engineConfig);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoEngineFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoEngineFactory.java
@@ -13,16 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datasqrl.calcite;
+package com.datasqrl.engine.database.relational;
 
-public enum Dialect {
-  SQRL,
-  CALCITE,
-  FLINK,
-  POSTGRES,
-  SNOWFLAKE,
-  DUCKDB,
-  SPARK_SQL,
-  REDSHIFT,
-  TRINO
+import com.datasqrl.config.EngineFactory;
+import com.datasqrl.engine.database.DatabaseEngineFactory;
+import com.google.auto.service.AutoService;
+
+@AutoService(EngineFactory.class)
+public class TrinoEngineFactory implements DatabaseEngineFactory {
+
+  public static final String ENGINE_NAME = "trino";
+
+  @Override
+  public String getEngineName() {
+    return ENGINE_NAME;
+  }
+
+  @Override
+  public Class getFactoryClass() {
+    return TrinoEngine.class;
+  }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoStatementFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/TrinoStatementFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import com.datasqrl.calcite.Dialect;
+import com.datasqrl.calcite.dialect.ExtendedTrinoSqlDialect;
+import com.datasqrl.config.PackageJson.EngineConfig;
+import com.datasqrl.deployment.model.JdbcStatementModel.Field;
+import com.datasqrl.engine.database.relational.ddl.TrinoCreateTableDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.TrinoCreateViewDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.TrinoTypeFormatter;
+import com.datasqrl.engine.database.relational.ddl.ViewIdentifierResolver;
+import com.datasqrl.plan.global.IndexDefinition;
+import com.datasqrl.planner.hint.DataTypeHint;
+import com.datasqrl.planner.hint.PlannerHints;
+import com.datasqrl.planner.util.Documented.Documentation;
+import java.util.Optional;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+
+public class TrinoStatementFactory extends AbstractJdbcStatementFactory {
+  private final EngineConfig engineConfig;
+
+  public TrinoStatementFactory(EngineConfig engineConfig) {
+    super(Dialect.TRINO, new TrinoCreateTableDdlFactory());
+    this.engineConfig = engineConfig;
+  }
+
+  @Override
+  protected TrinoCreateViewDdlFactory getCreateViewDdlFactory() {
+    return new TrinoCreateViewDdlFactory(getViewIdentifierResolver());
+  }
+
+  @Override
+  protected ViewIdentifierResolver getViewIdentifierResolver() {
+    return ViewIdentifierResolver.propertyHierarchy(
+        engineConfig, "view-catalog", "view-schema", "public");
+  }
+
+  @Override
+  protected SqlNode getSqlType(RelDataType type, Optional<DataTypeHint> hint) {
+    return ExtendedTrinoSqlDialect.DEFAULT.getCastSpec(type);
+  }
+
+  @Override
+  protected Field toField(RelDataTypeField field, PlannerHints hints, Documentation documentation) {
+    return new Field(
+        field.getName(),
+        TrinoTypeFormatter.format(field.getType()),
+        field.getType().isNullable(),
+        documentation.getColumn(field.getName(), null));
+  }
+
+  @Override
+  protected String createView(SqlIdentifier viewName, SqlNodeList columns, SqlNode query) {
+    return getCreateViewDdlFactory().createView(viewName, sqlConverters.convert(query));
+  }
+
+  @Override
+  public JdbcStatement addIndex(IndexDefinition indexDefinition) {
+    throw new UnsupportedOperationException("Trino does not support indexes");
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/GenericCreateViewDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/GenericCreateViewDdlFactory.java
@@ -17,22 +17,36 @@ package com.datasqrl.engine.database.relational.ddl;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
 
-@RequiredArgsConstructor
 public class GenericCreateViewDdlFactory {
 
   private final DdlIdentifierQuoter identifierQuoter;
+  private final ViewIdentifierResolver viewIdentifierResolver;
 
-  public GenericCreateViewDdlFactory(SqlDialect dialect) {
-    this(new DdlIdentifierQuoter(dialect));
+  public GenericCreateViewDdlFactory(
+      SqlDialect dialect, ViewIdentifierResolver viewIdentifierResolver) {
+    this.identifierQuoter = new DdlIdentifierQuoter(dialect);
+    this.viewIdentifierResolver = viewIdentifierResolver;
   }
 
   public String createView(String viewName, List<String> columns, String select) {
+    return createView(getViewIdentifier(viewName), columns, select);
+  }
+
+  public String createView(SqlIdentifier viewName, List<String> columns, String select) {
     var colStr = columns.stream().map(identifierQuoter::quote).collect(Collectors.joining(", "));
 
     return "CREATE OR REPLACE VIEW %s (%s) AS %s"
-        .formatted(identifierQuoter.quote(viewName), colStr, select);
+        .formatted(quoteIdentifier(viewName), colStr, select);
+  }
+
+  public SqlIdentifier getViewIdentifier(String viewName) {
+    return viewIdentifierResolver.resolve(viewName);
+  }
+
+  protected String quoteIdentifier(SqlIdentifier identifier) {
+    return identifier.names.stream().map(identifierQuoter::quote).collect(Collectors.joining("."));
   }
 }

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoCreateTableDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoCreateTableDdlFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational.ddl;
+
+import com.datasqrl.calcite.dialect.ExtendedTrinoSqlDialect;
+import com.datasqrl.engine.database.relational.CreateTableJdbcStatement;
+import java.util.stream.Collectors;
+
+/** Trino has no PRIMARY KEY syntax; keys remain in the deployment model for Iceberg/Flink. */
+public class TrinoCreateTableDdlFactory extends GenericCreateTableDdlFactory {
+  public TrinoCreateTableDdlFactory() {
+    super(ExtendedTrinoSqlDialect.DEFAULT);
+  }
+
+  @Override
+  public String createTableDdl(CreateTableJdbcStatement statement) {
+    return "CREATE TABLE IF NOT EXISTS %s (%s)"
+        .formatted(
+            quoteIdentifier(statement.getName()),
+            statement.getFields().stream().map(this::fieldToSql).collect(Collectors.joining(", ")));
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoCreateViewDdlFactory.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoCreateViewDdlFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational.ddl;
+
+import com.datasqrl.calcite.dialect.ExtendedTrinoSqlDialect;
+import java.util.List;
+import org.apache.calcite.sql.SqlIdentifier;
+
+/** Trino takes view column names from the query's projection, not a DDL column list. */
+public class TrinoCreateViewDdlFactory extends GenericCreateViewDdlFactory {
+
+  public TrinoCreateViewDdlFactory(ViewIdentifierResolver viewIdentifierResolver) {
+    super(ExtendedTrinoSqlDialect.DEFAULT, viewIdentifierResolver);
+  }
+
+  @Override
+  public String createView(SqlIdentifier viewName, List<String> columns, String select) {
+    return createView(viewName, select);
+  }
+
+  public String createView(SqlIdentifier viewName, String select) {
+    return "CREATE OR REPLACE VIEW %s AS %s".formatted(quoteIdentifier(viewName), select);
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoTypeFormatter.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/TrinoTypeFormatter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational.ddl;
+
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/** Formats Calcite types using Trino's DDL grammar. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TrinoTypeFormatter {
+
+  public static String format(RelDataType type) {
+    SqlTypeName typeName = type.getSqlTypeName();
+    if (typeName == null) {
+      throw new IllegalArgumentException("Trino does not support type: " + type);
+    }
+
+    return switch (typeName) {
+      case CHAR -> "CHAR" + precision(type);
+      case VARCHAR ->
+          type.getPrecision() == Integer.MAX_VALUE ? "VARCHAR" : "VARCHAR" + precision(type);
+      case BINARY, VARBINARY -> "VARBINARY";
+      case DECIMAL -> "DECIMAL(%d, %d)".formatted(type.getPrecision(), type.getScale());
+      case FLOAT, REAL -> "REAL";
+      case TIMESTAMP -> "TIMESTAMP" + precision(type);
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE -> "TIMESTAMP" + precision(type) + " WITH TIME ZONE";
+      case TIME -> "TIME" + precision(type);
+      case TIME_WITH_LOCAL_TIME_ZONE -> "TIME" + precision(type) + " WITH TIME ZONE";
+      case ARRAY, MULTISET -> "ARRAY(" + format(type.getComponentType()) + ")";
+      case MAP -> "MAP(" + format(type.getKeyType()) + ", " + format(type.getValueType()) + ")";
+      case ROW -> "ROW(" + formatFields(type) + ")";
+      default -> typeName.getName();
+    };
+  }
+
+  private static String formatFields(RelDataType type) {
+    return type.getFieldList().stream()
+        .map(TrinoTypeFormatter::formatField)
+        .collect(Collectors.joining(", "));
+  }
+
+  private static String formatField(RelDataTypeField field) {
+    return quote(field.getName()) + " " + format(field.getType());
+  }
+
+  private static String quote(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+  }
+
+  private static String precision(RelDataType type) {
+    return type.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED
+        ? ""
+        : "(" + type.getPrecision() + ")";
+  }
+}

--- a/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/ViewIdentifierResolver.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/database/relational/ddl/ViewIdentifierResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational.ddl;
+
+import com.datasqrl.config.PackageJson.EngineConfig;
+import java.util.ArrayList;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/** Resolves a view name to the location where the engine creates the view. */
+@FunctionalInterface
+public interface ViewIdentifierResolver {
+
+  SqlIdentifier resolve(String viewName);
+
+  /**
+   * Resolves a view location with an optional parent and child property. When the parent is set,
+   * the child defaults to {@code defaultChild}; without a parent, the configured child is used on
+   * its own.
+   */
+  static ViewIdentifierResolver propertyHierarchy(
+      EngineConfig engineConfig, String parentProperty, String childProperty, String defaultChild) {
+    return viewName -> {
+      var names = new ArrayList<String>();
+      var parent = engineConfig.getPropertyOptional(parentProperty);
+
+      if (parent.isPresent()) {
+        names.add(parent.get());
+        names.add(engineConfig.getPropertyOptional(childProperty).orElse(defaultChild));
+      } else {
+        engineConfig.getPropertyOptional(childProperty).ifPresent(names::add);
+      }
+
+      names.add(viewName);
+
+      return new SqlIdentifier(names, SqlParserPos.ZERO);
+    };
+  }
+}

--- a/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
+++ b/sqrl-planner/src/main/resources/jsonSchema/packageSchema.json
@@ -28,6 +28,7 @@
           "redshift",
           "snowflake",
           "sparksql",
+          "trino",
           "vertx"
         ]
       },
@@ -239,6 +240,18 @@
           },
           "additionalProperties": false,
           "required": ["url"]
+        },
+        "trino": {
+          "type": "object",
+          "properties": {
+            "view-catalog": {
+              "type": "string"
+            },
+            "view-schema": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         },
         "redshift": {
           "type": "object",

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/TrinoStatementFactoryTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/TrinoStatementFactoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.engine.database.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.datasqrl.calcite.Dialect;
+import com.datasqrl.calcite.convert.SqlConvertersFactory;
+import com.datasqrl.config.PackageJson.EngineConfig;
+import com.datasqrl.deployment.model.JdbcStatementModel.Field;
+import com.datasqrl.deployment.model.JdbcStatementModel.PartitionType;
+import com.datasqrl.engine.database.relational.ddl.TrinoCreateTableDdlFactory;
+import com.datasqrl.engine.database.relational.ddl.TrinoTypeFormatter;
+import java.time.Duration;
+import java.util.List;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.sql.SqlDynamicParam;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.junit.jupiter.api.Test;
+
+class TrinoStatementFactoryTest {
+  @Test
+  void rendersTrinoFunctionsAndPagination() throws Exception {
+    var sql =
+        SqlParser.create(
+                "SELECT SUBSTRING(\"name\" FROM 2 FOR 3), CHAR_LENGTH(\"name\"), "
+                    + "APPROX_COUNT_DISTINCT(\"id\") FROM \"source\" OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY")
+            .parseQuery();
+    assertThat(SqlConvertersFactory.get(Dialect.TRINO).convert(sql))
+        .contains(
+            "SUBSTRING(\"name\", 2, 3)",
+            "APPROX_DISTINCT(\"id\")",
+            "OFFSET 5 ROWS",
+            "FETCH NEXT 10 ROWS ONLY");
+  }
+
+  @Test
+  void preservesLogicalParameterIndexesAndQuotedText() throws Exception {
+    var query =
+        (SqlSelect)
+            SqlParser.create("SELECT 'keep ? and $2', ? + ? + ? FROM \"source\"").parseQuery();
+    query
+        .getSelectList()
+        .set(
+            1,
+            SqlStdOperatorTable.PLUS.createCall(
+                SqlParserPos.ZERO,
+                new SqlDynamicParam(2, SqlParserPos.ZERO),
+                SqlStdOperatorTable.PLUS.createCall(
+                    SqlParserPos.ZERO,
+                    new SqlDynamicParam(0, SqlParserPos.ZERO),
+                    new SqlDynamicParam(2, SqlParserPos.ZERO))));
+    assertThat(SqlConvertersFactory.get(Dialect.TRINO).convert(query))
+        .contains("'keep ? and $2'", "$3 + ($1 + $3)");
+  }
+
+  @Test
+  void mapsNestedTypesAndCreatesView() throws Exception {
+    var types = new JavaTypeFactoryImpl();
+    var row =
+        types
+            .builder()
+            .add("items", types.createArrayType(types.createSqlType(SqlTypeName.INTEGER), -1))
+            .add(
+                "attributes",
+                types.createMapType(
+                    types.createSqlType(SqlTypeName.VARCHAR),
+                    types.createSqlType(SqlTypeName.BIGINT)))
+            .build();
+    var factory = new TrinoStatementFactory(mock(EngineConfig.class));
+    assertThat(TrinoTypeFormatter.format(row))
+        .isEqualTo("ROW(\"items\" ARRAY(INTEGER), \"attributes\" MAP(VARCHAR, BIGINT))");
+    var query =
+        SqlParser.create("SELECT CAST(NULL AS INTEGER ARRAY) AS \"items\" FROM \"source\"")
+            .parseQuery();
+    assertThat(
+            factory.createView(
+                new SqlIdentifier("my view", SqlParserPos.ZERO),
+                new SqlNodeList(
+                    List.of(new SqlIdentifier("items", SqlParserPos.ZERO)), SqlParserPos.ZERO),
+                query))
+        .contains(
+            "CREATE OR REPLACE VIEW \"my view\" AS SELECT CAST(NULL AS INTEGER ARRAY) AS \"items\"");
+    assertThatThrownBy(() -> factory.addIndex(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void createsTablesWithoutPrimaryKeyConstraintsAndPreservesMetadata() {
+    var statement =
+        new CreateTableJdbcStatement(
+            "My Table",
+            null,
+            List.of(new Field("id", "BIGINT", false, null)),
+            List.of("id"),
+            List.of(),
+            PartitionType.NONE,
+            0,
+            Duration.ZERO,
+            null);
+    assertThat(statement.getSql(new TrinoCreateTableDdlFactory()))
+        .isEqualTo("CREATE TABLE IF NOT EXISTS \"My Table\" (\"id\" BIGINT NOT NULL)");
+    assertThat(statement.getPrimaryKey()).containsExactly("id");
+    assertThat(
+            new TrinoStatementFactory(mock(EngineConfig.class))
+                .getCreateViewDdlFactory()
+                .createView("My View", List.of("id"), "SELECT id FROM t"))
+        .isEqualTo("CREATE OR REPLACE VIEW \"My View\" AS SELECT id FROM t");
+  }
+
+  @Test
+  void preservesDecimalAndStringPrecision() throws Exception {
+    var types = new FlinkTypeFactory(getClass().getClassLoader(), FlinkTypeSystem.INSTANCE);
+    assertThat(TrinoTypeFormatter.format(types.createSqlType(SqlTypeName.DECIMAL, 38, 18)))
+        .isEqualTo("DECIMAL(38, 18)");
+    assertThat(
+            TrinoTypeFormatter.format(types.createSqlType(SqlTypeName.VARCHAR, Integer.MAX_VALUE)))
+        .isEqualTo("VARCHAR");
+  }
+
+  @Test
+  void usesTheCalciteBundledWithFlink() throws Exception {
+    var original = org.apache.calcite.sql.SqlDialect.class;
+    var source = original.getProtectionDomain().getCodeSource().getLocation();
+    assertThat(source.toString()).contains("flink-table-planner");
+    assertThatThrownBy(() -> Class.forName("org.apache.calcite.sql.dialect.TrinoSqlDialect"))
+        .isInstanceOf(ClassNotFoundException.class);
+    assertThat(FlinkTypeFactory.class.getClassLoader().loadClass(original.getName()))
+        .isSameAs(original);
+  }
+}

--- a/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/engine/database/relational/ViewStatementIdentifierTest.java
@@ -33,7 +33,8 @@ class ViewStatementIdentifierTest {
         .thenReturn(1);
     var factory = new PostgresStatementFactory(engineConfig);
 
-    assertThat(factory.getViewStatementIdentifier("Orders").names).containsExactly("Orders");
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
+        .containsExactly("Orders");
   }
 
   @Test
@@ -43,7 +44,7 @@ class ViewStatementIdentifierTest {
     when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.of("analytics"));
     var factory = new SparkSqlStatementFactory(engineConfig);
 
-    assertThat(factory.getViewStatementIdentifier("Orders").names)
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
         .containsExactly("spark_catalog", "analytics", "Orders");
   }
 
@@ -54,7 +55,7 @@ class ViewStatementIdentifierTest {
     when(engineConfig.getPropertyOptional("view-database")).thenReturn(Optional.empty());
     var factory = new SparkSqlStatementFactory(engineConfig);
 
-    assertThat(factory.getViewStatementIdentifier("Orders").names)
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
         .containsExactly("spark_catalog", "default", "Orders");
   }
 
@@ -65,7 +66,7 @@ class ViewStatementIdentifierTest {
     when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.of("reporting"));
     var factory = new RedshiftStatementFactory(engineConfig);
 
-    assertThat(factory.getViewStatementIdentifier("Orders").names)
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
         .containsExactly("analytics", "reporting", "Orders");
   }
 
@@ -76,7 +77,29 @@ class ViewStatementIdentifierTest {
     when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.empty());
     var factory = new RedshiftStatementFactory(engineConfig);
 
-    assertThat(factory.getViewStatementIdentifier("Orders").names)
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
+        .containsExactly("analytics", "public", "Orders");
+  }
+
+  @Test
+  void givenTrinoViewLocation_whenGettingViewIdentifier_thenPrependsCatalogAndSchema() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getPropertyOptional("view-catalog")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.of("reporting"));
+    var factory = new TrinoStatementFactory(engineConfig);
+
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
+        .containsExactly("analytics", "reporting", "Orders");
+  }
+
+  @Test
+  void givenTrinoViewCatalogWithoutSchema_whenGettingViewIdentifier_thenUsesPublicSchema() {
+    var engineConfig = mock(EngineConfig.class);
+    when(engineConfig.getPropertyOptional("view-catalog")).thenReturn(Optional.of("analytics"));
+    when(engineConfig.getPropertyOptional("view-schema")).thenReturn(Optional.empty());
+    var factory = new TrinoStatementFactory(engineConfig);
+
+    assertThat(factory.getCreateViewDdlFactory().getViewIdentifier("Orders").names)
         .containsExactly("analytics", "public", "Orders");
   }
 }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package-multi-shallow-no-server.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/engine-validation/package-multi-shallow-no-server.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "enabled-engines": ["flink", "iceberg", "sparksql", "redshift"],
+  "enabled-engines": ["flink", "iceberg", "sparksql", "redshift", "trino"],
   "script": {
     "main": "script.sqrl"
   }

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-multi-shallow-no-server.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/EngineValidationTest/package-multi-shallow-no-server.txt
@@ -7,6 +7,9 @@ CREATE TABLE IF NOT EXISTS "Numbers2" ("id" INTEGER NOT NULL, PRIMARY KEY ("id")
 >>>iceberg-sparksql-schema.sql
 CREATE TABLE IF NOT EXISTS `Numbers` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`));
 CREATE TABLE IF NOT EXISTS `Numbers2` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`))
+>>>iceberg-trino-schema.sql
+CREATE TABLE IF NOT EXISTS "Numbers" ("id" INTEGER NOT NULL);
+CREATE TABLE IF NOT EXISTS "Numbers2" ("id" INTEGER NOT NULL)
 >>>iceberg.json
 {
   "plans" : {
@@ -121,6 +124,49 @@ CREATE TABLE IF NOT EXISTS `Numbers2` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`)
           "name" : "Numbers2",
           "type" : "TABLE",
           "sql" : "CREATE TABLE IF NOT EXISTS `Numbers2` (`id` INTEGER NOT NULL, PRIMARY KEY (`id`))",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        }
+      ],
+      "standaloneExtensionStatements" : [ ]
+    },
+    "trino" : {
+      "statements" : [
+        {
+          "name" : "Numbers",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS \"Numbers\" (\"id\" INTEGER NOT NULL)",
+          "fields" : [
+            {
+              "name" : "id",
+              "type" : "INTEGER",
+              "nullable" : false
+            }
+          ],
+          "primaryKey" : [
+            "id"
+          ],
+          "partitionKey" : [ ],
+          "partitionType" : "NONE",
+          "numPartitions" : 0,
+          "ttl" : 0.0
+        },
+        {
+          "name" : "Numbers2",
+          "type" : "TABLE",
+          "sql" : "CREATE TABLE IF NOT EXISTS \"Numbers2\" (\"id\" INTEGER NOT NULL)",
           "fields" : [
             {
               "name" : "id",

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-trino-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/dialects-trino-compile-package.txt
@@ -1,0 +1,236 @@
+>>>pipeline_explain.txt
+=== TrinoAggregates
+ID:          default_catalog.default_database.TrinoAggregates
+Type:        state
+Stage:       flink
+Primary key: boolean_value
+Timestamp:   -
+Row count:   ~1e7
+---
+Schema:
+ - boolean_value: BOOLEAN
+ - record_count: BIGINT NOT NULL
+ - decimal_sum: DECIMAL(38, 2)
+ - double_average: DOUBLE
+ - latest_event: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+Inputs:
+ - default_catalog.default_database.TrinoTypeSource
+Annotations:
+ - stream-root: TrinoTypeSource
+
+=== TrinoFunctions
+ID:          default_catalog.default_database.TrinoFunctions
+Type:        stream
+Stage:       iceberg
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - short_string: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+ - string_length: INTEGER
+ - double_cast: DOUBLE
+ - empty_array: INTEGER ARRAY
+Inputs:
+ - default_catalog.default_database.TrinoTypeMappings
+Annotations:
+ - stream-root: TrinoTypeSource
+ - sort: [0 ASC-nulls-first]
+
+=== TrinoTypeMappings
+ID:          default_catalog.default_database.TrinoTypeMappings
+Type:        stream
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - tiny_value: TINYINT
+ - small_value: SMALLINT
+ - int_value: INTEGER
+ - float_value: FLOAT
+ - double_value: DOUBLE
+ - decimal_value: DECIMAL(12, 2)
+ - boolean_value: BOOLEAN
+ - string_value: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+ - varchar_value: VARCHAR(32) CHARACTER SET "UTF-16LE"
+ - char_value: CHAR(8) CHARACTER SET "UTF-16LE"
+ - binary_value: BINARY(16)
+ - varbinary_value: VARBINARY(32)
+ - date_value: DATE
+ - timestamp_value: TIMESTAMP(3)
+ - timestamp_ltz_value: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+ - string_array: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY
+ - string_to_int: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE", INTEGER) MAP
+ - attributes: RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" source, INTEGER priority)
+Inputs:
+ - default_catalog.default_database.TrinoTypeSource
+Annotations:
+ - stream-root: TrinoTypeSource
+
+=== TrinoTypeSource
+ID:          default_catalog.default_database.TrinoTypeSource
+Type:        stream
+Stage:       flink
+Primary key: id
+Timestamp:   -
+Row count:   ~1e8
+---
+Schema:
+ - id: BIGINT NOT NULL
+ - tiny_value: TINYINT
+ - small_value: SMALLINT
+ - int_value: INTEGER
+ - float_value: FLOAT
+ - double_value: DOUBLE
+ - decimal_value: DECIMAL(12, 2)
+ - boolean_value: BOOLEAN
+ - string_value: VARCHAR(2147483647) CHARACTER SET "UTF-16LE"
+ - varchar_value: VARCHAR(32) CHARACTER SET "UTF-16LE"
+ - char_value: CHAR(8) CHARACTER SET "UTF-16LE"
+ - binary_value: BINARY(16)
+ - varbinary_value: VARBINARY(32)
+ - date_value: DATE
+ - timestamp_value: TIMESTAMP(3)
+ - timestamp_ltz_value: TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)
+ - string_array: VARCHAR(2147483647) CHARACTER SET "UTF-16LE" ARRAY
+ - string_to_int: (VARCHAR(2147483647) CHARACTER SET "UTF-16LE", INTEGER) MAP
+ - attributes: RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" source, INTEGER priority)
+Inputs:
+ - default_catalog.default_database.TrinoTypeSource__base
+Annotations:
+ - features: DENORMALIZE (feature)
+ - stream-root: TrinoTypeSource
+
+>>>flink-sql-no-functions.sql
+CREATE TABLE `TrinoTypeSource` (
+  `id` BIGINT NOT NULL,
+  `tiny_value` TINYINT,
+  `small_value` SMALLINT,
+  `int_value` INTEGER,
+  `float_value` FLOAT,
+  `double_value` DOUBLE,
+  `decimal_value` DECIMAL(12, 2),
+  `boolean_value` BOOLEAN,
+  `string_value` STRING,
+  `varchar_value` VARCHAR(32),
+  `char_value` CHAR(8),
+  `binary_value` BINARY(16),
+  `varbinary_value` VARBINARY(32),
+  `date_value` DATE,
+  `timestamp_value` TIMESTAMP(3),
+  `timestamp_ltz_value` TIMESTAMP_LTZ(3),
+  `string_array` ARRAY< STRING >,
+  `string_to_int` MAP< STRING, INTEGER >,
+  `attributes` ROW< `source` STRING, `priority` INTEGER >,
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'TrinoTypeSource',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash',
+  'write.upsert.enabled' = 'true'
+);
+CREATE VIEW `TrinoTypeMappings`
+AS
+SELECT `id`, `tiny_value`, `small_value`, `int_value`, `float_value`, `double_value`, `decimal_value`, `boolean_value`, `string_value`, `varchar_value`, `char_value`, `binary_value`, `varbinary_value`, `date_value`, `timestamp_value`, `timestamp_ltz_value`, `string_array`, `string_to_int`, `attributes`
+FROM `TrinoTypeSource`;
+CREATE VIEW `TrinoAggregates`
+AS
+SELECT `boolean_value`, COUNT(*) AS `record_count`, SUM(`decimal_value`) AS `decimal_sum`, AVG(`double_value`) AS `double_average`, MAX(`timestamp_ltz_value`) AS `latest_event`
+FROM `TrinoTypeSource`
+GROUP BY `boolean_value`;
+CREATE VIEW `TrinoFunctions`
+AS
+SELECT `id`, SUBSTRING(`string_value`, 2, 3) AS `short_string`, CHAR_LENGTH(`string_value`) AS `string_length`, CAST(`int_value` AS DOUBLE) AS `double_cast`, CAST(NULL AS ARRAY< INTEGER >) AS `empty_array`
+FROM `TrinoTypeMappings`;
+CREATE TABLE `TrinoAggregates_1` (
+  `boolean_value` BOOLEAN,
+  `record_count` BIGINT NOT NULL,
+  `decimal_sum` DECIMAL(38, 2),
+  `double_average` DOUBLE,
+  `latest_event` TIMESTAMP(3) WITH LOCAL TIME ZONE,
+  PRIMARY KEY (`boolean_value`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'TrinoAggregates',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash',
+  'write.upsert.enabled' = 'true'
+);
+CREATE TABLE `TrinoTypeMappings_2` (
+  `id` BIGINT NOT NULL,
+  `tiny_value` TINYINT,
+  `small_value` SMALLINT,
+  `int_value` INTEGER,
+  `float_value` FLOAT,
+  `double_value` DOUBLE,
+  `decimal_value` DECIMAL(12, 2),
+  `boolean_value` BOOLEAN,
+  `string_value` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`,
+  `varchar_value` VARCHAR(32) CHARACTER SET `UTF-16LE`,
+  `char_value` CHAR(8) CHARACTER SET `UTF-16LE`,
+  `binary_value` BINARY(16),
+  `varbinary_value` VARBINARY(32),
+  `date_value` DATE,
+  `timestamp_value` TIMESTAMP(3),
+  `timestamp_ltz_value` TIMESTAMP(3) WITH LOCAL TIME ZONE,
+  `string_array` VARCHAR(2147483647) CHARACTER SET `UTF-16LE` ARRAY,
+  `string_to_int` MAP< VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, INTEGER >,
+  `attributes` ROW(`source` VARCHAR(2147483647) CHARACTER SET `UTF-16LE`, `priority` INTEGER),
+  PRIMARY KEY (`id`) NOT ENFORCED
+)
+WITH (
+  'catalog-name' = 'default_catalog',
+  'catalog-table' = 'TrinoTypeMappings',
+  'catalog-type' = 'hadoop',
+  'commit.retry.max-wait-ms' = '5000',
+  'commit.retry.min-wait-ms' = '100',
+  'commit.retry.num-retries' = '20',
+  'connector' = 'iceberg',
+  'format-version' = '2',
+  'warehouse' = 'sqrl_iceberg_data',
+  'write.distribution-mode' = 'hash'
+);
+EXECUTE STATEMENT SET BEGIN
+INSERT INTO `default_catalog`.`default_database`.`TrinoAggregates_1`
+SELECT *
+FROM `default_catalog`.`default_database`.`TrinoAggregates`
+;
+INSERT INTO `default_catalog`.`default_database`.`TrinoTypeMappings_2`
+SELECT *
+FROM `default_catalog`.`default_database`.`TrinoTypeMappings`
+;
+END
+>>>iceberg-schema.sql
+CREATE TABLE IF NOT EXISTS "TrinoAggregates" ("boolean_value" BOOLEAN, "record_count" BIGINT NOT NULL, "decimal_sum" NUMERIC, "double_average" DOUBLE PRECISION, "latest_event" TIMESTAMP WITH TIME ZONE, PRIMARY KEY ("boolean_value"));
+CREATE TABLE IF NOT EXISTS "TrinoTypeMappings" ("id" BIGINT NOT NULL, "tiny_value" SMALLINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" FLOAT, "double_value" DOUBLE PRECISION, "decimal_value" NUMERIC, "boolean_value" BOOLEAN, "string_value" TEXT, "varchar_value" TEXT, "char_value" TEXT, "binary_value" BYTEA, "varbinary_value" BYTEA, "date_value" DATE, "timestamp_value" TIMESTAMP WITHOUT TIME ZONE, "timestamp_ltz_value" TIMESTAMP WITH TIME ZONE, "string_array" TEXT ARRAY, "string_to_int" JSONB, "attributes" JSONB, PRIMARY KEY ("id"));
+CREATE TABLE IF NOT EXISTS "TrinoTypeSource" ("id" BIGINT NOT NULL, "tiny_value" SMALLINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" FLOAT, "double_value" DOUBLE PRECISION, "decimal_value" NUMERIC, "boolean_value" BOOLEAN, "string_value" TEXT, "varchar_value" TEXT, "char_value" TEXT, "binary_value" BYTEA, "varbinary_value" BYTEA, "date_value" DATE, "timestamp_value" TIMESTAMP WITHOUT TIME ZONE, "timestamp_ltz_value" TIMESTAMP WITH TIME ZONE, "string_array" TEXT ARRAY, "string_to_int" JSONB, "attributes" JSONB, PRIMARY KEY ("id"))
+>>>iceberg-trino-schema.sql
+CREATE TABLE IF NOT EXISTS "TrinoAggregates" ("boolean_value" BOOLEAN, "record_count" BIGINT NOT NULL, "decimal_sum" DECIMAL(38, 2), "double_average" DOUBLE, "latest_event" TIMESTAMP(3) WITH TIME ZONE);
+CREATE TABLE IF NOT EXISTS "TrinoTypeMappings" ("id" BIGINT NOT NULL, "tiny_value" TINYINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" REAL, "double_value" DOUBLE, "decimal_value" DECIMAL(12, 2), "boolean_value" BOOLEAN, "string_value" VARCHAR, "varchar_value" VARCHAR(32), "char_value" CHAR(8), "binary_value" VARBINARY, "varbinary_value" VARBINARY, "date_value" DATE, "timestamp_value" TIMESTAMP(3), "timestamp_ltz_value" TIMESTAMP(3) WITH TIME ZONE, "string_array" ARRAY(VARCHAR), "string_to_int" MAP(VARCHAR, INTEGER), "attributes" ROW("source" VARCHAR, "priority" INTEGER));
+CREATE TABLE IF NOT EXISTS "TrinoTypeSource" ("id" BIGINT NOT NULL, "tiny_value" TINYINT, "small_value" SMALLINT, "int_value" INTEGER, "float_value" REAL, "double_value" DOUBLE, "decimal_value" DECIMAL(12, 2), "boolean_value" BOOLEAN, "string_value" VARCHAR, "varchar_value" VARCHAR(32), "char_value" CHAR(8), "binary_value" VARBINARY, "varbinary_value" VARBINARY, "date_value" DATE, "timestamp_value" TIMESTAMP(3), "timestamp_ltz_value" TIMESTAMP(3) WITH TIME ZONE, "string_array" ARRAY(VARCHAR), "string_to_int" MAP(VARCHAR, INTEGER), "attributes" ROW("source" VARCHAR, "priority" INTEGER))
+>>>iceberg-trino-views.sql
+CREATE OR REPLACE VIEW "analytics"."reporting"."TrinoFunctions" AS SELECT *
+FROM (SELECT "id", SUBSTRING("string_value", 2, 3) AS "short_string", CHAR_LENGTH("string_value") AS "string_length", CAST("int_value" AS DOUBLE) AS "double_cast", CAST(NULL AS INTEGER ARRAY) AS "empty_array"
+  FROM "TrinoTypeMappings"
+  ORDER BY "id" IS NULL DESC, "id"
+  OFFSET 5 ROWS
+  FETCH NEXT 10 ROWS ONLY) AS "t0"

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/trino-compile/package.json
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/trino-compile/package.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "enabled-engines": ["flink", "iceberg", "trino"],
+  "script": {
+    "main": "trino-dialect.sqrl"
+  },
+  "engines": {
+    "flink": {
+      "config": {
+        "table.exec.source.idle-timeout": "1 ms"
+      }
+    },
+    "trino": {
+      "view-catalog": "analytics",
+      "view-schema": "reporting"
+    }
+  },
+  "test-runner": {
+    "delay-sec": -1
+  }
+}

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/trino-compile/trino-dialect.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/dialects/trino-compile/trino-dialect.sqrl
@@ -1,0 +1,67 @@
+/*+engine(iceberg), no_query */
+CREATE TABLE TrinoTypeSource (
+  id BIGINT NOT NULL,
+  tiny_value TINYINT,
+  small_value SMALLINT,
+  int_value INT,
+  float_value FLOAT,
+  double_value DOUBLE,
+  decimal_value DECIMAL(12, 2),
+  boolean_value BOOLEAN,
+  string_value STRING,
+  varchar_value VARCHAR(32),
+  char_value CHAR(8),
+  binary_value BINARY(16),
+  varbinary_value VARBINARY(32),
+  date_value DATE,
+  timestamp_value TIMESTAMP(3),
+  timestamp_ltz_value TIMESTAMP_LTZ(3),
+  string_array ARRAY<STRING>,
+  string_to_int MAP<STRING, INT>,
+  attributes ROW<source STRING, priority INT>,
+  PRIMARY KEY (id) NOT ENFORCED
+);
+
+TrinoTypeMappings :=
+  SELECT
+    id,
+    tiny_value,
+    small_value,
+    int_value,
+    float_value,
+    double_value,
+    decimal_value,
+    boolean_value,
+    string_value,
+    varchar_value,
+    char_value,
+    binary_value,
+    varbinary_value,
+    date_value,
+    timestamp_value,
+    timestamp_ltz_value,
+    string_array,
+    string_to_int,
+    attributes
+  FROM TrinoTypeSource;
+
+TrinoAggregates :=
+  SELECT
+    boolean_value,
+    COUNT(*) AS record_count,
+    SUM(decimal_value) AS decimal_sum,
+    AVG(double_value) AS double_average,
+    MAX(timestamp_ltz_value) AS latest_event
+  FROM TrinoTypeSource
+  GROUP BY boolean_value;
+
+/*+ engine(iceberg) */
+TrinoFunctions :=
+  SELECT id,
+    SUBSTRING(string_value, 2, 3) AS short_string,
+    CHAR_LENGTH(string_value) AS string_length,
+    CAST(int_value AS DOUBLE) AS double_cast,
+    CAST(NULL AS ARRAY<INT>) AS empty_array
+  FROM TrinoTypeMappings
+  ORDER BY id
+  LIMIT 10 OFFSET 5;


### PR DESCRIPTION
## Key changes

  - Add the `trino` engine, statement factory, table DDL factory, and SQL converters.
  - Add an `ExtendedTrinoSqlDialect` compatible with SQRL’s current Flink-provided Calcite version.
  - Generate Trino-compatible `CREATE VIEW` statements without a DDL column list.
  - Add `view-catalog` and `view-schema` properties for Trino view placement.
  - Share view identifier resolution across Spark SQL, Redshift, and Trino while retaining each engine’s location policy.
  - Add Trino compile fixtures, snapshots, and statement-factory tests.

  ## Validation

  - `mvn -o -pl sqrl-planner -am -Dtest=TrinoStatementFactoryTest,ViewStatementIdentifierTest -Dsurefire.failIfNoSpecifiedTests=false -Dgcf.skipInstallHooks=true test`
  - `mvn -o -pl sqrl-testing/sqrl-testing-integration -am -Dtest=UseCaseCompileTest -Dsurefire.failIfNoSpecifiedTests=false -Dgcf.skipInstallHooks=true test`