### PR TITLE
fix: INSERT analysis should not mutate query

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/engine/stream/flink/FlinkSqlNodes.java
@@ -114,6 +114,11 @@ public class FlinkSqlNodes {
         conflictBehavior.map(cb -> cb.symbol(SqlParserPos.ZERO)).orElse(null));
   }
 
+  /** Deep-copies a query so it can be validated without rewriting the original. */
+  public static SqlNode copyQuery(SqlNode query) {
+    return SqlNodeCopier.copy(query);
+  }
+
   /** Deep-copies an insert so it can be validated without rewriting the original. */
   public static RichSqlInsert copyInsert(RichSqlInsert insert) {
     var overwrite = SqlNodeList.EMPTY;

--- a/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/planner/Sqrl2FlinkSQLTranslator.java
@@ -514,14 +514,16 @@ public class Sqrl2FlinkSQLTranslator implements AutoCloseable {
   public TableAnalysis analyzeInsertQuery(
       SqlNode query, ObjectIdentifier identifier, HintsAndDoc hintsAndDoc, ErrorCollector errors) {
 
+    // Validation mutates the SQL tree, so analyze a copy and preserve the query for output.
+    var analysisQuery = FlinkSqlNodes.copyQuery(query);
     var flinkPlanner = validatorSupplier.get();
-    var relRoot = flinkSqlNodePlanner.toRelRoot(query, flinkPlanner);
+    var relRoot = flinkSqlNodePlanner.toRelRoot(analysisQuery, flinkPlanner);
     var analyzer =
         new SQRLLogicalPlanAnalyzer(
             relRoot.project(),
             tableLookup,
             identifier.getObjectName(),
-            getReferencedViews(query),
+            getReferencedViews(analysisQuery),
             flinkSqlNodePlanner.getRelBuilder(flinkPlanner),
             flinkPlanner,
             errors);

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/insertIntoInvalidColumn-fail.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/dagplanner/insertIntoInvalidColumn-fail.sqrl
@@ -1,0 +1,10 @@
+IMPORT ecommerceTs.customer;
+
+CREATE TABLE CustomerIds (
+  customerid BIGINT
+) WITH ('connector' = 'blackhole');
+
+INSERT INTO CustomerIds
+SELECT
+    missing_column
+FROM Customer;

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertInto.txt
@@ -64,9 +64,9 @@ LogicalAggregate(group=[{0}], numEntries=[COUNT()])
   LogicalProject(customerid=[$0])
     LogicalTableScan(table=[[default_catalog, default_database, Customer]])
 SQL:
-SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
-FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
-GROUP BY `Customer`.`customerid`
+SELECT `customerid`, COUNT(*) AS `numEntries`
+FROM `Customer`
+GROUP BY `customerid`
 >>>flink-sql-no-functions.sql
 CREATE TABLE `Customer` (
   `customerid` BIGINT NOT NULL,
@@ -114,9 +114,9 @@ SELECT *
 FROM `default_catalog`.`default_database`.`Customer`
 ;
 INSERT INTO `customer_id_count`
-SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
-FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
-GROUP BY `Customer`.`customerid`
+SELECT `customerid`, COUNT(*) AS `numEntries`
+FROM `Customer`
+GROUP BY `customerid`
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoInvalidColumn-fail.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoInvalidColumn-fail.txt
@@ -1,0 +1,7 @@
+[FATAL]  Column 'missing_column' not found in any table
+in script:insertIntoInvalidColumn-fail.sqrl [9:5]:
+INSERT INTO CustomerIds
+SELECT
+    missing_column
+----^
+

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoMutation.txt
@@ -96,9 +96,9 @@ LogicalAggregate(group=[{0}], numEntries=[COUNT()])
   LogicalProject(customerid=[$0])
     LogicalTableScan(table=[[default_catalog, default_database, Customer]])
 SQL:
-SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
-FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
-GROUP BY `Customer`.`customerid`
+SELECT `customerid`, COUNT(*) AS `numEntries`
+FROM `Customer`
+GROUP BY `customerid`
 === CustomerForApi
 ID:          default_catalog.default_database.CustomerForApi
 Type:        stream
@@ -217,9 +217,9 @@ FROM `default_catalog`.`default_database`.`CustomerCount`
 ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `CustomerCount`
-SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
-FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
-GROUP BY `Customer`.`customerid`
+SELECT `customerid`, COUNT(*) AS `numEntries`
+FROM `Customer`
+GROUP BY `customerid`
 ;
 INSERT INTO `default_catalog`.`default_database`.`CustomerForApi_3`
 SELECT *

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoNow.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGPlannerTest/insertIntoNow.txt
@@ -44,9 +44,9 @@ LogicalProject(id=[$0])
   LogicalFilter(condition=[<($1, NOW())])
     LogicalTableScan(table=[[default_catalog, default_database, NowSource]])
 SQL:
-SELECT `NowSource`.`id`
-FROM `default_catalog`.`default_database`.`NowSource` AS `NowSource`
-WHERE `NowSource`.`event_time` < NOW()
+SELECT `id`
+FROM `NowSource`
+WHERE `event_time` < `NOW`()
 >>>flink-sql-no-functions.sql
 CREATE TABLE IF NOT EXISTS `now_sink` (
   `id` INTEGER
@@ -79,9 +79,9 @@ FROM `default_catalog`.`default_database`.`NowSource`
 ON CONFLICT DO DEDUPLICATE
 ;
 INSERT INTO `now_sink`
-SELECT `NowSource`.`id`
-FROM `default_catalog`.`default_database`.`NowSource` AS `NowSource`
-WHERE `NowSource`.`event_time` < NOW()
+SELECT `id`
+FROM `NowSource`
+WHERE `event_time` < `NOW`()
 ;
 END
 >>>kafka.json

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/DAGWriterJsonTest/multi-batch-compile-package.txt
@@ -43,8 +43,8 @@
   "stage" : "flink",
   "inputs" : [ "default_catalog.default_database.Src" ],
   "annotations" : [ ],
-  "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
-  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "plan" : "LogicalSort(sort0=[$0], dir0=[DESC-nulls-last])\n  LogicalProject(val=[$0])\n    LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
+  "sql" : "SELECT *\nFROM `Src`\nORDER BY `val` DESC",
   "timestamp" : "-",
   "schema" : [ {
     "name" : "val",
@@ -67,14 +67,14 @@
   "stage" : "flink",
   "inputs" : [ "default_catalog.default_database.Src" ],
   "annotations" : [ ],
-  "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
-  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "plan" : "LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], offset=[1], fetch=[2])\n  LogicalProject(val=[$0])\n    LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
+  "sql" : "SELECT *\nFROM `Src`\nORDER BY `val` DESC\nOFFSET 1 ROWS\nFETCH NEXT 2 ROWS ONLY",
   "timestamp" : "-",
   "schema" : [ {
     "name" : "val",
     "type" : "INTEGER NOT NULL"
   } ],
-  "row_count" : "~1e8"
+  "row_count" : "~2"
 }, {
   "id" : "default_catalog.default_database.TableC",
   "name" : "TableC",
@@ -92,7 +92,7 @@
   "inputs" : [ "default_catalog.default_database.Src" ],
   "annotations" : [ ],
   "plan" : "LogicalProject(val=[$0])\n  LogicalTableScan(table=[[default_catalog, default_database, Src]])\n",
-  "sql" : "SELECT `Src`.`val`\nFROM `default_catalog`.`default_database`.`Src` AS `Src`",
+  "sql" : "SELECT *\nFROM `Src`",
   "timestamp" : "-",
   "schema" : [ {
     "name" : "val",
@@ -140,10 +140,10 @@ CREATE TABLE TableB (
 ) WITH (
   'connector' = 'print'
 );
-INSERT INTO TableA SELECT * FROM Src;
+INSERT INTO TableA SELECT * FROM Src ORDER BY val DESC;
 EXPORT Src TO tables.sinks.SinkA;
 NEXT_BATCH;
-INSERT INTO TableB SELECT * FROM Src;
+INSERT INTO TableB SELECT * FROM Src ORDER BY val DESC LIMIT 2 OFFSET 1;
 EXPORT Src TO tables.sinks.SinkB;
 NEXT_BATCH;
 CREATE TABLE TableC (

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-only-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/flink-only-compile-package.txt
@@ -74,8 +74,8 @@ WITH (
 );
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `customer_id_count`
-SELECT `Customer`.`customerid`, COUNT(*) AS `numEntries`
-FROM `default_catalog`.`default_database`.`Customer` AS `Customer`
-GROUP BY `Customer`.`customerid`
+SELECT `customerid`, COUNT(*) AS `numEntries`
+FROM `Customer`
+GROUP BY `customerid`
 ;
 END

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/multi-batch-compile-package.txt
@@ -49,7 +49,7 @@ Type:        stream
 Stage:       flink
 Primary key: -
 Timestamp:   -
-Row count:   ~1e8
+Row count:   ~2
 ---
 Schema:
  - val: INTEGER NOT NULL
@@ -132,8 +132,9 @@ SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
 INSERT INTO `TableA`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
+ORDER BY `val` DESC
 ;
 END
 >>>flink-sql-no-functions-1.sql
@@ -178,8 +179,11 @@ SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
 INSERT INTO `TableB`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
+ORDER BY `val` DESC
+OFFSET 1 ROWS
+FETCH NEXT 2 ROWS ONLY
 ;
 END
 >>>flink-sql-no-functions-2.sql
@@ -226,8 +230,8 @@ WITH (
 );
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `TableC`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
 ;
 END
 >>>flink-sql-no-functions.sql
@@ -278,8 +282,9 @@ SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
 INSERT INTO `TableA`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
+ORDER BY `val` DESC
 ;
 END;
 EXECUTE STATEMENT SET BEGIN
@@ -288,13 +293,16 @@ SELECT *
 FROM `default_catalog`.`default_database`.`Src`
 ;
 INSERT INTO `TableB`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
+ORDER BY `val` DESC
+OFFSET 1 ROWS
+FETCH NEXT 2 ROWS ONLY
 ;
 END;
 EXECUTE STATEMENT SET BEGIN
 INSERT INTO `TableC`
-SELECT `Src`.`val`
-FROM `default_catalog`.`default_database`.`Src` AS `Src`
+SELECT *
+FROM `Src`
 ;
 END

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-index-selection-compile-package.txt
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/snapshots/com/datasqrl/UseCaseCompileTest/pg-index-selection-compile-package.txt
@@ -1436,8 +1436,8 @@ FROM `default_catalog`.`default_database`.`ExplicitIndexes`
 ON CONFLICT DO NOTHING
 ;
 INSERT INTO `ExplicitIndexesSink`
-SELECT `ExplicitIndexes`.`orderId`, `ExplicitIndexes`.`customerId`, `ExplicitIndexes`.`createdAt`
-FROM `default_catalog`.`default_database`.`ExplicitIndexes` AS `ExplicitIndexes`
+SELECT `orderId`, `customerId`, `createdAt`
+FROM `ExplicitIndexes`
 ;
 INSERT INTO `default_catalog`.`default_database`.`NoIndexes_2`
 SELECT `orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`, `hash_columns`(`orderId`, `customerId`, `storeId`, `productId`, `category`, `status`, `paymentMethod`, `country`, `currency`, `channel`, `discountCode`, `shippingMethod`, `warehouseId`, `carrierId`, `campaignId`, `deviceType`, `riskLevel`, `fulfillmentStatus`, `returnReason`, `salesRepId`, `amount`, `epoch_timestamp`, `createdAt`) AS `__pk_hash`

--- a/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/multi-batch-compile/multi-batch.sqrl
+++ b/sqrl-testing/sqrl-testing-integration/src/test/resources/usecases/multi-batch-compile/multi-batch.sqrl
@@ -12,13 +12,13 @@ CREATE TABLE TableB (
   'connector' = 'print'
 );
 
-INSERT INTO TableA SELECT * FROM Src;
+INSERT INTO TableA SELECT * FROM Src ORDER BY val DESC;
 
 EXPORT Src TO tables.sinks.SinkA;
 
 NEXT_BATCH;
 
-INSERT INTO TableB SELECT * FROM Src;
+INSERT INTO TableB SELECT * FROM Src ORDER BY val DESC LIMIT 2 OFFSET 1;
 
 EXPORT Src TO tables.sinks.SinkB;
 


### PR DESCRIPTION
Fix duplicate ORDER BY clauses in generated SQL for sorted INSERT queries.

Calcite validation mutates the query tree in place, pushing ORDER BY and LIMIT/OFFSET into the inner SELECT. The compiler later emits the original INSERT, whose outer wrapper still contains those clauses, duplicating them. Analyze a separate copy to preserve the original query for output.

Extend the existing multi-batch-compile use case with sorted INSERTs, including LIMIT/OFFSET, and update its UseCase and DAG snapshots. Both snapshot tests fail without the fix and pass with it.

Fixes #2363