### PR TITLE
feat: Normalize engine configurations

### DIFF
--- a/sqrl-planner/src/main/java/com/datasqrl/config/ExecutionEnginesHolder.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/ExecutionEnginesHolder.java
@@ -65,6 +65,8 @@ public class ExecutionEnginesHolder {
     if (isTestExec()) {
       packageJson.setEnabledEngines(List.copyOf(engines.keySet()));
     }
+
+    packageJson.removeDisabledEngineConfigurations(errors);
   }
 
   public Map<String, ExecutionEngine> getEngines() {

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJson.java
@@ -33,6 +33,8 @@ public interface PackageJson {
 
   void setEnabledEngines(List<String> enabledEngines);
 
+  void removeDisabledEngineConfigurations(ErrorCollector errors);
+
   EnginesConfig getEngines();
 
   ConnectorsConfig getConnectors();

--- a/sqrl-planner/src/main/java/com/datasqrl/config/PackageJsonImpl.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/PackageJsonImpl.java
@@ -15,8 +15,12 @@
  */
 package com.datasqrl.config;
 
+import com.datasqrl.error.ErrorCollector;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 
 public class PackageJsonImpl implements PackageJson {
@@ -31,13 +35,19 @@ public class PackageJsonImpl implements PackageJson {
   public static final String TEST_RUNNER_KEY = "test-runner";
 
   @Getter private final SqrlConfig sqrlConfig;
+  private final Set<String> userEngineConfigurations;
 
   public PackageJsonImpl() {
     this(SqrlConfig.createCurrentVersion());
   }
 
   public PackageJsonImpl(SqrlConfig sqrlConfig) {
+    this(sqrlConfig, Set.of());
+  }
+
+  public PackageJsonImpl(SqrlConfig sqrlConfig, Set<String> userEngineConfigurations) {
     this.sqrlConfig = sqrlConfig;
+    this.userEngineConfigurations = Set.copyOf(userEngineConfigurations);
   }
 
   @Override
@@ -48,6 +58,33 @@ public class PackageJsonImpl implements PackageJson {
   @Override
   public void setEnabledEngines(List<String> enabledEngines) {
     sqrlConfig.setProperty(ENABLED_ENGINES_KEY, enabledEngines);
+  }
+
+  @Override
+  public void removeDisabledEngineConfigurations(ErrorCollector errors) {
+    var enabledEngines = new HashSet<>(getEnabledEngines());
+    var engineConfigurations = sqrlConfig.getSubConfig(ENGINES_PROPERTY);
+    var engineNamesToRemove = new ArrayList<String>();
+
+    for (String engineName : engineConfigurations.getKeys()) {
+      if (!enabledEngines.contains(engineName)) {
+        engineNamesToRemove.add(engineName);
+      }
+    }
+
+    engineNamesToRemove.forEach(engineConfigurations::removeProperty);
+
+    var userEngineConfigurationsToRemove =
+        engineNamesToRemove.stream().filter(userEngineConfigurations::contains).toList();
+    if (!userEngineConfigurationsToRemove.isEmpty()) {
+      errors.warn(
+          "Removed configurations for engines not listed in 'enabled-engines': %s.",
+          userEngineConfigurationsToRemove);
+    }
+
+    if (!engineConfigurations.getKeys().iterator().hasNext()) {
+      sqrlConfig.removeProperty(ENGINES_PROPERTY);
+    }
   }
 
   @Override

--- a/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConfig.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/config/SqrlConfig.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -71,15 +72,20 @@ public class SqrlConfig {
     this.prefix = prefix;
   }
 
-  public static PackageJson loadResolvedConfig(ErrorCollector errors, ObjectNode config) {
-    return loadResolvedConfig(errors, config, null);
+  public static PackageJson loadResolvedConfig(
+      ErrorCollector errors, ObjectNode config, @Nullable String jsonSchema) {
+    return loadResolvedConfig(errors, config, jsonSchema, Set.of());
   }
 
   public static PackageJson loadResolvedConfig(
-      ErrorCollector errors, ObjectNode config, @Nullable String jsonSchema) {
+      ErrorCollector errors,
+      ObjectNode config,
+      @Nullable String jsonSchema,
+      Set<String> userEngineConfigurations) {
 
     if (ConfigLoaderUtils.isValidJson(errors, config, jsonSchema)) {
-      return new PackageJsonImpl(new SqrlConfig(errors, config, SqrlConstants.PACKAGE_JSON, ""));
+      return new PackageJsonImpl(
+          new SqrlConfig(errors, config, SqrlConstants.PACKAGE_JSON, ""), userEngineConfigurations);
     }
 
     throw errors.exception(
@@ -315,6 +321,20 @@ public class SqrlConfig {
     return this;
   }
 
+  public SqrlConfig removeProperty(String key) {
+    var parts = getFullKey(key).split("\\.");
+    var curr = root;
+    for (var i = 0; i < parts.length - 1; i++) {
+      var child = curr.get(parts[i]);
+      if (!(child instanceof ObjectNode)) {
+        return this;
+      }
+      curr = (ObjectNode) child;
+    }
+    curr.remove(parts[parts.length - 1]);
+    return this;
+  }
+
   public void setProperties(Object value) {
     var tree = MAPPER.valueToTree(value);
     errors.checkFatal(
@@ -326,7 +346,7 @@ public class SqrlConfig {
   }
 
   public void copy(SqrlConfig from) {
-    errors.checkFatal(from instanceof SqrlConfig, "Cannot copy config from other impl");
+    errors.checkFatal(from != null, "Cannot copy config from other impl");
     root = from.root.deepCopy();
     this.prefix = from.prefix;
   }

--- a/sqrl-planner/src/main/java/com/datasqrl/util/ConfigLoaderUtils.java
+++ b/sqrl-planner/src/main/java/com/datasqrl/util/ConfigLoaderUtils.java
@@ -15,6 +15,7 @@
  */
 package com.datasqrl.util;
 
+import static com.datasqrl.config.PackageJsonImpl.ENGINES_PROPERTY;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datasqrl.config.PackageJson;
@@ -44,8 +45,12 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -293,6 +298,7 @@ public final class ConfigLoaderUtils {
       ErrorCollector errors, List<Path> files, List<String> defaults) {
     var valid = true;
     var jsons = new ArrayList<ObjectNode>();
+    var userEngineConfigs = new HashSet<String>();
 
     // Convert, validate, and add defaults
     for (String defaultPath : defaults) {
@@ -309,6 +315,7 @@ public final class ConfigLoaderUtils {
     for (Path file : files) {
       var json = convertFileToObjectNode(errors, Either.Left(file), true);
       valid &= isValidJson(errors, json, PACKAGE_SCHEMA_PATH);
+      userEngineConfigs.addAll(getConfiguredEngineNames(json));
       jsons.add(json);
     }
 
@@ -323,8 +330,16 @@ public final class ConfigLoaderUtils {
     // Merge all collected JSON into one object
     var merged = MAPPER.createObjectNode();
     jsons.forEach(node -> JsonUtils.merge(merged, node));
+    return SqrlConfig.loadResolvedConfig(errors, merged, null, userEngineConfigs);
+  }
 
-    return SqrlConfig.loadResolvedConfig(errors, merged);
+  private static Set<String> getConfiguredEngineNames(JsonNode json) {
+    return json.optional(ENGINES_PROPERTY)
+        .map(JsonNode::propertyStream)
+        .orElse(Stream.empty())
+        .filter(e -> !e.getValue().isNull())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   private static void validatePlanDir(Path planDir) {

--- a/sqrl-planner/src/test/java/com/datasqrl/util/ConfigLoaderUtilsTest.java
+++ b/sqrl-planner/src/test/java/com/datasqrl/util/ConfigLoaderUtilsTest.java
@@ -119,25 +119,51 @@ class ConfigLoaderUtilsTest {
   @Test
   void givenNoPaths_loadDefaultConfig_thenReturnsDefaults() {
     var underTest = ConfigLoaderUtils.loadDefaultConfig(errors);
+    underTest.removeDisabledEngineConfigurations(errors);
 
     assertThat(underTest).isNotNull();
     assertThat(underTest.getVersion()).isEqualTo(1);
     assertThat(underTest.getEnabledEngines()).contains("vertx", "postgres", "kafka", "flink");
     assertThat(underTest.getTestConfig()).isNotNull();
     assertThat(underTest.getEngines().getEngineConfig("flink")).isPresent();
+    assertThat(underTest.getEngines().getEngineConfig("duckdb")).isNotPresent();
+    assertThat(errors).isEmpty();
     assertThat(underTest.getScriptConfig().getGraphql()).isEmpty();
   }
 
   @Test
   void givenNoPaths_whenLoadingUnresolvedConfig_thenReturnsDefaults() {
     var underTest = ConfigLoaderUtils.loadUnresolvedConfig(errors, List.of());
+    underTest.removeDisabledEngineConfigurations(errors);
 
     assertThat(underTest).isNotNull();
     assertThat(underTest.getVersion()).isEqualTo(1);
     assertThat(underTest.getEnabledEngines()).contains("vertx", "postgres", "kafka", "flink");
     assertThat(underTest.getTestConfig()).isNotNull();
     assertThat(underTest.getEngines().getEngineConfig("flink")).isPresent();
+    assertThat(underTest.getEngines().getEngineConfig("duckdb")).isNotPresent();
+    assertThat(errors).isEmpty();
     assertThat(underTest.getScriptConfig().getGraphql()).isEmpty();
+  }
+
+  @Test
+  @SneakyThrows
+  void givenDisabledEngineConfigurationInSeparatePackageFile_whenMerged_thenRemovesItWithWarning() {
+    var enabledEngines = tempDir.resolve("enabled-engines.json");
+    var engineConfiguration = tempDir.resolve("engine-configuration.json");
+    Files.writeString(enabledEngines, "{\"enabled-engines\":[\"flink\"]}");
+    Files.writeString(
+        engineConfiguration, "{\"engines\":{\"postgres\":{\"partition-premake\":4}}}");
+
+    var underTest =
+        ConfigLoaderUtils.loadUnresolvedConfig(
+            errors, List.of(enabledEngines, engineConfiguration), List.of());
+    underTest.removeDisabledEngineConfigurations(errors);
+
+    assertThat(underTest.getEngines().getEngineConfig("postgres")).isNotPresent();
+    assertThat(errors).hasSize(1);
+    assertThat(errors.toString())
+        .contains("Removed configurations for engines not listed in 'enabled-engines': [postgres]");
   }
 
   @Test
@@ -145,6 +171,7 @@ class ConfigLoaderUtilsTest {
     var underTest =
         ConfigLoaderUtils.loadUnresolvedConfig(
             errors, List.of(Path.of("src/test/resources/config/test-package.json")));
+    underTest.removeDisabledEngineConfigurations(errors);
 
     assertThat(underTest).isNotNull();
     assertThat(underTest.getVersion()).isEqualTo(1);
@@ -152,8 +179,22 @@ class ConfigLoaderUtilsTest {
     assertThat(underTest.getEnabledEngines()).containsExactly("iceberg");
 
     assertThat(underTest.getTestConfig()).isNotNull();
-    assertThat(underTest.getEngines().getEngineConfig("flink")).isPresent();
+    assertThat(underTest.getEngines().getEngineConfig("flink")).isNotPresent();
+    assertThat(errors).isEmpty();
     assertThat(underTest.getScriptConfig().getGraphql()).isEmpty();
+  }
+
+  @Test
+  void givenTestEngineAddedBeforeCleanup_thenRetainsItsDefaultConfiguration() {
+    var underTest =
+        ConfigLoaderUtils.loadUnresolvedConfig(
+            errors, List.of(Path.of("src/test/resources/config/test-package.json")));
+
+    underTest.setEnabledEngines(List.of("iceberg", "postgres"));
+    underTest.removeDisabledEngineConfigurations(errors);
+
+    assertThat(underTest.getEngines().getEngineConfig("postgres")).isPresent();
+    assertThat(errors).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Key Changes

  - Remove configuration blocks for engines not present in the effective enabled-engines set.
  - Perform cleanup after `ExecutionEnginesHolder` expands test-only engines, preserving their default configurations.
  - Emit a warning only for removed engine configurations supplied by user package files.
  - Preserve silent cleanup for default-only engine configurations.
  - Add regression coverage for test-added engines and aggregated user configuration warnings.